### PR TITLE
Build a list of message parts and join them on \n\n

### DIFF
--- a/alot/message.py
+++ b/alot/message.py
@@ -201,11 +201,11 @@ def extract_body(mail):
                     tmpfile.write(raw_payload.encode('utf8'))
                 else:
                     tmpfile.write(raw_payload)
+                tmpfile.close()
                 #create and call external command
                 cmd = handler % tmpfile.name
                 rendered_payload = helper.cmd_output(cmd)
                 #remove tempfile
-                tmpfile.close()
                 os.unlink(tmpfile.name)
                 if rendered_payload:  # handler had output
                     body_parts.append(rendered_payload.strip())


### PR DESCRIPTION
Building a list and joining it is more efficient
than concatenating strings since strings are
immutable in python.

Also joining the different parts on \n\n is nicer imho.
