### PR TITLE
Mention that sent_box and draft_box must be within the notmuch database path

### DIFF
--- a/docs/source/configuration/accounts_table.rst
+++ b/docs/source/configuration/accounts_table.rst
@@ -42,9 +42,9 @@
     You can use mbox, maildir, mh, babyl and mmdf in the protocol part of the URL.
 
     .. note:: The path you specify here must be within your notmuch database path.
-    That is, if you have `path=/home/michael/offlineimap-copy` in the `[database]`
-    section in `~/.notmuch-config`, a valid sent_box is for example
-    `/home/michael/offlineimap-copy/Sent`.
+              That is, if you have `path=/home/michael/offlineimap-copy` in the
+              `[database]` section in `~/.notmuch-config`, a valid sent_box is for
+              example `/home/michael/offlineimap-copy/Sent`.
 
     :type: mail_container
     :default: None
@@ -57,9 +57,9 @@
     where to store draft mails, see :ref:`sent_box <sent-box>` for the format
 
     .. note:: The path you specify here must be within your notmuch database path.
-    That is, if you have `path=/home/michael/offlineimap-copy` in the `[database]`
-    section in `~/.notmuch-config`, a valid draft_box is for example
-    `/home/michael/offlineimap-copy/Drafts`.
+              That is, if you have `path=/home/michael/offlineimap-copy` in the
+              `[database]` section in `~/.notmuch-config`, a valid draft_box is for
+              example `/home/michael/offlineimap-copy/Drafts`.
 
     :type: mail_container
     :default: None


### PR DESCRIPTION
This is necessary so that notmuch can refer to and display this message later on. I initially used a path outside my notmuch database and neither notmuch nor alot were able to display my sent message afterwards.

This is consistent with the documentation at http://packages.python.org/notmuch/#notmuch.Database.add_message, stating "filename –
should be a path relative to the path of the open database (see get_path()), or else should be an absolute filename with initial components that match the path of the database."
