### PR TITLE
Config to display in thread buffer status bar all tags present in a thread, or tags common to all messages in thread

### DIFF
--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -339,12 +339,20 @@ class ThreadBuffer(Buffer):
                                                self.message_count,
                                                's' * (self.message_count > 1))
 
+    def translated_tags_str(self, intersection=False):
+        tags = self.thread.get_tags(intersection=intersection)
+        trans = [settings.get_tagstring_representation(tag)['translated']
+                 for tag in tags] 
+        return ' '.join(trans)
+
     def get_info(self):
         info = {}
         info['subject'] = self.thread.get_subject()
         info['authors'] = self.thread.get_authors_string()
         info['tid'] = self.thread.get_thread_id()
         info['message_count'] = self.message_count
+        info['thread_tags'] = self.translated_tags_str()
+        info['intersection_tags'] = self.translated_tags_str(intersection=True)
         return info
 
     def get_selected_thread(self):

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -115,6 +115,9 @@ search_statusbar = mixed_list(string, string, default=list('[{buffer_no}: search
 # * `{subject}`: subject line of the thread
 # * `{authors}`: abbreviated authors string for this thread
 # * `{message_count}`: number of contained messages
+# * `{thread_tags}`: displays all tags present in the current thread.
+# * `{intersection_tags}`: displays tags common to all messages in the current thread.
+
 thread_statusbar = mixed_list(string, string, default=list('[{buffer_no}: thread] {subject}','{input_queue} total messages: {total_messages}'))
 
 # Format of the status-bar in taglist mode.

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -42,9 +42,12 @@ class MessageSummaryWidget(urwid.WidgetWrap):
         txt = urwid.Text(sumstr)
         cols.append(txt)
 
-        thread_tags = message.get_thread().get_tags(intersection=True)
-        outstanding_tags = set(message.get_tags()).difference(thread_tags)
-        tag_widgets = [TagWidget(t, attr, focus_att) for t in outstanding_tags]
+        if settings.get('msg_summary_hides_threadwide_tags'):
+            thread_tags = message.get_thread().get_tags(intersection=True)
+            displayed_tags = set(message.get_tags()).difference(thread_tags)
+        else:
+            displayed_tags = message.get_tags()
+        tag_widgets = [TagWidget(t, attr, focus_att) for t in displayed_tags]
         tag_widgets.sort(tag_cmp, lambda tag_widget: tag_widget.translated)
         for tag_widget in tag_widgets:
             if not tag_widget.hidden:


### PR DESCRIPTION
Allows to add **{thread_tags}** or/and **{intersection_tags}** to the Thread Buffer statusbar.
- **thread_tags**: shows all tags present in the current thread.
- **intersection_tags**: shows tags common to all messages in the current thread.

**(New P.R. with squashed commits)**
