### PR TITLE
Magic versions

### DIFF
--- a/alot/helper.py
+++ b/alot/helper.py
@@ -391,6 +391,17 @@ def guess_encoding(blob):
     :returns: encoding
     :rtype: str
     """
+    # this is a bit of a hack to support different versions of python magic.
+    # Hopefully at some point this will no longer be necessary
+    #
+    # the version with open() is the bindings shipped with the file source from
+    # http://darwinsys.com/file/ - this is what is used by the python-magic
+    # package on Debian/Ubuntu.  However it is not available on pypi/via pip.
+    #
+    # the version with from_buffer() is from https://github.com/ahupp/python-magic
+    # which is installable via pip.
+    #
+    # for more detail see https://github.com/pazz/alot/pull/588
     if hasattr(magic, 'open'):
         m = magic.open(magic.MAGIC_MIME_TYPE)
         m.load()


### PR DESCRIPTION
When I try to add a signature using alot, I get the following error

```
DEBUG:globals:has signature
DEBUG:globals:is file
ERROR:ui:Traceback (most recent call last):
  File "/home/hamish/.pythonbrew/pythons/Python-2.7.3/lib/python2.7/site-packages/twisted/internet/defer.py", line     576, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/home/hamish/.pythonbrew/pythons/Python-2.7.3/lib/python2.7/site-packages/alot/ui.py", line 609, in call_apply
    return defer.maybeDeferred(cmd.apply, self)
  File "/home/hamish/.pythonbrew/pythons/Python-2.7.3/lib/python2.7/site-packages/twisted/internet/defer.py", line     138, in maybeDeferred
    result = f(*args, **kw)
  File "/home/hamish/.pythonbrew/pythons/Python-2.7.3/lib/python2.7/site-packages/twisted/internet/defer.py", line     1214, in unwindGenerator
    return _inlineCallbacks(None, gen, Deferred())
--- <exception caught here> ---
  File "/home/hamish/.pythonbrew/pythons/Python-2.7.3/lib/python2.7/site-packages/twisted/internet/defer.py", line     1071, in _inlineCallbacks
    result = g.send(result)
  File "/home/hamish/.pythonbrew/pythons/Python-2.7.3/lib/python2.7/site-packages/alot/commands/globals.py", line 726, in apply
    enc = helper.guess_encoding(sigcontent)
  File "/home/hamish/.pythonbrew/pythons/Python-2.7.3/lib/python2.7/site-packages/alot/helper.py", line 396, in        guess_encoding
    m = magic.open(magic.MAGIC_MIME_ENCODING)
exceptions.AttributeError: 'module' object has no attribute 'open'
```

Two answers on [this stackoverflow question](http://stackoverflow.com/questions/43580/how-to-find-the-mime-type-of-a-file-in-python) suggest that the API had changed by 2010. The current Ubuntu release package installed via apt still has the older version though (with `magic.open`) 

I have installed python-magic using pip, and it doesn't seem to want to offer me anything older than 0.4.3  (Unless I have  installed entirely the wrong package from pip?  I have spent a while looking at various magic file python libraries and haven't found a better one yet.)

This patch checks if magic has the open attribute, and if not it will use the newer version of the magic bindings.
