### PR TITLE
Toggletag unread

### DIFF
--- a/alot/defaults/alot.rc
+++ b/alot/defaults/alot.rc
@@ -127,6 +127,7 @@ select = openfocussed
 a = toggletag inbox
 & = toggletag killed
 ! = toggletag flagged
+s = toggletag unread
 l = retagprompt
 O = refineprompt
 | = refineprompt


### PR DESCRIPTION
Toggles the 'unread' tag of a mail thread in the search buffer.
Default key is 's' as in the maildir flag 'seen'. Thunderbirds 'm' is taken
globally for composing mails.

Closes #200
