### PR TITLE
make it possible to pass alot it's config file from a fifo

### DIFF
--- a/alot/settings.py
+++ b/alot/settings.py
@@ -57,9 +57,6 @@ class AlotConfigParser(FallbackConfigParser):
         return None
 
     def read(self, file):
-        if not os.path.isfile(file):
-            return
-
         SafeConfigParser.readfp(self, codecs.open(file, "r", "utf8"))
         if self.has_option('general', 'hooksfile'):
             hf = os.path.expanduser(self.get('general', 'hooksfile'))


### PR DESCRIPTION
It's nice to be able to generate the alot config file on the fly and pass it via a fifo.

for example: https://raw.github.com/jakeogh/gpgmda/master/email_read

another option would be to add a second test:
stat.S_ISFIFO(os.stat(path).st_mode)
as mentioned at:
http://stackoverflow.com/questions/8558884/check-if-file-is-a-named-pipe-fifo-in-python
