### PR TITLE
fix command line escaping for arguments containing spaces

### DIFF
--- a/alot/helper.py
+++ b/alot/helper.py
@@ -27,7 +27,8 @@ def split_commandline(s, comments=False, posix=True):
     """
     splits semi-colon separated commandlines
     """
-    # shlex seems to remove unescaped quotes
+    # shlex seems to remove unescaped quotes and backslashes
+    s = s.replace('\\', '\\\\')
     s = s.replace('\'', '\\\'')
     s = s.replace('\"', '\\\"')
     # encode s to utf-8 for shlex


### PR DESCRIPTION
Hi Pazz,

Here is a tiny pull request for a little issue I encountered when attaching files with spaces in it.
The attach command was rejected with "Unrecognized argument".

After some search, it seems the problem lies in shlex which removes backslashes that are not espaced so I added a line to escape backslashes like wthat was already done for ' and "".

Yann
