### PR TITLE
Trivial fix for a traceback when trying to view the tag list

### DIFF
--- a/alot/buffer.py
+++ b/alot/buffer.py
@@ -282,7 +282,7 @@ class TagListBuffer(Buffer):
         displayedtags = filter(self.filtfun, self.tags)
         for (num, b) in enumerate(displayedtags):
             tw = widgets.TagWidget(b)
-            lines.append(urwid.Columns([('fixed', tw.len(), tw)]))
+            lines.append(urwid.Columns([('fixed', tw.width(), tw)]))
         self.taglist = urwid.ListBox(urwid.SimpleListWalker(lines))
         self.body = self.taglist
 


### PR DESCRIPTION
When pressing L to view the tag list, I get the following traceback:

```
  File "/home/lmacken/code/github.org/alot.lmacken/alot/command.py", line 278, in apply
    buf = buffer.TagListBuffer(ui, tags, self.filtfun)
  File "/home/lmacken/code/github.org/alot.lmacken/alot/buffer.py", line 270, in __init__
    self.rebuild()
  File "/home/lmacken/code/github.org/alot.lmacken/alot/buffer.py", line 285, in rebuild
    lines.append(urwid.Columns([('fixed', tw.len(), tw)]))
AttributeError: 'TagWidget' object has no attribute 'len'

```

My fork contains a patch that fixes this issue by using the renamed 'width' method instead of 'len', which resolves this issue.
