### PR TITLE
Fix 228

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,8 +22,12 @@ class Mock(object):
     def __init__(self, *args, **kwargs):
         pass
 
+    def __call__(self, *args, **kwargs):
+        return Mock()
+
+    @classmethod
     def __getattr__(self, name):
-        return Mock if name != '__file__' else '/dev/null'
+        return Mock() if name not in ('__file__', '__path__') else '/dev/null'
 
 MOCK_MODULES = ['notmuch', 'notmuch.globals',
                 'twisted', 'twisted.internet',


### PR DESCRIPTION
The python import machinery expects **path** to be a string, so
**getattr** has to return a mock string instead of a mock object.

**getattr** now also returns Mock objects instead of the Mock class
and Mock objects are now callable.

Fixes #228.
