### PR TITLE
encode to utf-8 before passing to urwid (issue #4)

### DIFF
--- a/alot/widgets.py
+++ b/alot/widgets.py
@@ -118,6 +118,8 @@ class TagWidget(urwid.AttrMap):
     def __init__(self, tag):
         self.tag = tag
         self.translated = config.get('tag translate', tag, fallback=tag)
+        # encode to utf-8 before passing to urwid (issue #4)
+        self.translated = self.translated.encode('utf-8')
         txt = urwid.Text(self.translated, wrap='clip')
         normal = config.get_tagattr(tag)
         focus = config.get_tagattr(tag, focus=True)


### PR DESCRIPTION
I threw together a quick workaround for issue #4 by encoding our tags to utf-8 before passing them to Urwid.

In an idealistic world, we would receive and pass around unicode strings through APIs, and live happily ever after. Sadly, we already seen that we can't rely on notmuch to give us unicode strings (although,you said that is changing soon), and passing them to urwid has caused this unexpected issue.

It almost feels like this patch is a hack around an Urwid bug, yet they claim to support both unicode and byte strings. There may be future issues regarding encoding, since there are still places throughout 'alot' that pass unicode strings to Urwid.
