### PR TITLE
mail aliases treated as regexp causes mismatch

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -627,7 +627,8 @@ class PipeCommand(Command):
                     pipestrings.append(mail.as_string())
                 elif self.output_format == 'decoded':
                     headertext = extract_headers(mail)
-                    bodytext = extract_body(mail)
+                    # Get bodytext from accumulate_body which strips ANSI esc
+                    bodytext = msg.accumulate_body()
                     msgtext = '%s\n\n%s' % (headertext, bodytext)
                     pipestrings.append(msgtext.encode('utf-8'))
 

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -244,7 +244,13 @@ class Message(object):
         returns bodystring extracted from this mail
         """
         #TODO: allow toggle commands to decide which part is considered body
-        return extract_body(self.get_email())
+        # Strip ANSI escapes from message
+        body = extract_body(self.get_email())
+        body = body.split('\033[')
+        stripped = body[0]
+        for part in body[1:]:
+            stripped += part.split('m',1)[1]
+        return stripped
 
     def get_text_content(self):
         return extract_body(self.get_email(), types=['text/plain'])

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -10,6 +10,7 @@ import logging
 from alot.settings import settings
 from alot.db.utils import decode_header
 from alot.helper import tag_cmp
+from alot.helper import parse_escapes_to_urwid
 from alot.widgets.globals import TagWidget
 from alot.widgets.globals import AttachmentWidget
 from alot.foreign.urwidtrees import Tree, SimpleTree, CollapsibleTree
@@ -93,7 +94,6 @@ class FocusableText(urwid.WidgetWrap):
     def keypress(self, size, key):
         return key
 
-
 class TextlinesList(SimpleTree):
     def __init__(self, content, attr=None, attr_focus=None):
         """
@@ -102,6 +102,7 @@ class TextlinesList(SimpleTree):
         """
         structure = []
         for line in content.splitlines():
+            line = parse_escapes_to_urwid(line)
             structure.append((FocusableText(line, attr, attr_focus), None))
         SimpleTree.__init__(self, structure)
 
@@ -232,6 +233,7 @@ class MessageTree(CollapsibleTree):
     def _get_source(self):
         if self._sourcetree is None:
             sourcetxt = self._message.get_email().as_string()
+            """TODO: Apply syntax to source"""
             att = settings.get_theming_attribute('thread', 'body')
             att_focus = settings.get_theming_attribute('thread', 'body_focus')
             self._sourcetree = TextlinesList(sourcetxt, att, att_focus)
@@ -241,6 +243,7 @@ class MessageTree(CollapsibleTree):
         if self._bodytree is None:
             bodytxt = extract_body(self._message.get_email())
             if bodytxt:
+                """TODO: Apply syntax to bodytxt"""
                 att = settings.get_theming_attribute('thread', 'body')
                 att_focus = settings.get_theming_attribute(
                     'thread', 'body_focus')


### PR DESCRIPTION
Currently a regexp is created for every alias in configuration file. However
special characters are not escaped which causes a mismatch. Mail aliases are
string literals that may contain lots of special regexp chars and those
should be escaped before compiling a regexp.

For instance, one may have an alias like:
a.lot.of.dots@server.com

Gmail aliases are constructed with + sign:
username+anything@gmail.com

which would match 'usernameeeeeeanything@gmail.com' but not 'username+anything@gmail.com' =(

This commit fixes this issue.
