### PR TITLE
Made default abook_regexp to better comply with the format

### DIFF
--- a/alot/account.py
+++ b/alot/account.py
@@ -249,12 +249,12 @@ class MatchSdtoutAddressbook(AddressBook):
         :param match: regular expression used to match contacts in `commands`
                       output to stdout. Must define subparts named "email" and
                       "name".  Defaults to
-                      :regexp:`(?P<email>.+?@.+?)\s+(?P<name>.+?)\s*$`.
+                      :regexp:`^(?P<email>[^@]+@[^\t]+)\t+(?P<name>[^\t]+)`.
         :type match: str
         """
         self.command = command
         if not match:
-            self.match = '(?P<email>.+?@.+?)\s+(?P<name>.+?)\s*$'
+            self.match = '^(?P<email>[^@]+@[^\t]+)\t+(?P<name>[^\t]+)'
         else:
             self.match = match
 
@@ -266,7 +266,7 @@ class MatchSdtoutAddressbook(AddressBook):
         resultstring, errmsg, retval = helper.call_cmd(cmdlist + [prefix])
         if not resultstring:
             return []
-        lines = resultstring.replace('\t', ' ' * 4).splitlines()
+        lines = resultstring.splitlines()
         res = []
         for l in lines:
             m = re.match(self.match, l)

--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -63,15 +63,15 @@ respectively. See below for an example that uses `abook <http://abook.sourceforg
     [[youraccount]]
         ...
         abook_command = abook --mutt-query
-        abook_regexp = '(?P<email>.+?@.+?)\s+(?P<name>.+?)\s*$'
+        abook_regexp = '^(?P<email>[^@]+@[^\t]+)\t+(?P<name>[^\t]+)'
 
-See `here <http://notmuchmail.org/emacstips/#index11h2>`_ for alternative lookup commands. The few others I have tested so far are:
+See `here <http://notmuchmail.org/emacstips/#index12h2>`_ for alternative lookup commands. The few others I have tested so far are:
 
 `goobook <http://code.google.com/p/goobook/>`_
-    for cached google contacts lookups::
+    for cached google contacts lookups. Works with the above default regexp::
 
       abook_command = goobook query
-      abook_regexp = (?P<email>.+?@.+?)\s\s+(?P<name>.+)\s\s+.+
+      abook_regexp = '^(?P<email>[^@]+@[^\t]+)\t+(?P<name>[^\t]+)'
 
 `nottoomuch-addresses <http://www.iki.fi/too/nottoomuch/nottoomuch-addresses/>`_
     completes contacts found in the notmuch index::


### PR DESCRIPTION
The default regexp now ignores a third field (only caring for the
first email and name). Tabs are not transformed to spaces before
matching is done. "goobook query" now works with the default regexp
like it should; both it and abook were made to output a mutt
query_command compatible format. Docs are updated accordingly. The
example for nottoomuch-addresses still works.
