### PR TITLE
Add Message::has_replies()

### DIFF
--- a/alot/message.py
+++ b/alot/message.py
@@ -116,6 +116,10 @@ class Message(object):
             self._thread = self._dbman.get_thread(self._thread_id)
         return self._thread
 
+    def has_replies(self):
+        """returns true if this message has at least one reply"""
+        return (len(self.get_replies()) > 0)
+
     def get_replies(self):
         """returns replies to this message as list of :class:`Message`"""
         t = self.get_thread()

--- a/alot/widgets.py
+++ b/alot/widgets.py
@@ -481,7 +481,7 @@ class MessageWidget(urwid.WidgetWrap):
         return ('fixed', length, spacer)
 
     def _get_arrowhead_aligner(self):
-        if len(self.message.get_replies()) > 0:
+        if self.message.has_replies():
             aligner = u'\u2502'
         else:
             aligner = ' '


### PR DESCRIPTION
This method enables a callee to ask a Message object whether there are any
replies to it. Use it to decide what spacer to use for aligning unfolded message
parts to its summary line (cf issue #183).

Actually I thought there were two places in the code where this functionality was used (really thought I had only stolen that code from you _weird_), but I can't seem to find it.

So if it's only me using that method, it's up to you to decide whether it really adds value or just bloats the interface. Your call ;)

Just close accordingly
dtk
