### PR TITLE
Use separate lines for rendering messages

### DIFF
--- a/alot/defaults/default.theme
+++ b/alot/defaults/default.theme
@@ -297,6 +297,9 @@
     [[[body]]]
         bg = 'default'
         fg = 'light gray'
+    [[[body_focus]]]
+        bg = 'h14'
+        fg = 'black'
     [[[header]]]
         bg = 'dark gray'
         fg = 'white'

--- a/alot/widgets.py
+++ b/alot/widgets.py
@@ -656,7 +656,15 @@ class HeadersList(urwid.WidgetWrap):
         return headerlines
 
 
-class MessageBodyWidget(urwid.AttrMap):
+class SelectableText(urwid.Text):
+    def selectable(self):
+        return True
+
+    def keypress(self, size, key):
+        return key
+
+
+class MessageBodyWidget(urwid.BoxAdapter):
     """
     displays printable parts of an email
 
@@ -666,8 +674,15 @@ class MessageBodyWidget(urwid.AttrMap):
 
     def __init__(self, msg):
         bodytxt = message.extract_body(msg)
+        lines = bodytxt.split("\n")
+        texts = [urwid.Text(line) for line in lines]
         att = settings.get_theming_attribute('thread', 'body')
-        urwid.AttrMap.__init__(self, urwid.Text(bodytxt), att)
+        focus_att = settings.get_theming_attribute('thread', 'body_focus')
+        content = urwid.SimpleListWalker([
+            urwid.AttrMap(w, att, focus_att) for w in [
+                SelectableText(line) for line in lines]])
+
+        urwid.BoxAdapter.__init__(self, urwid.ListBox(content), len(lines))
 
 
 class AttachmentWidget(urwid.WidgetWrap):


### PR DESCRIPTION
This makes each line selectable so that you can scroll through messages in a
thread a bit better than before.

This fixes issue #214
