### PR TITLE
Fix sphinx build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,8 @@ class Mock(object):
 MOCK_MODULES = ['notmuch', 'notmuch.globals',
                 'twisted', 'twisted.internet',
                 'twisted.internet.defer',
+                'twisted.python',
+                'twisted.python.failure',
                 'urwid',
                 'argparse']
 for mod_name in MOCK_MODULES:


### PR DESCRIPTION
Hi Pazz,

on my system, running sphinx yielded:

```
teythoon@thinkbox ~/repos/alot/docs (git)-[master] % make html
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.0.8

Exception occurred:
  File "/usr/lib/python2.7/dist-packages/pygments/plugin.py", line 39, in <module>
    import pkg_resources
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2727, in <module>
    add_activation_listener(lambda dist: dist.activate())
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 700, in subscribe
    callback(dist)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2727, in <lambda>
    add_activation_listener(lambda dist: dist.activate())
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2227, in activate
    self.insert_on(path)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2334, in insert_on
    self.check_version_conflict()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2381, in check_version_conflict
    if fn and (normalize_path(fn).startswith(loc) or
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 1866, in normalize_path
    return os.path.normcase(os.path.realpath(filename))
  File "/usr/lib/python2.7/posixpath.py", line 358, in realpath
    if isabs(filename):
  File "/usr/lib/python2.7/posixpath.py", line 53, in isabs
    return s.startswith('/')
AttributeError: type object 'Mock' has no attribute 'startswith'
The full traceback has been saved in /tmp/sphinx-err-pURCLX.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
Either send bugs to the mailing list at <http://groups.google.com/group/sphinx-dev/>,
or report them in the tracker at <http://bitbucket.org/birkenfeld/sphinx/issues/>. Thanks!
make: *** [html] Error 1
```

I used the **file** hack for afews documentation and it works nicely with rtd. 
