### PR TITLE
Check for "Re:" at start of subject in case insensitive manner

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -149,7 +149,7 @@ class ReplyCommand(Command):
             subject = reply_subject_hook(subject)
         else:
             rsp = settings.get('reply_subject_prefix')
-            if not subject.startswith(('Re:', rsp)):
+            if not subject.lower().startswith(('re:', rsp.lower())):
                 subject = rsp + subject
         envelope.add('Subject', subject)
 


### PR DESCRIPTION
To avoid a subject ending up like:

```
"Re: RE: RE: RE: original subject"
```

That I've seen a few times.

The fix is to lower case the subject and the strings to compare against
before calling startwith()
