### PR TITLE
correcting error message for theme

### DIFF
--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -98,7 +98,7 @@ class SettingsManager(object):
                     self._theme = Theme(theme_path)
                 except ConfigError as e:
                     err_msg = 'Theme file %s failed validation:\n'
-                    raise ConfigError((err_msg % themestring) + e.message)
+                    raise ConfigError((err_msg % themestring) + str(e.message))
 
         # if still no theme is set, resort to default
         if self._theme is None:


### PR DESCRIPTION
When there was a theme parse error, alot was producing incorrect exception:

```
in read_config raise ConfigError((err_msg % str(themestring)) + e.message)
TypeError: cannot concatenate 'str' and 'ParseError' objects
```
