### PR TITLE
Sorted searchbuffer taglist

### DIFF
--- a/alot/helper.py
+++ b/alot/helper.py
@@ -321,7 +321,7 @@ def tag_cmp(a, b):
     if min(len(a), len(b)) == 1:
         return cmp(len(a), len(b))
     else:
-        return cmp(a, b)
+        return cmp(a.lower(), b.lower())
 
 
 def humanize_size(size):


### PR DESCRIPTION
Preserve property that single char tags are always displayed before all other
tags.

So far the sorting of tags in a ThreadlineWidget was case sensitive:
['✉', 'Notmuch', 'alot', 'xapian'].
Now the sorting is case insensitive but still treats single char tags
preferentially: ['✉', 'alot', 'Notmuch', 'xapian']

Cf issues #190, #109 and #77.
