### PR TITLE
make tag commands undoable

### DIFF
--- a/alot/commands/search.py
+++ b/alot/commands/search.py
@@ -7,6 +7,7 @@ import logging
 from alot.commands import Command, registerCommand
 from alot.commands.globals import PromptCommand
 from alot.commands.globals import MoveCommand
+from alot.commands.thread import UndoTagCommand
 
 from alot.db.errors import DatabaseROError
 from alot import commands
@@ -205,6 +206,8 @@ class TagCommand(Command):
         tags = filter(lambda x: x, self.tagsstring.split(','))
 
         try:
+            UndoTagCommand.stack.append([thread, thread.get_tags().copy()])
+
             if self.action == 'add':
                 ui.dbman.tag(testquery, tags, remove_rest=False)
             if self.action == 'set':

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -946,7 +946,7 @@ class ThreadSelectCommand(Command):
     (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
                       'help': 'postpone a writeout to the index'}),
     (['tags'], {'help': 'comma separated list of tags'})],
-    help='set message(s) tags.',
+    help='set message(s) tags. Like add, but discards previously existing tags',
 )
 @registerCommand(MODE, 'untag', forced={'action': 'remove'}, arguments=[
     (['--all'], {'action': 'store_true',
@@ -1006,8 +1006,12 @@ class TagCommand(Command):
 
             tbuffer.refresh()
 
-        tags = filter(lambda x: x, self.tagsstring.split(','))
+        tags = set(filter(lambda x: x, self.tagsstring.split(',')))
         try:
+            UndoTagCommand.stack.append(zip(
+                [ m.get_message()               for m in messagetrees],
+                [ m.get_message().get_tags()[:] for m in messagetrees]))
+
             for mt in messagetrees:
                 m = mt.get_message()
                 if self.action == 'add':
@@ -1018,14 +1022,8 @@ class TagCommand(Command):
                 elif self.action == 'remove':
                     m.remove_tags(tags, afterwards=refresh_widgets)
                 elif self.action == 'toggle':
-                    to_remove = []
-                    to_add = []
-                    for t in tags:
-                        if t in m.get_tags():
-                            to_remove.append(t)
-                        else:
-                            to_add.append(t)
-                    m.remove_tags(to_remove)
+                    to_add = tags.difference(m.get_tags())
+                    m.remove_tags(tags.intersection(m.get_tags()))
                     m.add_tags(to_add, afterwards=refresh_widgets)
 
         except DatabaseROError:
@@ -1035,3 +1033,48 @@ class TagCommand(Command):
         # flush index
         if self.flush:
             ui.apply_command(FlushCommand())
+
+
+@registerCommand('thread', 'undotag', arguments=[
+    (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
+                      'help': 'postpone a writeout to the index'})],
+    help='undo previous tagging command',
+)
+@registerCommand('search', 'undotag', arguments=[
+    (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
+                      'help': 'postpone a writeout to the index'})],
+    help='undo previous tagging command',
+)
+class UndoTagCommand(Command):
+    stack = []
+
+    """reverts previous tagging commands"""
+    def __init__(self, flush=True, **kwargs):
+        """
+        :param flush: imediately write out to the index
+        :type flush: bool
+        """
+        self.flush = flush
+        super(UndoTagCommand, self).__init__(**kwargs)
+
+    def apply(self, ui):
+        # restore most recent tags
+        logging.debug('stack[-1]: %s' % self.stack[-1])
+        msg, tags = self.stack[-1]
+        msg.add_tags(tags, remove_rest=True)
+
+        # pop most recent entry
+        self.stack.pop()
+
+        # flush index
+        if self.flush:
+            ui.apply_command(FlushCommand())
+
+        # refresh buffer
+        try:
+            threadline_widget = ui.current_buffer.get_selected_threadline()
+            threadline_widget.rebuild()
+        except:
+            ui.current_buffer.rebuild()
+        finally:
+            ui.update()


### PR DESCRIPTION
First of all, i do not consider this patch ready to merge, however I wanted to kick of some discussion about an undo mechanism.

Tackling this issue in general is far from trivial and would also require rethinking the whole command mechanism. Inverse operations aren't always obvious/possible and the concept of command lines makes it even harder (e.g. a long command line could include a single non-reversible command).
But what can easily be realized is the undoing of _individual_ tag commands, which doesn't handle whole command lines. Yes, this feels like a hack, but the possibility to at least undo tagging is something I desperately like to have.

Apart from that, the implemented mechanism  does offend existing code, by registering the very same command in both search and thread mode, albeit implemented only in thread. One would need to duplicate the implementation to match the existing code/policy. 
Currently, similar but independent TagCommands exist in search as well as tag mode. The reason for that -as far as I understand it- is, that each command is individually responsible for choosing it's scope to act on. If modes would be responsible for scoping, rather than commands, they could also handle ui refreshes, etc... and all commands could drop the corresponding code. Furthermore, commands like TagCommand could be reused in search and thread mode or maybe I got it all wrong ;-). Even though, beyond this pull request, this is more about kicking  off some discussion. Did you ever consider such a change and is this something you would be interested in? What do you think about undoing in general and in particular? What is your opinion on reusing the UndoTagCommand in thread and search mode?
