### PR TITLE
Remove the old default documentation template.

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,7 +1,0 @@
-{% extends "!layout.html" %}
-{% set script_files = [] %}
-
-{% block linktags %}{% endblock %}
-{% block relbar1 %}{% endblock %}
-{% block footer %}{% endblock %}
-{% block relbaritems %}{% endblock %}


### PR DESCRIPTION
It was an old default that wasn't up-to-date. Since there was no
customization, the best bet is to entirely remove it to avoid having the
issue next time Sphinx changes something.

This fixes the search page, which was the last blocker for the Debian
package.
