### PR TITLE
Reply subject hook

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -247,6 +247,13 @@ class ForwardCommand(Command):
         # copy subject
         subject = decode_header(mail.get('Subject', ''))
         subject = 'Fwd: ' + subject
+        forward_subject_hook = settings.get_hook('forward_subject')
+        if forward_subject_hook:
+            subject = forward_subject_hook(subject)
+        else:
+            fsp = settings.get('forward_subject_prefix')
+            if not subject.startwith(('Fwd:', fsp)):
+                subject = fsp + subject
         envelope.add('Subject', subject)
 
         # set From

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -123,6 +123,10 @@ quote_prefix = string(default='> ')
 # only if original subject doesn't start with 'Re:' or this prefix
 reply_subject_prefix = string(default='Re: ')
 
+# String prepended to subject header on forward
+# only if original subject doesn't start with 'Fwd:' or this prefix
+forward_subject_prefix = string(default='Fwd: ')
+
 # Key bindings 
 [bindings]
     __many__ = string(default=None)

--- a/docs/source/configuration/alotrc_table.rst
+++ b/docs/source/configuration/alotrc_table.rst
@@ -182,6 +182,17 @@
     :default: 5
 
 
+.. _forward-subject-prefix:
+
+.. describe:: forward_subject_prefix
+
+     String prepended to subject header on forward
+     only if original subject doesn't start with 'Fwd:' or this prefix
+
+    :type: string
+    :default: `Fwd: `
+
+
 .. _hooksfile:
 
 .. describe:: hooksfile

--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -241,6 +241,14 @@ Apart from command pre- and posthooks, the following hooks will be interpreted:
     :type subject: str
     :rtype: str
 
+.. py:function:: forward_subject(subject)
+
+    used to reformat the subject header on forward
+
+    :param subject: subject to reformat
+    :type subject: str
+    :rtype: str
+
 .. _themes:
 
 Themes


### PR DESCRIPTION
This introduces a hook which generates a new subject header on reply.

This can be used to:
- use a different subject prefix than `Re:`
- recognize different subject prefixes than `Re:` and therefore
- prevent things like `Re: Antwort: Re: Antwort:...` ("Antwort" is german and means reply)

One could also introduce one or two settings, which determine which prefix to
use in outgoing mails and which ones to recognize in incoming mails
