### PR TITLE
Fix tab rendering in MessageBodyWidget

### DIFF
--- a/alot/widgets.py
+++ b/alot/widgets.py
@@ -538,8 +538,8 @@ class MessageHeaderWidget(urwid.AttrMap):
 class MessageBodyWidget(urwid.AttrMap):
     """displays printable parts of an email"""
 
-    def __init__(self, msg):
-        bodytxt = message.extract_body(msg)
+    def __init__(self, msg, tab_width = 8):
+        bodytxt = message.extract_body(msg).replace('\t', ' ' * tab_width)
         urwid.AttrMap.__init__(self, urwid.Text(bodytxt), 'message_body')
 
 


### PR DESCRIPTION
urwid renders all characters in map(chr, range(32)) as
'?' except for the newline character. This makes sense
since it is up to the application to interpret those
characters.

Fixes #74.
