### PR TITLE
Allow specifing the mailcap field key for `pipeto`

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -556,6 +556,8 @@ class ChangeDisplaymodeCommand(Command):
                    'help': 'let the shell interpret the command'}),
     (['--notify_stdout'], {'action': 'store_true',
                            'help': 'display cmd\'s stdout as notification'}),
+    (['--field_key'], {'help': 'mailcap field key for decoding',
+                       'default': 'copiousoutput'}),
 ],
 )
 class PipeCommand(Command):
@@ -566,7 +568,8 @@ class PipeCommand(Command):
     def __init__(self, cmd, all=False, separately=False, background=False,
                  shell=False, notify_stdout=False, format='raw',
                  add_tags=False, noop_msg='no command specified',
-                 confirm_msg='', done_msg=None, **kwargs):
+                 confirm_msg='', done_msg=None, field_key='copiousoutput',
+                 **kwargs):
         """
         :param cmd: shellcommand to open
         :type cmd: str or list of str
@@ -595,6 +598,8 @@ class PipeCommand(Command):
         :type confirm_msg: str
         :param done_msg: notification message to show upon success
         :type done_msg: str
+        :param field_key: malcap field key for decoding
+        :type field_key: str
         """
         Command.__init__(self, **kwargs)
         if isinstance(cmd, unicode):
@@ -610,6 +615,7 @@ class PipeCommand(Command):
         self.noop_msg = noop_msg
         self.confirm_msg = confirm_msg
         self.done_msg = done_msg
+        self.field_key = field_key
 
     @inlineCallbacks
     def apply(self, ui):
@@ -655,7 +661,7 @@ class PipeCommand(Command):
                     pipestrings.append(mail.as_string())
                 elif self.output_format == 'decoded':
                     headertext = extract_headers(mail)
-                    bodytext = extract_body(mail)
+                    bodytext = extract_body(mail, field_key=self.field_key)
                     msgtext = '%s\n\n%s' % (headertext, bodytext)
                     pipestrings.append(msgtext.encode('utf-8'))
 

--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -243,7 +243,7 @@ def extract_headers(mail, headers=None):
     return headertext
 
 
-def extract_body(mail, types=None):
+def extract_body(mail, types=None, field_key='copiousoutput'):
     """
     returns a body text string for given mail.
     If types is `None`, `text/*` is used:
@@ -287,8 +287,7 @@ def extract_body(mail, types=None):
             body_parts.append(string_sanitize(raw_payload))
         else:
             # get mime handler
-            key = 'copiousoutput'
-            handler, entry = settings.mailcap_find_match(ctype, key=key)
+            handler, entry = settings.mailcap_find_match(ctype, key=field_key)
             tempfile_name = None
             stdin = None
 


### PR DESCRIPTION
When decoding the message, use the mailcap field specified for command
lookup.
