### PR TITLE
Encrypt on reply to encrypted email

### DIFF
--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -196,6 +196,12 @@ class EnvelopeBuffer(Buffer):
         displayed_widgets.append(self.body_wgt)
         self.body = urwid.ListBox(displayed_widgets)
 
+    def render(self, size, focus=False):
+        if self.envelope.encrypt and not self.envelope.encrypt_keys:
+            fcmd = commands.envelope.EncryptCommand(action='encrypt')
+            self.ui.apply_command(fcmd)
+        return self.body.render(size, focus)
+
     def toggle_all_headers(self):
         """toggles visibility of all envelope headers"""
         self.all_headers = not self.all_headers

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -511,7 +511,7 @@ class SignCommand(Command):
                       'help': 'keyid of the key to encrypt with'})],
                  help='do not encrypt to given recipient key')
 class EncryptCommand(Command):
-    def __init__(self, action=None, keyids=None, **kwargs):
+    def __init__(self, action=None, keyids=[], **kwargs):
         """
         :param action: wether to encrypt/unencrypt/toggleencrypt
         :type action: str

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -233,6 +233,8 @@ class ReplyCommand(Command):
         else:
             envelope.add('References', '<%s>' % self.message.get_message_id())
 
+        envelope.encrypt = mail.get_content_subtype() == 'encrypted'
+
         # continue to compose
         ui.apply_command(ComposeCommand(envelope=envelope,
                                         spawn=self.force_spawn))


### PR DESCRIPTION
For issue #661.

It fix the issues of the first pull-request (#669). Now the check for keys is done at soon as it enters on the envelop buffer.

I don't know much of urwid, I hope I'm not doing any mistake.