### PR TITLE
add 'next unfolded' and 'previous unfolded' as thread move commands

### DIFF
--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -511,6 +511,43 @@ class ThreadBuffer(Buffer):
         if newpos is not None:
             self.body.set_focus(newpos)
 
+    def focus_property(self, prop, direction):
+        """does a walk in the given direction and focuses the
+        first message tree that matches the given property"""
+        newpos = self.get_selected_mid()
+        newpos = direction(newpos)
+        while newpos is not None:
+            MT = self._tree[newpos]
+            if prop(MT):
+                newpos = self._sanitize_position((newpos,))
+                self.body.set_focus(newpos)
+                break
+            newpos = direction(newpos)
+
+    def focus_next_matching(self, querystring):
+        """focus next matching message in depth first order"""
+        self.focus_property(
+                lambda x: x._message.matches(querystring),
+                self._tree.next_position)
+
+    def focus_prev_matching(self, querystring):
+        """focus previous matching message in depth first order"""
+        self.focus_property(
+                lambda x: x._message.matches(querystring),
+                self._tree.prev_position)
+
+    def focus_next_unfolded(self):
+        """focus next unfolded message in depth first order"""
+        self.focus_property(
+                lambda x: not x.is_collapsed(x.root),
+                self._tree.next_position)
+
+    def focus_prev_unfolded(self):
+        """focus previous unfolded message in depth first order"""
+        self.focus_property(
+                lambda x: not x.is_collapsed(x.root),
+                self._tree.prev_position)
+
     def expand(self, msgpos):
         """expand message at given position"""
         MT = self._tree[msgpos]

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -907,6 +907,10 @@ class MoveFocusCommand(MoveCommand):
             tbuffer.focus_next()
         elif self.movement == 'previous':
             tbuffer.focus_prev()
+        elif self.movement == 'next unfolded':
+            tbuffer.focus_next_unfolded()
+        elif self.movement == 'previous unfolded':
+            tbuffer.focus_prev_unfolded()
         else:
             MoveCommand.apply(self, ui)
         # TODO add 'next matching' if threadbuffer stores the original query


### PR DESCRIPTION
When I open a thread in a search buffer for tag:unread, then I want to be able to cycle through all unfolded unread messages with a single button without having to search for them. This patch adds that functionality.

It also contains functions to select the next matching and previous matching but as far as I can see the ThreadBuffer does not know about the current search query?
