### PR TITLE
On exit command, check if there are any unsent messages

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -42,6 +42,16 @@ class ExitCommand(Command):
     @inlineCallbacks
     def apply(self, ui):
         msg = 'index not fully synced. ' if ui.db_was_locked else ''
+
+        # check if there are any unsent messages
+        for buffer in ui.buffers:
+            if (isinstance(buffer, buffers.EnvelopeBuffer) and
+                    not buffer.envelope.sent_time):
+                if (yield ui.choice('quit without sending message?',
+                                    select='yes', cancel='no',
+                                    msg_position='left') == 'no'):
+                    raise CommandCanceled()
+
         if settings.get('bug_on_exit') or ui.db_was_locked:
             msg += 'really quit?'
             if (yield ui.choice(msg, select='yes', cancel='no',


### PR DESCRIPTION
This commit doesn't actually work, though it looks like it should.  I've stepped through the debugger, and it does get to the line with:

```
if (yield ui.choice('quit without sending message?',
                    select='yes', cancel='no',
                    msg_position='left') == 'no'):
```

but the message never actually appears.  When I get to this line it goes off somewhere into some defer code and eventually the application quits without ever showing the 'quit without sending message?' prompt.

Any pointers as to how to get this to work appreciated - I've lost a few messages due to quitting when I have an unsent message.
