### PR TITLE
show threads and unread in tag list

### DIFF
--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -381,10 +381,10 @@ class TagListBuffer(Buffer):
 
     modename = 'taglist'
 
-    def __init__(self, ui, alltags=[], filtfun=None):
+    def __init__(self, ui, alltags_with_counts={}, filtfun=None):
         self.filtfun = filtfun
         self.ui = ui
-        self.tags = alltags
+        self.tags_with_counts = alltags_with_counts
         self.isinitialized = False
         self.rebuild()
         Buffer.__init__(self, ui, self.body)
@@ -397,7 +397,8 @@ class TagListBuffer(Buffer):
             self.isinitialized = True
 
         lines = list()
-        displayedtags = sorted(filter(self.filtfun, self.tags),
+        displayedtags = sorted(filter(self.filtfun,
+                                      self.tags_with_counts.keys()),
                                key=unicode.lower)
         for (num, b) in enumerate(displayedtags):
             if (num % 2) == 0:
@@ -412,6 +413,10 @@ class TagListBuffer(Buffer):
                 rows.append(urwid.Text(b + ' [hidden]'))
             elif tw.translated is not b:
                 rows.append(urwid.Text('(%s)' % b))
+            threads_count = self.tags_with_counts[b][0]
+            unread_count = self.tags_with_counts[b][1]
+            rows.append(urwid.Text(' (%d / %d)' % (unread_count,
+                                                   threads_count)))
             line = urwid.Columns(rows, dividechars=1)
             line = urwid.AttrMap(line, attr, focus_att)
             lines.append(line)

--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -413,9 +413,11 @@ class TagListBuffer(Buffer):
                 rows.append(urwid.Text(b + ' [hidden]'))
             elif tw.translated is not b:
                 rows.append(urwid.Text('(%s)' % b))
-            threads_count = self.tags_with_counts[b][0]
-            unread_count = self.tags_with_counts[b][1]
-            rows.append(urwid.Text(' (%d / %d)' % (unread_count,
+            # print counts if enabled
+            if self.tags_with_counts[b]:
+                threads_count = self.tags_with_counts[b][0]
+                unread_count = self.tags_with_counts[b][1]
+                rows.append(urwid.Text(' (%d / %d)' % (unread_count,
                                                    threads_count)))
             line = urwid.Columns(rows, dividechars=1)
             line = urwid.AttrMap(line, attr, focus_att)

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -442,15 +442,22 @@ class TagListCommand(Command):
         Command.__init__(self, **kwargs)
 
     def apply(self, ui):
+        tags_with_count = {}
         tags = ui.dbman.get_all_tags()
+        for tag in tags:
+            threads_count = ui.dbman.count_threads("tag:%s" % tag)
+            unread_count = ui.dbman.count_threads(
+                    "tag:%s AND tag:unread" % tag)
+            tags_with_count[tag] = [threads_count, unread_count]
         blists = ui.get_buffers_of_type(buffers.TagListBuffer)
         if blists:
             buf = blists[0]
-            buf.tags = tags
+            buf.tags_with_count = tags_with_count
             buf.rebuild()
             ui.buffer_focus(buf)
         else:
-            ui.buffer_open(buffers.TagListBuffer(ui, tags, self.filtfun))
+            ui.buffer_open(buffers.TagListBuffer(ui, tags_with_count,
+                                                 self.filtfun))
 
 
 @registerCommand(MODE, 'flush')

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -445,10 +445,18 @@ class TagListCommand(Command):
         tags_with_count = {}
         tags = ui.dbman.get_all_tags()
         for tag in tags:
-            threads_count = ui.dbman.count_threads("tag:%s" % tag)
-            unread_count = ui.dbman.count_threads(
+            if settings.get('show_count_in_tag_list') == 'threads':
+                threads_count = ui.dbman.count_threads("tag:%s" % tag)
+                unread_count = ui.dbman.count_threads(
                     "tag:%s AND tag:unread" % tag)
-            tags_with_count[tag] = [threads_count, unread_count]
+                tags_with_count[tag] = [threads_count, unread_count]
+            elif settings.get('show_count_in_tag_list') == 'messages':
+                messages_count = ui.dbman.count_messages("tag:%s" % tag)
+                unread_count = ui.dbman.count_messages(
+                    "tag:%s AND tag:unread" % tag)
+                tags_with_count[tag] = [messages_count, unread_count]
+            else:
+                tags_with_count[tag] = []
         blists = ui.get_buffers_of_type(buffers.TagListBuffer)
         if blists:
             buf = blists[0]

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -19,6 +19,13 @@ bufferclose_focus_offset = integer(default=-1)
 # number of colours to use
 colourmode = option(1, 16, 256, default=256)
 
+# Show the number of threads or messages besides the tag in the tag list
+# widget along with the number of unread items within it.
+# Calculation of the number of threads is much more expensive than the number
+# of messages and may result in severely longer loading times for the tag list
+# widget.
+show_count_in_tag_list = option('threads', 'messages', 'none', default='none')
+
 # number of spaces used to replace tab characters
 tabwidth = integer(default=8)
 


### PR DESCRIPTION
The tag list widget now shows the number of threads and number of unread
threads of each tag next to its name.
