### PR TITLE
Be more clever when editing mail template, see discussion in #388

### DIFF
--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -183,6 +183,7 @@ class EditCommand(Command):
         self.openNew = (envelope != None)
         self.force_spawn = spawn
         self.refocus = refocus
+        self.edit_only_body = False
         Command.__init__(self, **kwargs)
 
     def apply(self, ui):
@@ -217,7 +218,7 @@ class EditCommand(Command):
             translate = settings.get_hook('post_edit_translate')
             if translate:
                 template = translate(template, ui=ui, dbm=ui.dbman)
-            self.envelope.parse_template(template)
+            self.envelope.parse_template(template, only_body=self.edit_only_body)
             if self.openNew:
                 ui.buffer_open(buffers.EnvelopeBuffer(ui, self.envelope))
             else:
@@ -249,7 +250,9 @@ class EditCommand(Command):
         tf = tempfile.NamedTemporaryFile(delete=False)
         content = bodytext
         if headertext:
-            content = '%s%s' % (headertext, content)
+            content = '%s\n%s' % (headertext, content)
+        else:
+            self.edit_only_body = True
         tf.write(content.encode('utf-8'))
         tf.flush()
         tf.close()


### PR DESCRIPTION
If any headers are to be edited along with the body, then put a
separating empty newline between headertext and body. This is the
default; self.edit_only_body==False. Thus, in the callback function,
the call to parse_template() will have only_body=False. The parsing
regexp then picks up an empty line as separating headerlines from
body. Though, if there is no empty line there, the first
non-header-look line will belong to the body ("\n?" in the regexp).

If no headers are to be edited, we set self.edit_only_body to True.
This is passed on to parse_template(), which then will not do any
regexp parsing, but just let the whole template become the body.
