### PR TITLE
Sort TagListBuffer

### DIFF
--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -310,7 +310,7 @@ class TagListBuffer(Buffer):
             self.isinitialized = True
 
         lines = list()
-        displayedtags = filter(self.filtfun, self.tags)
+        displayedtags = sorted(filter(self.filtfun, self.tags), key=unicode.lower)
         for (num, b) in enumerate(displayedtags):
             tw = widgets.TagWidget(b)
             lines.append(urwid.Columns([('fixed', tw.width(), tw)]))


### PR DESCRIPTION
Make sorting of tags in TagListBuffer case insensitive. So far the following
three tags would have been sorted like ['Notmuch', 'alot', 'xapian']. The new
case insensitive sorting will arrange them as ['alot', 'Notmuch', 'xapian'].

Closes #109.
