### PR TITLE
Fix docu

### DIFF
--- a/alot/defaults/alot.rc
+++ b/alot/defaults/alot.rc
@@ -199,7 +199,7 @@ ls = bufferlist
 [256c-theme]
 
 # default formating for tagstrings
-# add 'tag_X_fg' and 'tag_X_bg' to your config to specify
+# add 'tag_X_[focus_]fg' and 'tag_X_[focus_]bg' to your config to specify
 # formating for tagstring 'X'
 tag_bg = default
 tag_fg = brown


### PR DESCRIPTION
So far the comment in the default config only explained how to theme unfocussed
tags.

This commits extends the example (syntax) to indicate how focussed tags may be
themed.
