### PR TITLE
Align unfolded mail parts to summary line

### DIFF
--- a/alot/widgets.py
+++ b/alot/widgets.py
@@ -481,7 +481,11 @@ class MessageWidget(urwid.WidgetWrap):
         return ('fixed', length, spacer)
 
     def _get_arrowhead_aligner(self):
-        return ('fixed', 1, urwid.SolidFill(' '))
+        if len(self.message.get_replies()) > 0:
+            aligner = u'\u2502'
+        else:
+            aligner = ' '
+        return ('fixed', 1, urwid.SolidFill(aligner))
 
     def toggle_full_header(self):
         """toggles if message headers are shown"""


### PR DESCRIPTION
In the tree widget used in thread view, arrow heads are part of the summary
line. This caused the following widgets in the pile (headers, attachments, mail
body) to align to the column of the arrow head instead of the actual summary.
This commit adds an additional spacer that optically aligns above widgets to the
perceived start of the summary line.
