### PR TITLE
Added checks to hide disabled keys in 'Binding Help'

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -576,12 +576,7 @@ class HelpCommand(Command):
             title_att = settings.get_theming_attribute('help', 'title')
             section_att = settings.get_theming_attribute('help', 'section')
             # get mappings
-            if ui.mode in settings._bindings:
-                modemaps = dict(settings._bindings[ui.mode].items())
-            else:
-                modemaps = {}
-            is_scalar = lambda k_v: k_v[0] in settings._bindings.scalars
-            globalmaps = dict(filter(is_scalar, settings._bindings.items()))
+            globalmaps, modemaps = settings.get_keybindings(ui.mode)
 
             # build table
             maxkeylength = len(max((modemaps).keys() + globalmaps.keys(),


### PR DESCRIPTION
This PR check if a binding is actually not an empty string to show up in the Binding Help.
This is from issue: https://github.com/pazz/alot/issues/690
