### PR TITLE
config to allow specific command for when editing a mail the first time

### DIFF
--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -285,7 +285,7 @@ class SendCommand(Command):
                      'help': 'refocus envelope after editing'})])
 class EditCommand(Command):
     """edit mail"""
-    def __init__(self, envelope=None, spawn=None, refocus=True, **kwargs):
+    def __init__(self, envelope=None, spawn=None, refocus=True, new_file=False, **kwargs):
         """
         :param envelope: email to edit
         :type envelope: :class:`~alot.db.envelope.Envelope`
@@ -298,6 +298,7 @@ class EditCommand(Command):
         self.force_spawn = spawn
         self.refocus = refocus
         self.edit_only_body = False
+        self.new_file = new_file
         Command.__init__(self, **kwargs)
 
     def apply(self, ui):
@@ -387,7 +388,8 @@ class EditCommand(Command):
                                   on_success=openEnvelopeFromTmpfile,
                                   spawn=self.force_spawn,
                                   thread=self.force_spawn,
-                                  refocus=self.refocus)
+                                  refocus=self.refocus,
+                                  new_file=self.new_file)
         ui.apply_command(cmd)
 
 

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -275,7 +275,7 @@ class ExternalCommand(Command):
 class EditCommand(ExternalCommand):
 
     """edit a file"""
-    def __init__(self, path, spawn=None, thread=None, **kwargs):
+    def __init__(self, path, spawn=None, thread=None, new_file=False, **kwargs):
         """
         :param path: path to the file to be edited
         :type path: str
@@ -292,10 +292,14 @@ class EditCommand(ExternalCommand):
             self.thread = settings.get('editor_in_thread')
 
         editor_cmdstring = None
-        if os.path.isfile('/usr/bin/editor'):
-            editor_cmdstring = '/usr/bin/editor'
-        editor_cmdstring = os.environ.get('EDITOR', editor_cmdstring)
-        editor_cmdstring = settings.get('editor_cmd') or editor_cmdstring
+
+        # Allows to set a specific command when editing a new file
+        editor_cmdstring = settings.get('new_file_editor_cmd') or editor_cmdstring
+        if not editor_cmdstring or not new_file:
+            if os.path.isfile('/usr/bin/editor'):
+                editor_cmdstring = '/usr/bin/editor'
+            editor_cmdstring = os.environ.get('EDITOR', editor_cmdstring)
+            editor_cmdstring = settings.get('editor_cmd') or editor_cmdstring
         logging.debug('using editor_cmd: %s' % editor_cmdstring)
 
         self.cmdlist = None
@@ -845,7 +849,8 @@ class ComposeCommand(Command):
 
         cmd = commands.envelope.EditCommand(envelope=self.envelope,
                                             spawn=self.force_spawn,
-                                            refocus=False)
+                                            refocus=False,
+                                            new_file=True)
         ui.apply_command(cmd)
 
 

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -56,6 +56,9 @@ terminal_cmd = string(default='x-terminal-emulator -e')
 # if unset, alot will first try the :envvar:`EDITOR` env variable, then :file:`/usr/bin/editor`
 editor_cmd = string(default=None)
 
+# command to be used when editing an email for the first time; if unset, uses the above.
+new_file_editor_cmd = string(default=None)
+
 # file encoding used by your editor
 editor_writes_encoding = string(default='UTF-8')
 


### PR DESCRIPTION
New config ´new_file_editor_cmd´ that allows to set the command to be used when editing a mail for the first time (reply, forward, ...). The ´editor_cmd´ will be used only in the Envelope Buffer, after you openned and closed the mail a first time.
If ´new_file_editor_cmd´ is unset (default) uses the old behavior.

Why all this?

For exemple:

```
new_file_editor_cmd = vim -c 'exe "norm }O\n\n\<esc>O"' -c 'startinsert'
editor_cmd = vim -c 'exe "norm }"'
```

Will open some space between the headers and the quoting part, and enter insertion mode in Vim. That's something I always have to do when editing a new mail. But I don't want it to happen twice in the same mail (for example, when I'm in Enevelop Buffer, forgot something in my mail, and I'm going to edit it for the second time).
