### PR TITLE
Use ">" followed by a space to quote emails

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -108,7 +108,7 @@ class ReplyCommand(Command):
             quotestring = 'Quoting %s (%s)\n' % (name, timestamp)
         mailcontent = quotestring
         for line in self.message.accumulate_body().splitlines():
-            mailcontent += '>' + line + '\n'
+            mailcontent += '> ' + line + '\n'
 
         envelope = Envelope(bodytext=mailcontent)
 


### PR DESCRIPTION
This follows what all the other people are doing.
See also the USENET and mailing list posting netiquette:
http://linux.sgms-centre.com/misc/netiquette.php#quoting
