### PR TITLE
Fix exception imports

### DIFF
--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -1,5 +1,5 @@
 import urwid
-from notmuch.globals import NotmuchError
+from notmuch import NotmuchError
 
 import widgets
 import settings

--- a/alot/message.py
+++ b/alot/message.py
@@ -10,7 +10,7 @@ charset.add_charset('utf-8', charset.QP, charset.QP, 'utf-8')
 from email.iterators import typed_subpart_iterator
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
-from notmuch.globals import NullPointerError
+from notmuch import NullPointerError
 
 from alot import __version__
 import logging


### PR DESCRIPTION
You hardcoded the location of the exceptions, bad pazz, _spankspank_. But since I'm oh so generous I whipped up a patch (aka I broke my alot while refactoring notmuchs python bindings and was desperately in need of a working mail client).
