### PR TITLE
Color html rendering

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -627,7 +627,8 @@ class PipeCommand(Command):
                     pipestrings.append(mail.as_string())
                 elif self.output_format == 'decoded':
                     headertext = extract_headers(mail)
-                    bodytext = extract_body(mail)
+                    # Get bodytext from accumulate_body which strips ANSI esc
+                    bodytext = msg.accumulate_body()
                     msgtext = '%s\n\n%s' % (headertext, bodytext)
                     pipestrings.append(msgtext.encode('utf-8'))
 

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -244,7 +244,13 @@ class Message(object):
         returns bodystring extracted from this mail
         """
         #TODO: allow toggle commands to decide which part is considered body
-        return extract_body(self.get_email())
+        # Strip ANSI escapes from message
+        body = extract_body(self.get_email())
+        body = body.split('\033[')
+        stripped = body[0]
+        for part in body[1:]:
+            stripped += part.split('m',1)[1]
+        return stripped
 
     def get_text_content(self):
         return extract_body(self.get_email(), types=['text/plain'])

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -1,4 +1,3 @@
-
 ask_subject = boolean(default=True) # ask for subject when compose
 
 # automatically remove 'unread' tag when focussing messages in thread mode
@@ -34,6 +33,9 @@ themes_dir = string(default=None)
 
 # name of the theme to use
 theme = string(default=None)
+
+# apply background colors from ANSI character escapes
+ansi_background = boolean(default=True)
 
 # fill threadline with message content
 display_content_in_threadline = boolean(default=False)

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -518,88 +518,69 @@ def parse_escapes_to_urwid(text):
     attributes and returns a list containing each part of text and its
     corresponding Urwid Attributes object.
     """
+    ECODES = {
+         '0': { 'bold': False, 'underline': False, 'standout': False },
+         '1': { 'bold': True },
+         '4': { 'underline': True },
+         '7': { 'standout': True },
+        '30': { 'fg': 'black' },
+        '31': { 'fg': 'dark red' },
+        '32': { 'fg': 'dark green' },
+        '33': { 'fg': 'brown' },
+        '34': { 'fg': 'dark blue' },
+        '35': { 'fg': 'dark magenta' },
+        '36': { 'fg': 'dark cyan' },
+        '37': { 'fg': 'light gray' },
+        '40': { 'bg': 'black' },
+        '41': { 'bg': 'dark red' },
+        '42': { 'bg': 'dark green' },
+        '43': { 'bg': 'brown' },
+        '44': { 'bg': 'dark blue' },
+        '45': { 'bg': 'dark magenta' },
+        '46': { 'bg': 'dark cyan' },
+        '47': { 'bg': 'light gray' },
+    }
+
     text = text.split("\033[")
     urwid_text = []
     urwid_text.append((urwid.AttrSpec('default','default'),text[0]))
 
     # Escapes are cumulative so we always keep previous values until it's
     # changed by another escape.
-    fg,bg = 'default','default'
-    bold,underline,standout = False,False,False
+    attr = dict(fg='default', bg='default',
+                bold=False, underline=False, standout=False)
     for part in text[1:]:
         esc_code, esc_substr = part.split('m',1)
         esc_code = esc_code.split(';')
 
         if len(esc_code) == 0:
-            fg = 'default'
-            bg = 'default'
-            bold,underline,standout = False,False,False
+            attr.update(fg='default', bg='default',
+                        bold=False, underline=False, standout=False)
         else:
             i=0
             while i<len(esc_code):
                 code = esc_code[i]
-                # Attributes
-                if code == '0':
-                    bold,underline,standout = False,False,False
-                elif code == '1':
-                    bold = True
-                elif code == '4':
-                    underline = True
-                elif code == '7':
-                    standout = True
-                # Foreground Colors
-                elif code == '30':
-                    fg = 'black'
-                elif code == '31':
-                    fg = 'dark red'
-                elif code == '32':
-                    fg = 'dark green'
-                elif code == '33':
-                    fg = 'brown'
-                elif code == '34':
-                    fg = 'dark blue'
-                elif code == '35':
-                    fg = 'dark magenta'
-                elif code == '36':
-                    fg = 'dark cyan'
-                elif code == '37':
-                    fg = 'light gray'
+                if code in ECODES:
+                    attr.update(ECODES[code])
+                # 256 codes
                 elif code == '38':
-                    fg = 'h'+esc_code[i+2]
+                    attr.update(fg='h'+esc_code[i+2])
                     i += 2
-                # Background Colors
-                elif code == '40':
-                    bg = 'black'
-                elif code == '41':
-                    bg = 'dark red'
-                elif code == '42':
-                    bg = 'dark green'
-                elif code == '44':
-                    bg = 'brown'
-                elif code == '44':
-                    bg = 'dark blue'
-                elif code == '45':
-                    bg = 'dark magenta'
-                elif code == '46':
-                    bg = 'dark cyan'
-                elif code == '47':
-                    bg = 'light gray'
                 elif code == '48':
-                    bg = 'h'+esc_code[i+2]
+                    attr.update(bg='h'+esc_code[i+2])
                     i += 2
-                # Everything else is just ignored
                 i += 1
 
         # If there is no string in esc_substr we skip it, the above
         # attributes will accumulate to the next escapes.
         if esc_substr != '':
             # Construct Urwid Foreground attr
-            urwid_fg = fg
-            if bold:
+            urwid_fg = attr['fg']
+            if attr['bold']:
                 urwid_fg += ',bold'
-            if underline:
+            if attr['underline']:
                 urwid_fg += ',underline'
-            if standout:
+            if attr['standout']:
                 urwid_fg += ',standout'
-            urwid_text.append((urwid.AttrSpec(urwid_fg,bg),esc_substr))
+            urwid_text.append((urwid.AttrSpec(urwid_fg,attr['bg']),esc_substr))
     return urwid_text

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -516,7 +516,8 @@ def parse_mailcap_nametemplate(tmplate='%s'):
 def parse_escapes_to_urwid(text, default_attr=None, default_attr_focus=None):
     """This function converts a text with ANSI escape for terminal
     attributes and returns a list containing each part of text and its
-    corresponding Urwid Attributes object.
+    corresponding Urwid Attributes object, it also returns a dictionary which
+    maps all attributes applied here to focused attribute.
     """
     ECODES = {
          '0': { 'bold': default_attr.bold,
@@ -544,8 +545,8 @@ def parse_escapes_to_urwid(text, default_attr=None, default_attr_focus=None):
     }
 
     text = text.split("\033[")
-    urwid_text = []
-    urwid_text.append(text[0])
+    urwid_text = [ text[0] ]
+    urwid_focus = { None: default_attr_focus }
 
     # Escapes are cumulative so we always keep previous values until it's
     # changed by another escape.
@@ -557,8 +558,9 @@ def parse_escapes_to_urwid(text, default_attr=None, default_attr_focus=None):
         esc_code = esc_code.split(';')
 
         if len(esc_code) == 0:
-            attr.update(fg=default_attr._foreground_color, bg=default_attr.background,
-                        bold=default_attr.bold, underline=default_attr.underline,
+            attr.update(fg=default_attr._foreground_color,
+                        bg=default_attr.background, bold=default_attr.bold,
+                        underline=default_attr.underline,
                         standout=default_attr.underline)
         else:
             i=0
@@ -586,5 +588,7 @@ def parse_escapes_to_urwid(text, default_attr=None, default_attr_focus=None):
                 urwid_fg += ',underline'
             if attr['standout']:
                 urwid_fg += ',standout'
-            urwid_text.append((urwid.AttrSpec(urwid_fg,attr['bg']),esc_substr))
-    return urwid_text
+            urwid_attr = urwid.AttrSpec(urwid_fg,attr['bg'])
+            urwid_focus[urwid_attr] = default_attr_focus
+            urwid_text.append((urwid_attr,esc_substr))
+    return urwid_text,urwid_focus

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -22,7 +22,6 @@ from twisted.internet.defer import Deferred
 import StringIO
 import logging
 
-
 def split_commandline(s, comments=False, posix=True):
     """
     splits semi-colon separated commandlines
@@ -513,7 +512,8 @@ def parse_mailcap_nametemplate(tmplate='%s'):
         template_suffix = tmplate
     return (template_prefix, template_suffix)
 
-def parse_escapes_to_urwid(text, default_attr=None, default_attr_focus=None):
+def parse_escapes_to_urwid(text, default_attr=None, default_attr_focus=None,
+                           parse_background=True):
     """This function converts a text with ANSI escape for terminal
     attributes and returns a list containing each part of text and its
     corresponding Urwid Attributes object, it also returns a dictionary which
@@ -580,15 +580,18 @@ def parse_escapes_to_urwid(text, default_attr=None, default_attr_focus=None):
         # If there is no string in esc_substr we skip it, the above
         # attributes will accumulate to the next escapes.
         if esc_substr != '':
-            # Construct Urwid Foreground attr
+            # Construct Urwid attributes
             urwid_fg = attr['fg']
+            urwid_bg = default_attr.background
             if attr['bold']:
                 urwid_fg += ',bold'
             if attr['underline']:
                 urwid_fg += ',underline'
             if attr['standout']:
                 urwid_fg += ',standout'
-            urwid_attr = urwid.AttrSpec(urwid_fg,attr['bg'])
+            if parse_background:
+                urwid_bg = attr['bg']
+            urwid_attr = urwid.AttrSpec(urwid_fg,urwid_bg)
             urwid_focus[urwid_attr] = default_attr_focus
             urwid_text.append((urwid_attr,esc_substr))
     return urwid_text,urwid_focus

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -513,13 +513,15 @@ def parse_mailcap_nametemplate(tmplate='%s'):
         template_suffix = tmplate
     return (template_prefix, template_suffix)
 
-def parse_escapes_to_urwid(text):
+def parse_escapes_to_urwid(text, default_attr=None, default_attr_focus=None):
     """This function converts a text with ANSI escape for terminal
     attributes and returns a list containing each part of text and its
     corresponding Urwid Attributes object.
     """
     ECODES = {
-         '0': { 'bold': False, 'underline': False, 'standout': False },
+         '0': { 'bold': default_attr.bold,
+                'underline': default_attr.underline,
+                'standout': default_attr.standout },
          '1': { 'bold': True },
          '4': { 'underline': True },
          '7': { 'standout': True },
@@ -543,19 +545,21 @@ def parse_escapes_to_urwid(text):
 
     text = text.split("\033[")
     urwid_text = []
-    urwid_text.append((urwid.AttrSpec('default','default'),text[0]))
+    urwid_text.append(text[0])
 
     # Escapes are cumulative so we always keep previous values until it's
     # changed by another escape.
-    attr = dict(fg='default', bg='default',
-                bold=False, underline=False, standout=False)
+    attr = dict(fg=default_attr._foreground_color, bg=default_attr.background,
+                bold=default_attr.bold, underline=default_attr.underline,
+                standout=default_attr.underline)
     for part in text[1:]:
         esc_code, esc_substr = part.split('m',1)
         esc_code = esc_code.split(';')
 
         if len(esc_code) == 0:
-            attr.update(fg='default', bg='default',
-                        bold=False, underline=False, standout=False)
+            attr.update(fg=default_attr._foreground_color, bg=default_attr.background,
+                        bold=default_attr.bold, underline=default_attr.underline,
+                        standout=default_attr.underline)
         else:
             i=0
             while i<len(esc_code):

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -84,7 +84,6 @@ class MessageBodyWidget(urwid.AttrMap):
 class FocusableText(urwid.WidgetWrap):
     """Selectable Text used for nodes in our example"""
     def __init__(self, txt, att, att_focus):
-        txt,att_focus = parse_escapes_to_urwid(txt,att,att_focus)
         t = urwid.Text(txt)
         w = urwid.AttrMap(t, att, att_focus)
         urwid.WidgetWrap.__init__(self, w)
@@ -103,7 +102,8 @@ class TextlinesList(SimpleTree):
         """
         structure = []
         for line in content.splitlines():
-            structure.append((FocusableText(line, attr, attr_focus), None))
+            line,attr_focus_dict = parse_escapes_to_urwid(line,attr,attr_focus)
+            structure.append((FocusableText(line, attr, attr_focus_dict), None))
         SimpleTree.__init__(self, structure)
 
 

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -100,6 +100,7 @@ class TextlinesList(SimpleTree):
         :class:`SimpleTree` that contains a list of all-level-0 Text widgets
         for each line in content.
         """
+        """ TODO: text comes with ANSI escapes """
         structure = []
         for line in content.splitlines():
             structure.append((FocusableText(line, attr, attr_focus), None))
@@ -232,6 +233,7 @@ class MessageTree(CollapsibleTree):
     def _get_source(self):
         if self._sourcetree is None:
             sourcetxt = self._message.get_email().as_string()
+            """TODO: Apply syntax to source"""
             att = settings.get_theming_attribute('thread', 'body')
             att_focus = settings.get_theming_attribute('thread', 'body_focus')
             self._sourcetree = TextlinesList(sourcetxt, att, att_focus)
@@ -241,6 +243,7 @@ class MessageTree(CollapsibleTree):
         if self._bodytree is None:
             bodytxt = extract_body(self._message.get_email())
             if bodytxt:
+                """TODO: Apply syntax to bodytxt"""
                 att = settings.get_theming_attribute('thread', 'body')
                 att_focus = settings.get_theming_attribute(
                     'thread', 'body_focus')

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -102,7 +102,9 @@ class TextlinesList(SimpleTree):
         """
         structure = []
         for line in content.splitlines():
-            line,attr_focus_dict = parse_escapes_to_urwid(line,attr,attr_focus)
+            ansi_background = settings.get("ansi_background")
+            line,attr_focus_dict = parse_escapes_to_urwid(line,attr,attr_focus,
+                                                          ansi_background)
             structure.append((FocusableText(line, attr, attr_focus_dict), None))
         SimpleTree.__init__(self, structure)
 

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -84,6 +84,7 @@ class MessageBodyWidget(urwid.AttrMap):
 class FocusableText(urwid.WidgetWrap):
     """Selectable Text used for nodes in our example"""
     def __init__(self, txt, att, att_focus):
+        txt,att_focus = parse_escapes_to_urwid(txt,att,att_focus)
         t = urwid.Text(txt)
         w = urwid.AttrMap(t, att, att_focus)
         urwid.WidgetWrap.__init__(self, w)
@@ -102,7 +103,6 @@ class TextlinesList(SimpleTree):
         """
         structure = []
         for line in content.splitlines():
-            line = parse_escapes_to_urwid(line,attr,attr_focus)
             structure.append((FocusableText(line, attr, attr_focus), None))
         SimpleTree.__init__(self, structure)
 

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -10,6 +10,7 @@ import logging
 from alot.settings import settings
 from alot.db.utils import decode_header
 from alot.helper import tag_cmp
+from alot.helper import parse_escapes_to_urwid
 from alot.widgets.globals import TagWidget
 from alot.widgets.globals import AttachmentWidget
 from alot.foreign.urwidtrees import Tree, SimpleTree, CollapsibleTree
@@ -93,16 +94,15 @@ class FocusableText(urwid.WidgetWrap):
     def keypress(self, size, key):
         return key
 
-
 class TextlinesList(SimpleTree):
     def __init__(self, content, attr=None, attr_focus=None):
         """
         :class:`SimpleTree` that contains a list of all-level-0 Text widgets
         for each line in content.
         """
-        """ TODO: text comes with ANSI escapes """
         structure = []
         for line in content.splitlines():
+            line = parse_escapes_to_urwid(line)
             structure.append((FocusableText(line, attr, attr_focus), None))
         SimpleTree.__init__(self, structure)
 

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -102,7 +102,7 @@ class TextlinesList(SimpleTree):
         """
         structure = []
         for line in content.splitlines():
-            line = parse_escapes_to_urwid(line)
+            line = parse_escapes_to_urwid(line,attr,attr_focus)
             structure.append((FocusableText(line, attr, attr_focus), None))
         SimpleTree.__init__(self, structure)
 


### PR DESCRIPTION
Put some colors in mail body. This should work in case you use color dump with elinks or other program in mailcap for html rendering. It translates the ANSI escapes to Urwid attributes object and applies them while in thread mode. Also it strips them out on replies, forwards, bounces, write as new and pipeto (--format=decoded) commands.

It assumes no extra configuration in alot files: i.e. user would decide if he wants it by simply adding color dump in mailcap.

Works with 8 color escapes or 256 color escapes. Also bold, underline and reverse attributes. Ignores all other escapes. It also honors the cumulative behaviour of ANSI escapes which is different from how Urwid works (i.e. turn on bold… it will be turned on until it is turned off =P).

Invalid escapes like '\e[38;233' instead of '\e[38;5;233' will probably raise an exception (out of bounds indexing), however I don’t know if it is something that 'alot' would care about. ;)
