### PR TITLE
typo in docs

### DIFF
--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -182,7 +182,7 @@
 
 .. describe:: editor_spawn
 
-     use terminal_command to spawn a new terminal for the editor?
+     use terminal_cmd to spawn a new terminal for the editor?
      equivalent to always providing the `--spawn=yes` parameter to compose/edit commands
 
     :type: boolean


### PR DESCRIPTION
that variable is called _terminal_cmd_, not _terminal_command_
