### PR TITLE
Mailing lists

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -73,26 +73,30 @@ def recipient_to_from(mail, my_accounts):
 
 
 @registerCommand(MODE, 'reply', arguments=[
-    (['--all'], {'action':'store_true', 'help':'reply to all'}),
-    (['--list'], {'action':'store_true', 'help':'reply to list'}),
+    (['--all'], {'action': BooleanAction, 'default':None,
+                   'help':'reply to all'}),
+    (['--tolist'], {'action': BooleanAction, 'default':None,
+                   'help':'reply to list'}),
     (['--spawn'], {'action': BooleanAction, 'default':None,
                    'help':'open editor in new window'})])
 class ReplyCommand(Command):
     """reply to message"""
-    def __init__(self, message=None, all=False, list=False, spawn=None, **kwargs):
+    def __init__(self, message=None, toall=None, tolist=None, ccauthor=True, spawn=None, **kwargs):
         """
         :param message: message to reply to (defaults to selected message)
         :type message: `alot.db.message.Message`
-        :param all: group reply; copies recipients from Bcc/Cc/To to the reply
-        :type all: bool
-        :param list: list reply
-        :type list: bool
+        :param toall: group reply; copies recipients from Bcc/Cc/To to the reply
+        :type toall: bool
+        :param tolist: reply to list; moves sender to Cc,
+                       autodetect if unset and not disabled in config
+        :type tolist: bool
         :param spawn: force spawning of editor in a new terminal
         :type spawn: bool
         """
         self.message = message
-        self.groupreply = all
-        self.listreply = list
+        self.groupreply = toall
+        self.listreply = tolist
+        self.list_cc_author = ccauthor
         self.force_spawn = spawn
         Command.__init__(self, **kwargs)
 
@@ -138,11 +142,17 @@ class ReplyCommand(Command):
                 subject = rsp + subject
         envelope.add('Subject', subject)
 
-        is_list_hook = settings.get_hook('is_list')
-        if is_list_hook:
-            self.listreply = is_list_hook(mail)
-        autodetect_lists = settings.get('autodetect_list')
-        if autodetect_lists and mail['List-Id']:
+        reply_flags_hook = settings.get_hook('reply_flags')
+        if reply_flags_hook:
+            reply_flags = reply_flags_hook(mail)
+            if reply_flags.has_key("groupreply"):
+                self.groupreply = reply_flags["groupreply"]
+            if reply_flags.has_key("listreply"):
+                self.listreply = reply_flags["listreply"]
+
+        if self.listreply == None \
+        and settings.get('autodetect_list') \
+        and 'List-Id' in mail:
             self.listreply = True
 
         # set From
@@ -151,28 +161,35 @@ class ReplyCommand(Command):
 
         # set To
         sender = mail['Reply-To'] or mail['From']
-        recipients = [sender]
+        recipients = set([decode_header(sender, normalize=True)])
         my_addresses = settings.get_addresses()
+        cc = set()
+
         if self.groupreply:
             if sender != mail['From']:
-                recipients.append(mail['From'])
-            cleared = self.clear_my_address(my_addresses, mail.get('To', ''))
-            recipients.append(cleared)
+                recipients.add(mail['From'])
+            recipients = recipients.union( \
+                    map(str.strip, mail.get('To', '').split(',')) \
+                    )
+            recipients.difference_update(my_addresses)
 
             # copy cc for group-replies
             if 'Cc' in mail:
-                cc = self.clear_my_address(my_addresses, mail['Cc'])
-                envelope.add('Cc', decode_header(cc))
+                cc = cc.union( \
+                        map(str.strip, mail.get('Cc', '').split(',')) \
+                        )
+                cc.discard(mail.get('To').strip())
+                cc.difference_update(my_addresses)
 
         if self.listreply:
-            cc = mail['From']
-            if 'Cc' in mail:
-                cc += ", " + self.clear_my_address(my_addresses, mail['Cc'])
-            envelope.add('Cc', decode_header(cc))
+            cc.add(mail['From'])
+            recipients.discard(mail['From'])
 
         to = ', '.join(recipients)
         logging.debug('reply to: %s' % to)
         envelope.add('To', decode_header(to))
+        if len(cc) != 0:
+            envelope.add('Cc', decode_header(", ".join(cc)))
 
         # set In-Reply-To header
         envelope.add('In-Reply-To', '<%s>' % self.message.get_message_id())
@@ -192,13 +209,6 @@ class ReplyCommand(Command):
         # continue to compose
         ui.apply_command(ComposeCommand(envelope=envelope,
                                         spawn=self.force_spawn))
-
-    def clear_my_address(self, my_addresses, value):
-        new_value = []
-        for entry in value.split(','):
-            if not [a for a in my_addresses if a in entry]:
-                new_value.append(entry.strip())
-        return ', '.join(new_value)
 
 
 @registerCommand(MODE, 'forward', arguments=[

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -74,21 +74,25 @@ def recipient_to_from(mail, my_accounts):
 
 @registerCommand(MODE, 'reply', arguments=[
     (['--all'], {'action':'store_true', 'help':'reply to all'}),
+    (['--list'], {'action':'store_true', 'help':'reply to list'}),
     (['--spawn'], {'action': BooleanAction, 'default':None,
                    'help':'open editor in new window'})])
 class ReplyCommand(Command):
     """reply to message"""
-    def __init__(self, message=None, all=False, spawn=None, **kwargs):
+    def __init__(self, message=None, all=False, list=False, spawn=None, **kwargs):
         """
         :param message: message to reply to (defaults to selected message)
         :type message: `alot.db.message.Message`
         :param all: group reply; copies recipients from Bcc/Cc/To to the reply
         :type all: bool
+        :param list: list reply
+        :type list: bool
         :param spawn: force spawning of editor in a new terminal
         :type spawn: bool
         """
         self.message = message
         self.groupreply = all
+        self.listreply = list
         self.force_spawn = spawn
         Command.__init__(self, **kwargs)
 
@@ -152,6 +156,12 @@ class ReplyCommand(Command):
             if 'Cc' in mail:
                 cc = self.clear_my_address(my_addresses, mail['Cc'])
                 envelope.add('Cc', decode_header(cc))
+
+        if self.listreply:
+            cc = mail['From']
+            if 'Cc' in mail:
+                cc += ", " + self.clear_my_address(my_addresses, mail['Cc'])
+            envelope.add('Cc', decode_header(cc))
 
         to = ', '.join(recipients)
         logging.debug('reply to: %s' % to)

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -138,6 +138,13 @@ class ReplyCommand(Command):
                 subject = rsp + subject
         envelope.add('Subject', subject)
 
+        is_list_hook = settings.get_hook('is_list')
+        if is_list_hook:
+            self.listreply = is_list_hook(mail)
+        autodetect_lists = settings.get('autodetect_list')
+        if autodetect_lists and mail['List-Id']:
+            self.listreply = True
+
         # set From
         realname, address = recipient_to_from(mail, my_accounts)
         envelope.add('From', '%s <%s>' % (realname, address))

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -170,6 +170,9 @@ reply_subject_prefix = string(default='Re: ')
 # only if original subject doesn't start with 'Fwd:' or this prefix
 forward_subject_prefix = string(default='Fwd: ')
 
+# Automatically switch to list reply mode if appropriate
+autodetect_list = boolean(default=True)
+
 # Key bindings 
 [bindings]
     __many__ = string(default=None)

--- a/docs/source/configuration/alotrc_table.rst
+++ b/docs/source/configuration/alotrc_table.rst
@@ -36,6 +36,16 @@
     :default: 30
 
 
+.. _autodetect-list:
+
+.. describe:: autodetect_list
+
+     Automatically switch to list reply mode if appropriate
+
+    :type: boolean
+    :default: True
+
+
 .. _bufferclose-focus-offset:
 
 .. describe:: bufferclose_focus_offset

--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -265,6 +265,14 @@ Apart from command pre- and posthooks, the following hooks will be interpreted:
     :type subject: str
     :rtype: str
 
+.. py:function:: is_list(mail)
+
+    checks if the given mail is from a mailing list
+
+    :param mail: mail to check
+    :type mail: email.message.Message
+    :rtype: boolean
+
 .. _themes:
 
 Themes

--- a/docs/source/usage/modes/thread.rst
+++ b/docs/source/usage/modes/thread.rst
@@ -174,6 +174,7 @@ reply to message
 
 optional arguments
 	:---all: reply to all.
+	:---list: reply to list.
 	:---spawn: open editor in new window.
 
 .. _cmd_thread_save:


### PR DESCRIPTION
This allows nice list replies. It assumes, that the mailing list sets the `Reply-To` header.
The Mail is sent to the value of `Reply-To` and `From` is added to `Cc`.

There is also early list autodetection and a hook for fine grained control. And of course documentation.