### PR TITLE
Exchange & Outlook display blank emails

### DIFF
--- a/alot/helper.py
+++ b/alot/helper.py
@@ -610,9 +610,9 @@ def RFC3156_canonicalize(text):
     :param text: text to canonicalize (already encoded as quoted-printable)
     :rtype: str
     """
-    text = re.sub("\r?\n", "\r\n", text)
-    if not text.endswith("\r\n"):
-        text += "\r\n"
+    #text = re.sub("\r?\n", "\r\n", text)
+    #if not text.endswith("\r\n"):
+    #    text += "\r\n"
     text = re.sub("^From ", "From=20", text, flags=re.MULTILINE)
     return text
 


### PR DESCRIPTION
For whatever reason, it looks like Exchange Webmail and Outlook don't like plain-text emails with \r\n newlines- they will display them as 'blank' messages.

I don't really expect you to merge this- it subverts 90% of the `RFC3156_canonicalize` function- but I'd like you to be aware of the issue, and make it easy for other people to find the problem.

I don't really know if there's a good solution without pulling SMTP functionality inside of alot, unfortunately.