### PR TITLE
Rename `os.remove()` to `os.unlink()`

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -717,7 +717,7 @@ class OpenAttachmentCommand(Command):
                 tmpfile.close()
 
                 def afterwards():
-                    os.remove(tempfile_name)
+                    os.unlink(tempfile_name)
             else:
                 handler_stdin = StringIO()
                 self.attachment.write(handler_stdin)


### PR DESCRIPTION
The two functions are exactly the same, but for consistency only use
`os.unlink()` (make grepping easier).
