### PR TITLE
`tag` and `untag` only affect matching messages in seach mode

### DIFF
--- a/alot/commands/search.py
+++ b/alot/commands/search.py
@@ -116,7 +116,7 @@ class RetagPromptCommand(Command):
     (['--all'], {'action': 'store_true', 'dest': 'allmessages', 'default':
                  False, 'help': 'retag all messages in search result'}),
     (['tags'], {'help': 'comma separated list of tags'})],
-    help='add tags to all messages in the thread',
+    help='add tags to all messages in the thread that match the current query',
 )
 @registerCommand(MODE, 'retag', forced={'action': 'set'}, arguments=[
     (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
@@ -125,7 +125,7 @@ class RetagPromptCommand(Command):
     (['--all'], {'action': 'store_true', 'dest': 'allmessages', 'default':
                  False, 'help': 'retag all messages in search result'}),
     (['tags'], {'help': 'comma separated list of tags'})],
-    help='set tags of all messages in the thread',
+    help='set tags of all messages in the thread that match the current query',
 )
 @registerCommand(MODE, 'untag', forced={'action': 'remove'}, arguments=[
     (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
@@ -134,7 +134,7 @@ class RetagPromptCommand(Command):
     (['--all'], {'action': 'store_true', 'dest': 'allmessages', 'default':
                  False, 'help': 'retag all messages in search result'}),
     (['tags'], {'help': 'comma separated list of tags'})],
-    help='remove tags from all messages in the thread',
+    help='remove tags from all messages in the thread that match the current query',
 )
 @registerCommand(MODE, 'toggletags', forced={'action': 'toggle'}, arguments=[
     (['--no-flush'], {'action': 'store_false', 'dest': 'flush',


### PR DESCRIPTION
In search mode, when I say `tag foo` on a given thread, only the messages matching the current search get the tag `foo`, non-matching messages are unchanged. The same applies for the `untag` command, which is consistent. However, the documentation states _tag: add tags to all messages in the thread_, which is not what happens.

This is problematic in several use cases. A typical example for me is the `killed` tag: when I press `&` on a thread line, I do want to kill the thread, i.e. put the `killed` tag on all messages in the thread, otherwise the thread is not killed, only some of its messages.

Surely, tagging only matching messages is also useful in other situations, so I think the best solution would be to add an option to the `tag` and `untag` commands to let the user choose.
