### PR TITLE
HACK: alot/helper.py: don't convert tabs to spaces

### DIFF
--- a/alot/helper.py
+++ b/alot/helper.py
@@ -74,21 +74,21 @@ def string_sanitize(string, tab_width=8):
 
     lines = list()
     for line in string.split('\n'):
-        tab_count = line.count('\t')
-
-        if tab_count > 0:
-            line_length = 0
-            new_line = list()
-            for i, chunk in enumerate(line.split('\t')):
-                line_length += len(chunk)
-                new_line.append(chunk)
-
-                if i < tab_count:
-                    next_tab_stop_in = tab_width - (line_length % tab_width)
-                    new_line.append(' ' * next_tab_stop_in)
-                    line_length += next_tab_stop_in
-            lines.append(''.join(new_line))
-        else:
+#        tab_count = line.count('\t')
+#
+#        if tab_count > 0:
+#            line_length = 0
+#            new_line = list()
+#            for i, chunk in enumerate(line.split('\t')):
+#                line_length += len(chunk)
+#                new_line.append(chunk)
+#
+#                if i < tab_count:
+#                    next_tab_stop_in = tab_width - (line_length % tab_width)
+#                    new_line.append(' ' * next_tab_stop_in)
+#                    line_length += next_tab_stop_in
+#            lines.append(''.join(new_line))
+#        else:
             lines.append(line)
 
     return '\n'.join(lines)


### PR DESCRIPTION
A primary use case for any mail reader is pulling patches off an email
list.  Alot does not support "saving emails" directly, so the print_cmd
function can be used in it's place.  However the email body is sanitized
which corrupts many file types such as diffs.

This hack patch comments out the code which converts tabs to spaces.
This demonstrates a desired feature where the email body is kept
unsanitized.  This change prevents diff and patch files from being
corrupted.

A better solution would be to honor the tabwidth configuration option.
While documented it appears that this config option is never used in the
code.  Note that even if tabwidth was honored in configuration the code
would still need to interpret a value of zero correctly to skip the
tabs-to-space conversion entirely.

The author's python fu is weak and he is in a hurry so commenting out
the offending code block is the quickest way.

Signed-off-by: Mike Turquette mturquette@linaro.org
