### PR TITLE
canceling a command in a sequence will now stop the subsequent commands from being run

### DIFF
--- a/alot/commands/__init__.py
+++ b/alot/commands/__init__.py
@@ -27,6 +27,11 @@ class Command(object):
         pass
 
 
+class CommandCanceled(Exception):
+    """ Exception triggered when an interactive command has been canceled
+    """
+    pass
+
 COMMANDS = {
     'search': {},
     'envelope': {},

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -4,6 +4,7 @@
 import os
 import code
 from twisted.internet import threads
+from twisted.internet import defer
 import subprocess
 import email
 import urwid
@@ -17,6 +18,7 @@ from alot.commands import Command, registerCommand
 from alot.completion import CommandLineCompleter
 from alot.commands import CommandParseError
 from alot.commands import commandfactory
+from alot.commands import CommandCanceled
 from alot import buffers
 from alot.widgets.utils import DialogBox
 from alot import helper
@@ -120,6 +122,8 @@ class PromptCommand(Command):
             # save into prompt history
             ui.commandprompthistory.append(cmdline)
             ui.apply_commandline(cmdline)
+        else:
+            raise CommandCanceled()
 
 
 @registerCommand(MODE, 'refresh')
@@ -726,8 +730,8 @@ class ComposeCommand(Command):
                 fromaddress = yield ui.prompt('From', completer=cmpl,
                                               tab=1)
                 if fromaddress is None:
-                    ui.notify('canceled')
-                    return
+                    raise CommandCanceled()
+
                 self.envelope.add('From', fromaddress)
 
         # add signature
@@ -782,8 +786,8 @@ class ComposeCommand(Command):
             to = yield ui.prompt('To',
                                  completer=completer)
             if to is None:
-                ui.notify('canceled')
-                return
+                raise CommandCanceled()
+
             self.envelope.add('To', to.strip(' \t\n,'))
 
         if settings.get('ask_subject') and \
@@ -791,8 +795,8 @@ class ComposeCommand(Command):
             subject = yield ui.prompt('Subject')
             logging.debug('SUBJECT: "%s"' % subject)
             if subject is None:
-                ui.notify('canceled')
-                return
+                raise CommandCanceled()
+
             self.envelope.add('Subject', subject)
 
         if settings.get('compose_ask_tags'):
@@ -800,8 +804,8 @@ class ComposeCommand(Command):
             tagsstring = yield ui.prompt('Tags', completer=comp)
             tags = filter(lambda x: x, tagsstring.split(','))
             if tags is None:
-                ui.notify('canceled')
-                return
+                raise CommandCanceled()
+
             self.envelope.tags = tags
 
         if self.attach:
@@ -853,18 +857,29 @@ class CommandSequenceCommand(Command):
         Command.__init__(self, **kwargs)
         self.cmdline = cmdline
 
-    @inlineCallbacks
     def apply(self, ui):
+
+        def apply_command(ignored, cmdstring, cmd):
+            logging.debug('CMDSEQ: apply %s' % str(cmdstring))
+            # store cmdline for use with 'repeat' command
+            if cmd.repeatable:
+                ui.last_commandline = self.cmdline.lstrip()
+            return ui.apply_command(cmd, handle_error=False)
+
+        # we initialize a deferred which is already triggered 
+        # so that our callbacks will start to be called 
+        # immediately as possible
+        d = defer.succeed(None)
+
         # split commandline if necessary
         for cmdstring in split_commandline(self.cmdline):
-            logging.debug('CMDSEQ: apply %s' % str(cmdstring))
             # translate cmdstring into :class:`Command`
             try:
                 cmd = commandfactory(cmdstring, ui.mode)
-                # store cmdline for use with 'repeat' command
-                if cmd.repeatable:
-                    ui.last_commandline = self.cmdline.lstrip()
             except CommandParseError, e:
                 ui.notify(e.message, priority='error')
                 return
-            yield ui.apply_command(cmd)
+            d.addCallback(apply_command, cmdstring, cmd)
+
+        return d
+

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -17,6 +17,7 @@ from alot.commands.globals import ExternalCommand
 from alot.commands.globals import FlushCommand
 from alot.commands.globals import ComposeCommand
 from alot.commands.globals import MoveCommand
+from alot.commands.globals import CommandCanceled
 from alot.commands.envelope import SendCommand
 from alot import completion
 from alot.db.utils import decode_header
@@ -382,8 +383,8 @@ class BounceMailCommand(Command):
             completer = None
         to = yield ui.prompt('To', completer=completer)
         if to is None:
-            ui.notify('canceled')
-            return
+            raise CommandCanceled()
+
         mail['Resent-To'] = to.strip(' \t\n,')
 
         logging.debug("bouncing mail")
@@ -814,7 +815,7 @@ class SaveAttachmentCommand(Command):
                     ui.notify('not a directory: %s' % self.path,
                               priority='error')
             else:
-                ui.notify('canceled')
+                raise CommandCanceled()
         else:  # save focussed attachment
             focus = ui.get_deep_focus()
             if isinstance(focus, AttachmentWidget):
@@ -833,7 +834,7 @@ class SaveAttachmentCommand(Command):
                     except (IOError, OSError), e:
                         ui.notify(str(e), priority='error')
                 else:
-                    ui.notify('canceled')
+                    raise CommandCanceled()
 
 
 class OpenAttachmentCommand(Command):

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -8,6 +8,7 @@ from twisted.internet import reactor, defer
 from settings import settings
 from buffers import BufferlistBuffer
 from commands import commandfactory
+from commands import CommandCanceled
 from alot.commands import CommandParseError
 from alot.commands.globals import CommandSequenceCommand
 from alot.helper import string_decode
@@ -557,7 +558,7 @@ class UI(object):
         footer_att = settings.get_theming_attribute('global', 'footer')
         return urwid.AttrMap(columns, footer_att)
 
-    def apply_command(self, cmd):
+    def apply_command(self, cmd, handle_error=True):
         """
         applies a command
 
@@ -566,6 +567,11 @@ class UI(object):
 
         :param cmd: an applicable command
         :type cmd: :class:`~alot.commands.Command`
+        :param handle_error: if True, the caller wants to rely on the default
+                             error handling mechanism to process the eventual
+                             errors raised while the command is applied.
+                             This is the default.
+        :type handle_error: bool
         """
         if cmd:
             # define (callback) function that invokes post-hook
@@ -575,15 +581,18 @@ class UI(object):
                     return defer.maybeDeferred(cmd.posthook, ui=self,
                                                dbm=self.dbman)
 
-            # define error handler for Failures/Exceptions
+            # define a generic error handler for Failures/Exceptions
             # raised in cmd.apply()
             def errorHandler(failure):
-                logging.error(failure.getTraceback())
-                errmsg = failure.getErrorMessage()
-                if errmsg:
-                    msg = "%s\n(check the log for details)"
-                    self.notify(
-                        msg % failure.getErrorMessage(), priority='error')
+                if failure.check(CommandCanceled):
+                    self.notify('canceled')
+                else:
+                    logging.error(failure.getTraceback())
+                    errmsg = failure.getErrorMessage()
+                    if errmsg:
+                        msg = "%s\n(check the log for details)"
+                        self.notify(
+                            msg % failure.getErrorMessage(), priority='error')
 
             # call cmd.apply
             def call_apply(ignored):
@@ -593,5 +602,6 @@ class UI(object):
             d = defer.maybeDeferred(prehook, ui=self, dbm=self.dbman)
             d.addCallback(call_apply)
             d.addCallback(call_posthook)
-            d.addErrback(errorHandler)
+            if handle_error:
+                d.addErrback(errorHandler)
             return d


### PR DESCRIPTION
Hi Pazz,

I recently discovered alot and I am very happy with it !

However I had a little problem with a binding I use to quickly tag and archive my mails:
     l = prompt 'tag '; untag inbox

If I change my mind after having typed 'l' and type 'escape', the inbox tag is still removed from the message because "escape" will only cancel the current command of a sequence.

I think it would be better if canceling a command belonging to a sequence would at least prevent the subsequent ones from being run (and maybe unapply the previous one but this may be subject to debate).

The following patch is an attempt to do it.

I am not sure it really fits in the logic of the code so I am waiting for your feedback.

Thanks for your work on alot.

Yann
