### PR TITLE
Make pipeto work with multiple word commands

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -388,7 +388,7 @@ class ChangeDisplaymodeCommand(Command):
 
 
 @registerCommand(MODE, 'pipeto', arguments=[
-    (['cmd'], {'help':'shellcommand to pipe to'}),
+    (['cmd'], {'help':'shellcommand to pipe to', 'nargs': '+'}),
     (['--all'], {'action': 'store_true', 'help':'pass all messages'}),
     (['--format'], {'help':'output format', 'default':'raw',
                     'choices':['raw', 'decoded', 'id', 'filepath']}),


### PR DESCRIPTION
Hi pazz,

Wouldn't it make more sense for pipeto to accept multiple args, to do things like "pipeto tee whatever" or (from my own config) "Y = prompt 'pipeto --shell --notify_stdout reminder-queue.sh now + '" (the command gets completed from the prompt)?

Cheers,
## 

Antoine
