### PR TITLE
Fix ignoring of colourmode in configuration

### DIFF
--- a/alot/init.py
+++ b/alot/init.py
@@ -79,7 +79,7 @@ class Options(usage.Options):
     optParameters = [
             ['config', 'c', '~/.config/alot/config', 'config file'],
             ['notmuch-config', 'n', '~/.notmuch-config', 'notmuch config'],
-            ['colour-mode', 'C', 256, 'terminal colour mode', colourint],
+            ['colour-mode', 'C', None, 'terminal colour mode', colourint],
             ['mailindex-path', 'p', None, 'path to notmuch index'],
             ['debug-level', 'd', 'info', 'debug log', debuglogstring],
             ['logfile', 'l', '/dev/null', 'logfile'],


### PR DESCRIPTION
alot ignored colourmode set in configuration file due to default value
of 256 being added into commandline
