### PR TITLE
Fix the sorting of tags with length == 1

### DIFF
--- a/alot/helper.py
+++ b/alot/helper.py
@@ -418,7 +418,7 @@ def tag_cmp(a, b):
     Sorting tags using this function puts all tags of length 1 at the
     beginning. This groups all tags mapped to unicode characters.
     '''
-    if min(len(a), len(b)) == 1:
+    if min(len(a), len(b)) == 1 and max(len(a), len(b)) > 1:
         return cmp(len(a), len(b))
     else:
         return cmp(a.lower(), b.lower())


### PR DESCRIPTION
The tag sorting `cmp()` put single unicode tags before the long tag
names, but don't sort the single length tags. This commit fix this
behavior sorting the single length tags separately.
