### PR TITLE
envelope: add a .eml suffix to the temp mail

### DIFF
--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -375,7 +375,8 @@ class EditCommand(Command):
         if self.envelope.tmpfile:
             old_tmpfile = self.envelope.tmpfile
         self.envelope.tmpfile = tempfile.NamedTemporaryFile(delete=False,
-                                                            prefix='alot.')
+                                                            prefix='alot.',
+                                                            suffix='.eml')
         self.envelope.tmpfile.write(content.encode('utf-8'))
         self.envelope.tmpfile.flush()
         self.envelope.tmpfile.close()


### PR DESCRIPTION
Add a .eml extension to let $EDITOR known the file as a mail.
