### PR TITLE
Fix the default failobj of get_params

### DIFF
--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -57,7 +57,7 @@ def add_signature_headers(mail, sigs, error_msg):
     )
 
 
-def get_params(mail, failobj=None, header='content-type', unquote=True):
+def get_params(mail, failobj=list(), header='content-type', unquote=True):
     '''Get Content-Type parameters as dict.
 
     RFC 2045 specifies that parameter names are case-insensitive, so


### PR DESCRIPTION
Formerly None was used as failobj, but None is not iterable and that
is all that get_params does. Use list() instead which is iterable.

Closes #626.

Signed-off-by: Justus Winter 4winter@informatik.uni-hamburg.de
