### PR TITLE
Remove message tempfile on buffer close

### DIFF
--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -122,8 +122,8 @@ class EnvelopeBuffer(Buffer):
         return info
 
     def cleanup(self):
-        for tmp in self.envelope.tmpfile:
-            os.unlink(tmp.name)
+        if self.envelope.tmpfile:
+            os.unlink(self.envelope.tmpfile.name)
 
     def rebuild(self):
         displayed_widgets = []

--- a/alot/db/envelope.py
+++ b/alot/db/envelope.py
@@ -42,7 +42,7 @@ class Envelope(object):
         assert isinstance(bodytext, unicode)
         self.headers = {}
         self.body = None
-        self.tmpfile = list()
+        self.tmpfile = None
         logging.debug('TEMPLATE: %s' % template)
         if template:
             self.parse_template(template)


### PR DESCRIPTION
Hello!

This fix the remaining issue in #453, namely removing the tempfile only after sending.

This with the close confirmation (`0.3.2-feature-bclosebang-453`) give us a more safe editing, in particular the tempfile survive a `killall -9 alot`!

Now, this is making the BufferCloseCommand cluttered. Next what about we make a cleaning adding some sort of callbacks to BufferCloseCommand so we can attach callables to the buffer and let BufferCloseCommand trigger then?
