### PR TITLE
solarized_dark: improve 256 color approximation

### DIFF
--- a/extra/themes/solarized_dark
+++ b/extra/themes/solarized_dark
@@ -32,8 +32,8 @@
 256_base02 = 'black'
 256_base01 = 'light green'
 256_base00 = 'yellow'
-256_base0 = 'g66'
-256_base1 = 'g70'
+256_base0 = 'g50'		#808080
+256_base1 = 'g52'		#848484 - approximates #8a8a8a
 256_base2 = 'light gray'
 256_base3 = 'white'
 256_yellow = 'brown'
@@ -42,7 +42,7 @@
 256_magenta = 'dark magenta'
 256_violet = 'light magenta'
 256_blue = 'dark blue'
-256_cyan = '#088'
+256_cyan = '#0aa'		#00afaf
 256_green = 'dark green'
 
 


### PR DESCRIPTION
Solarized colors for 256 color palettes are not as closely approximated
as they could be.

256_base0 is set to g66 in Urwid's 256 color palette.  This corresponds
to #a8a8a8 in Xterm.  base0 should ideally be #808080.  This matches g50
exactly, so switch to that grayscale value.

256_base1 is set to g70 in Urwid's 256 color palette.  This corresponds
to #b2b2b2 in Xterm.  base1 should ideally be #8a8a8a.  We can't get
this exactly with Urwid's 256 color palette, but #848484 is a closer
approximation.  Switch to g52 to get this grayscale value.

256_cyan is set to #088 in Urwid's 256 color palette.  This corresponds
to #008787 in Xterm.  cyan should ideally be #00afaf.  This matches #0aa
exactly, so switch to that value.

Signed-off-by: Michael Turquette mturquette@deferred.io
