### PR TITLE
Use Unicode strings when dealing with GPG

### DIFF
--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -51,9 +51,9 @@ def add_signature_headers(mail, sigs, error_msg):
     )
     mail.add_header(
         X_SIGNATURE_MESSAGE_HEADER,
-        'Invalid: {0}'.format(error_msg)
+        u'Invalid: {0}'.format(error_msg)
         if error_msg else
-        'Valid: {0}'.format(sig_from),
+        u'Valid: {0}'.format(sig_from),
     )
 
 
@@ -104,19 +104,19 @@ def message_from_file(handle):
 
         malformed = False
         if len(m.get_payload()) != 2:
-            malformed = 'expected exactly two messages, got {0}'.format(
+            malformed = u'expected exactly two messages, got {0}'.format(
                 len(m.get_payload()))
 
         ct = m.get_payload(1).get_content_type()
         if ct != app_pgp_sig:
-            malformed = 'expected Content-Type: {0}, got: {1}'.format(
+            malformed = u'expected Content-Type: {0}, got: {1}'.format(
                 app_pgp_sig, ct)
 
         # TODO: RFC 3156 says the alg has to be lower case, but I've
         # seen a message with 'PGP-'. maybe we should be more
         # permissive here, or maybe not, this is crypto stuff...
         if not p.get('micalg', 'nothing').startswith('pgp-'):
-            malformed = 'expected micalg=pgp-..., got: {0}'.format(
+            malformed = u'expected micalg=pgp-..., got: {0}'.format(
                 p.get('micalg', 'nothing'))
 
         sigs = []
@@ -144,13 +144,13 @@ def message_from_file(handle):
 
         ct = m.get_payload(0).get_content_type()
         if ct != app_pgp_enc:
-            malformed = 'expected Content-Type: {0}, got: {1}'.format(
+            malformed = u'expected Content-Type: {0}, got: {1}'.format(
                 app_pgp_enc, ct)
 
         want = 'application/octet-stream'
         ct = m.get_payload(1).get_content_type()
         if ct != want:
-            malformed = 'expected Content-Type: {0}, got: {1}'.format(want, ct)
+            malformed = u'expected Content-Type: {0}, got: {1}'.format(want, ct)
 
         if not malformed:
             try:
@@ -199,7 +199,7 @@ def message_from_file(handle):
                     add_signature_headers(m, sigs, '')
 
         if malformed:
-            msg = 'Malformed OpenPGP message: {0}'.format(malformed)
+            msg = u'Malformed OpenPGP message: {0}'.format(malformed)
             m.attach(email.message_from_string(msg))
 
     return m


### PR DESCRIPTION
This delays the encoding of special chars, if any, to the actual display
which is supposed to know into what it should be encoded.

This patch will be shipped in the Debian package.
