### PR TITLE
widgets: do not focus lines in email

### DIFF
--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -102,7 +102,7 @@ class TextlinesList(SimpleTree):
         """
         structure = []
         for line in content.splitlines():
-            structure.append((FocusableText(line, attr, attr_focus), None))
+            structure.append((urwid.Text((attr, line)), None))
         SimpleTree.__init__(self, structure)
 
 


### PR DESCRIPTION
Currently the thread view widget (below the hood) allows focussing
each line in e-mail. This not ideal for reading long threads as the
first movement actions always move the focus and only when focus
has reached the edge of the widget does scrolling begin.

As there seems to be no direct use for focussing individual lines
in the email, switch the lines to be plain Text elements rather
than FocussableText.
