### PR TITLE
Fix regex for unquoting in decode_header

### DIFF
--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -357,7 +357,10 @@ def decode_header(header, normalize=False):
 
     # some mailers send out incorrectly escaped headers
     # and double quote the escaped realname part again. remove those
-    value = re.sub(r'\"(.*?=\?.*?.*?)\"', r'\1', value)
+    # RFC: 2047
+    regex = r'"(=\?.+?\?.+?\?[^ ?]+\?=)"'
+    value = re.sub(regex, r'\1', value)
+    logging.debug("unquoted header: |%s|", value)
 
     # otherwise we interpret RFC2822 encoding escape sequences
     valuelist = email.header.decode_header(value)


### PR DESCRIPTION
I've created test cases to verify that the new regex fixes the issue and is not introducing new issues. Hopefully I understand the RFC 2047 correctly.

If you are not happy with the test suite, I can improve it somehow.