### PR TITLE
empty lines in quoted mails lead to trailing whitespace

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -112,6 +112,8 @@ class ReplyCommand(Command):
         for line in self.message.accumulate_body().splitlines():
             if line == '':
                 mailcontent += '>\n'
+            elif line[0] == '>':
+                mailcontent += '>' + line + '\n'
             else:
                 mailcontent += '> ' + line + '\n'
 


### PR DESCRIPTION
When quoting a mail with empty lines the quote has a line like this one:
`> \n`

This patch changes this behaviour to remove the space if theres no more text
on this line.

Addition: The second commit fixes spaces between quoting signs when quoting
already quoted text.
