### PR TITLE
Made the abook regexp matching more robust.

### DIFF
--- a/alot/addressbooks.py
+++ b/alot/addressbooks.py
@@ -97,7 +97,8 @@ class MatchSdtoutAddressbook(AddressBook):
             m = re.match(self.match, l, self.reflags)
             if m:
                 info = m.groupdict()
-                email = info['email'].strip()
-                name = info['name']
-                res.append((name, email))
+                if 'email' and 'name' in info:
+                    email = info['email'].strip()
+                    name = info['name']
+                    res.append((name, email))
         return res


### PR DESCRIPTION
I use notmuch-addresses for email address completion. I ran into problems with my abook regexp. It  matches the address but didn't fill the the 'email' and 'name'  variable. To solve this I added a if statement to check if the two key are present  in the groupdict of the match.
