### PR TITLE
Fix 308

### DIFF
--- a/alot/helper.py
+++ b/alot/helper.py
@@ -293,7 +293,7 @@ def call_cmd_async(cmdlist, stdin=None, env=None):
     logging.debug('ENV = %s' % environment)
     proc = reactor.spawnProcess(_EverythingGetter(d), executable=cmdlist[0],
                                 env=environment,
-                                args=cmdlist[1:])
+                                args=cmdlist)
     if stdin:
         logging.debug('writing to stdin')
         proc.write(stdin)


### PR DESCRIPTION
Quoting http://twistedmatrix.com/documents/current/api/twisted.internet.interfaces.IReactorProcess.spawnProcess.html:

args - the command line arguments to pass to the process; a sequence
       of strings. The first string should be the executable's name.

Fixes #308, possible more.
