### PR TITLE
threadlist: make display_content use the most recent messages instead of...

### DIFF
--- a/alot/widgets.py
+++ b/alot/widgets.py
@@ -155,7 +155,8 @@ class ThreadlineWidget(urwid.AttrMap):
                 msgs = self.thread.get_messages().keys()
             else:
                 msgs = []
-            msgs.sort()
+            # sort the most recent messages first
+            msgs.sort(key=lambda msg: msg.get_date(), reverse=True)
             lastcontent = ' '.join([m.get_text_content() for m in msgs])
             contentstring = lastcontent.replace('\n', ' ').strip()
             self.content_w = urwid.AttrMap(urwid.Text(


### PR DESCRIPTION
... _random_ messages

Previously, this code used just sort() on a list of db.message objects, which will use the message id, which doesn’t tell you _anything_ and leads to completely random sort order in any real-world inbox :).
