### PR TITLE
Highlight section

### DIFF
--- a/alot/defaults/alot.rc
+++ b/alot/defaults/alot.rc
@@ -32,26 +32,6 @@ envelope_headers_blacklist = In-Reply-To,References
 # set terminal command used for spawning shell commands
 terminal_cmd = x-terminal-emulator -e
 
-######################
-# HIGHLIGHT settings #
-######################
-# Thread lines in the search buffer can be highlighted if they match a query
-# by theming their components.
-
-# dictionary of highlighting rules. The keys are queries you want highlighting
-# for; values are chosen designators that identify themeing options in the
-# colour scheme:
-#    search_thread_<component>_<id>_[focus_][fg|bg]
-# Note that the sequence of the list defines the search order. The first
-# specified query that matches selects the themeing.
-thread_highlight_rules = { "tag:unread AND tag:flagged":"isunread+flagged",
-                           "tag:unread":"isunread", "tag:flagged":"isflagged" }
-
-# comma separated list of the components of a thread line you want highlighted
-# if a query matches.
-# Possible components are [date|mailcount|tags|authors|subject|content].
-thread_highlight_components = subject
-
 ####################
 # EDITOR settings  #
 ####################
@@ -195,6 +175,24 @@ clo = close
 bp = bprevious
 ls = bufferlist
 
+[highlighting]
+# Thread lines in the search buffer can be highlighted if they match a query
+# by theming their components.
+
+# dictionary of highlighting rules. The keys are queries you want highlighting
+# for; values are chosen designators that identify themeing options in the
+# colour scheme:
+#    search_thread_<component>_<id>_[focus_][fg|bg]
+# Note that the sequence of the list defines the search order. The first
+# specified query that matches selects the themeing.
+rules = { "tag:unread AND tag:flagged":"isunread+flagged",
+          "tag:unread":"isunread",
+          "tag:flagged":"isflagged" }
+
+# comma separated list of the components of a thread line you want highlighted
+# if a query matches.
+# Possible components are [date|mailcount|tags|authors|subject|content].
+components = subject
 
 [256c-theme]
 

--- a/alot/settings.py
+++ b/alot/settings.py
@@ -183,14 +183,14 @@ class AlotConfigParser(FallbackConfigParser):
         """
         rules = OrderedDict()
         try:
-            config_string = self.get('general', 'thread_highlight_rules')
+            config_string = self.get('highlighting', 'rules')
             rules = json.loads(config_string, object_pairs_hook=OrderedDict)
         except NoOptionError as err:
             logging.exception(err)
         except ValueError as err:
             report = ParsingError("Could not parse config option" \
-                                  " 'thread_highlight_rules' in section" \
-                                  " 'general': {reason}".format(reason=err))
+                                  " 'rules' in section 'highlighting':" \
+                                  " {reason}".format(reason=err))
             logging.exception(report)
         finally:
             return rules
@@ -230,8 +230,7 @@ class AlotConfigParser(FallbackConfigParser):
         base = 'tag'
         themes = [base, base + '_{}'.format(tag)]
         if (highlight and 
-            'tags' in self.getstringlist('general',
-                                         'thread_highlight_components')):
+            'tags' in self.getstringlist('highlighting', 'components')):
             themes.insert(1, base + '_{}'.format(highlight))
             themes.insert(3, base + '_{}_{}'.format(tag, highlight))
         if focus:

--- a/alot/widgets.py
+++ b/alot/widgets.py
@@ -77,8 +77,8 @@ class ThreadlineWidget(urwid.AttrMap):
         self.tag_widgets = []
         self.display_content = config.getboolean('general',
                                     'display_content_in_threadline')
-        self.highlight_components = config.getstringlist('general',
-                                            'thread_highlight_components')
+        self.highlight_components = config.getstringlist('highlighting',
+                                                         'components')
         self.highlight_rules = config.get_highlight_rules()
         self.rebuild()
         urwid.AttrMap.__init__(self, self.columns,


### PR DESCRIPTION
Rebased against current `testing`

> Move options concerned with thread highlighting into their own section in the
> config file. This makes the `[general]` section less cluttered and deskews the
> name space.
> 
> Closes #25.
