### PR TITLE
Reenable the sidebar in the HTML documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -133,7 +133,7 @@ html_theme = 'default'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {'nosidebar': True}
+html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []


### PR DESCRIPTION
Without this sidebar it is not possible to use the search feature of the
documentation.
This patch will be shipped with the Debian package — no point in fixing
the search feature if it remains hidden ;-).

While connected to the previous PR, this patch is less technical, that's why I filed it separately.
