### PR TITLE
Fix clipping of subjects

### DIFF
--- a/alot/widgets.py
+++ b/alot/widgets.py
@@ -71,7 +71,7 @@ class ThreadlineWidget(urwid.AttrMap):
         self.subject_w = urwid.AttrMap(urwid.Text(subjectstring, wrap='clip'),
                                  'threadline_subject')
         if subjectstring:
-            cols.append(('fixed', len(subjectstring), self.subject_w))
+            cols.append(('weight', 2, self.subject_w))
 
         if self.display_content:
             msgs = self.thread.get_messages().keys()


### PR DESCRIPTION
Subjects that did not fit into the available space were not
displayed at all, giving the column with the subject a
higher weight fixes this.
