### PR TITLE
Add a hidden TOC for the manpage

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,7 +94,6 @@ release = version
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = [
-'manpage.rst'
 ]
 
 # The reST default role (used for this markup: `text`) to use for all documents.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,3 +17,8 @@ User Manual
    crypto/index
    api/index
    faq
+
+.. toctree::
+   :hidden:
+
+   manpage


### PR DESCRIPTION
This allows to silence the warnings while making it possible to build
the manpage from source.

I intend to ship this patch in the 0.3.2 Debian package.
