### PR TITLE
Option to show all tags of a message, even if they are commom to thread

### DIFF
--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -212,6 +212,10 @@ mailinglists = force_list(default=list())
 # prefer plaintext alternatives over html content in multipart/alternative
 prefer_plaintext = boolean(default=False)
 
+# In a thread buffer, hide from messages summaries tags that are commom to all
+# messages in that thread.
+msg_summary_hides_threadwide_tags = boolean(default=True)
+
 # Key bindings 
 [bindings]
     __many__ = string(default=None)

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -42,9 +42,14 @@ class MessageSummaryWidget(urwid.WidgetWrap):
         txt = urwid.Text(sumstr)
         cols.append(txt)
 
-        thread_tags = message.get_thread().get_tags(intersection=True)
-        outstanding_tags = set(message.get_tags()).difference(thread_tags)
-        tag_widgets = [TagWidget(t, attr, focus_att) for t in outstanding_tags]
+        if settings.get('msg_summary_hides_threadwide_tags'):
+            thread_tags = message.get_thread().get_tags(intersection=True)
+            outstanding_tags = set(message.get_tags()).difference(thread_tags)
+            tag_widgets = [TagWidget(t, attr, focus_att)
+                           for t in outstanding_tags]
+        else:
+            tag_widgets = [TagWidget(t, attr, focus_att)
+                           for t in message.get_tags()]
         tag_widgets.sort(tag_cmp, lambda tag_widget: tag_widget.translated)
         for tag_widget in tag_widgets:
             if not tag_widget.hidden:


### PR DESCRIPTION
Setting ´msg_summary_hides_threadwide_tags´ to False in the configs allows to show all tags of a message in the end of the message´s summary, in Thread Buffer.