### PR TITLE
On reply dont use [Delivered-To] address as From address

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -59,7 +59,7 @@ def determine_sender(mail, action='reply'):
     # extract list of addresses to check for my address
     candidate_addresses = getaddresses(mail.get_all('To', []) +
                                        mail.get_all('Cc', []) +
-                                       mail.get_all('Delivered-To', []) +
+#                                       mail.get_all('Delivered-To', []) +
                                        mail.get_all('From', []))
 
     logging.debug('candidate addresses: %s' % candidate_addresses)


### PR DESCRIPTION
Hi,

I find that the following behavior is not desirable.
if using two addresses (address-one is automatically delivered to address-two by its server), when i receive an email in address-one, it is delivered to address-two.
When replying to this message, the `determine_sender` function find both address-one and address-two to match, but if address-two is the main address it is chosen upon address-one (which is to be preferred i think).

In this pull request I comment out the `Delivered-To` address. Now the `address-one` is chosen by default.
