### PR TITLE
Add body_mimetype to tweak extract_body's defaults

### DIFF
--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -243,9 +243,7 @@ class Message(object):
         """
         returns bodystring extracted from this mail
         """
-        #TODO: don't hardcode which part is considered body but allow toggle
-        #      commands and a config default setting
-
+        #TODO: allow toggle commands to decide which part is considered body
         return extract_body(self.get_email())
 
     def get_text_content(self):

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -24,6 +24,17 @@
     :default: "~"
 
 
+.. _body_mimetype:
+
+.. describe:: body_mimetype
+
+     Preferred MIME type to display as mail body if it is present.
+     The fallback type is text/* if the preferred type is missing
+
+    :type: string
+    :default: "text/html"
+
+
 .. _bufferclose-focus-offset:
 
 .. describe:: bufferclose_focus_offset


### PR DESCRIPTION
Add a body_mimetype global configuration option to choose the default message
part to return as body in extract_body when types is None. Parts of the
preferred type will be returned if present, all text/\* parts will be returned if
none parts of the preferred type exist. The default is "text/html", which should
result in the same behavior as before.

This addresses the second point of https://github.com/pazz/alot/issues/405
