### PR TITLE
helper: do not strip in string_sanitize

### DIFF
--- a/alot/helper.py
+++ b/alot/helper.py
@@ -81,14 +81,13 @@ def string_sanitize(string, tab_width=8):
     :type tab_width: int or `None`
 
     >>> string_sanitize(' foo\rbar ', 8)
-    'foobar'
+    ' foobar '
     >>> string_sanitize('foo\tbar', 8)
     'foo     bar'
     >>> string_sanitize('foo\t\tbar', 8)
     'foo             bar'
     """
 
-    string = string.strip()
     string = string.replace('\r', '')
 
     lines = list()


### PR DESCRIPTION
Stripping the string causes leading whitespace on the first line
of a message to be removed leading to weird indentation in thread
view for some html messages.

string_sanitize is also used for mail header parsing but I would
not expect them to contain undesired whitespace too often either.
