### PR TITLE
Port to Py3k

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ docs/build
 docs/source/configuration/*table.rst
 /alot/VERSION
 tags
+.idea
+alot.egg-info

--- a/alot/account.py
+++ b/alot/account.py
@@ -1,10 +1,11 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-import mailbox
-import logging
-import os
+
 import glob
+import logging
+import mailbox
+import os
 
 from alot.helper import call_cmd_async
 from alot.helper import split_commandstring

--- a/alot/addressbooks.py
+++ b/alot/addressbooks.py
@@ -1,12 +1,12 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-import re
-import os
 
+import os
+import re
+
+from alot.helper import call_cmd, split_commandstring
 from alot.settings.utils import read_config
-from helper import call_cmd
-from alot.helper import split_commandstring
 
 
 class AddressbookError(Exception):

--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -1,24 +1,23 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-import urwid
-import os
-from notmuch import NotmuchError
+
 import logging
+import os
 
-from settings import settings
-import commands
-from walker import PipeWalker
-from helper import shorten_author_string
-from db.errors import NonexistantObjectError
+from notmuch import NotmuchError
+import urwid
 
-from alot.widgets.globals import TagWidget
-from alot.widgets.globals import HeadersList
-from alot.widgets.globals import AttachmentWidget
+from alot import commands
+from alot.foreign.urwidtrees import ArrowTree, TreeBox, NestedTree
+from alot.db.errors import NonexistantObjectError
+from alot.helper import shorten_author_string
+from alot.settings import settings
+from alot.walker import PipeWalker
+from alot.widgets.globals import (AttachmentWidget, HeadersList, TagWidget)
 from alot.widgets.bufferlist import BufferlineWidget
 from alot.widgets.search import ThreadlineWidget
 from alot.widgets.thread import ThreadTree
-from alot.foreign.urwidtrees import ArrowTree, TreeBox, NestedTree
 
 
 class Buffer(object):
@@ -85,7 +84,7 @@ class BufferlistBuffer(Buffer):
             self.isinitialized = True
 
         lines = list()
-        displayedbuffers = filter(self.filtfun, self.ui.buffers)
+        displayedbuffers = [self.filtfun(x) for x in self.ui.buffers]
         for (num, b) in enumerate(displayedbuffers):
             line = BufferlineWidget(b)
             if (num % 2) == 0:
@@ -634,8 +633,8 @@ class TagListBuffer(Buffer):
             self.isinitialized = True
 
         lines = list()
-        displayedtags = sorted(filter(self.filtfun, self.tags),
-                               key=unicode.lower)
+
+        displayedtags = sorted(filter(self.filtfun, self.tags), key=str.lower)
         for (num, b) in enumerate(displayedtags):
             if (num % 2) == 0:
                 attr = settings.get_theming_attribute('taglist', 'line_even')

--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -634,7 +634,8 @@ class TagListBuffer(Buffer):
 
         lines = list()
 
-        displayedtags = sorted(filter(self.filtfun, self.tags), key=str.lower)
+        displayedtags = sorted(filter(self.filtfun, self.tags),
+                               key=lambda s: s.lower())
         for (num, b) in enumerate(displayedtags):
             if (num % 2) == 0:
                 attr = settings.get_theming_attribute('taglist', 'line_even')

--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -84,7 +84,8 @@ class BufferlistBuffer(Buffer):
             self.isinitialized = True
 
         lines = list()
-        displayedbuffers = [self.filtfun(x) for x in self.ui.buffers]
+        displayedbuffers = [x for x in self.ui.buffers
+                            if not self.filtfun or self.filtfun(x)]
         for (num, b) in enumerate(displayedbuffers):
             line = BufferlineWidget(b)
             if (num % 2) == 0:

--- a/alot/commands/__init__.py
+++ b/alot/commands/__init__.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-import os
-import re
+
+import argparse
 import glob
 import logging
-import argparse
+import os
+import re
 
+from alot.helper import split_commandstring, string_decode
 from alot.settings import settings
-import alot.helper
-from alot.helper import split_commandstring
 
 
 class Command(object):
@@ -177,7 +177,7 @@ def commandfactory(cmdline, mode='global'):
         args = split_commandstring(cmdline)
     except ValueError as e:
         raise CommandParseError(e.message)
-    args = map(lambda x: alot.helper.string_decode(x, 'utf-8'), args)
+    args = [string_decode(x, 'utf-8') for x in args]
     logging.debug('ARGS: %s' % args)
     cmdname = args[0]
     args = args[1:]

--- a/alot/commands/bufferlist.py
+++ b/alot/commands/bufferlist.py
@@ -1,8 +1,9 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from alot.commands import Command, registerCommand
-from . import globals
+
+from . import Command, globals, registerCommand
+
 
 MODE = 'bufferlist'
 

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -1,37 +1,35 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-import os
-import code
-from twisted.internet import threads
-from twisted.internet import defer
-import subprocess
-import email
-import urwid
-from twisted.internet.defer import inlineCallbacks
-import logging
-import argparse
-import glob
-from StringIO import StringIO
 
-from alot.commands import Command, registerCommand
-from alot.completion import CommandLineCompleter
-from alot.commands import CommandParseError
-from alot.commands import commandfactory
-from alot.commands import CommandCanceled
-from alot import buffers
-from alot.widgets.utils import DialogBox
-from alot import helper
-from alot.db.errors import DatabaseLockedError
-from alot.completion import ContactsCompleter
-from alot.completion import AccountCompleter
-from alot.completion import TagsCompleter
+import argparse
+import code
+import email
+import glob
+import logging
+import os
+import subprocess
+import sys
+
+try:
+    from io import StringIO
+except ImportError:
+    from cStringIO import StringIO
+
+from twisted.internet import threads
+from twisted.internet.defer import inlineCallbacks
+import urwid
+
+from . import Command, CommandCanceled, registerCommand
+from alot import buffers, commands, helper
+from alot.completion import (AccountCompleter, CommandLineCompleter,
+                             ContactsCompleter, TagsCompleter)
+from alot.helper import mailto_to_envelope, split_commandstring
 from alot.db.envelope import Envelope
-from alot import commands
+from alot.db.errors import DatabaseLockedError
 from alot.settings import settings
-from alot.helper import split_commandstring, split_commandline
-from alot.helper import mailto_to_envelope
 from alot.utils.booleanaction import BooleanAction
+from alot.widgets.utils import DialogBox
 
 MODE = 'global'
 
@@ -176,7 +174,8 @@ class ExternalCommand(Command):
         """
         logging.debug({'spawn': spawn})
         # make sure cmd is a list of str
-        if isinstance(cmd, unicode):
+        if sys.version_info < (3,0,0) and isinstance(cmd, unicode) \
+            or sys.version_info > (3,0,0) and isinstance(cmd, str):
             # convert cmdstring to list: in case shell==True,
             # Popen passes only the first item in the list to $SHELL
             cmd = [cmd] if shell else split_commandstring(cmd)
@@ -215,7 +214,8 @@ class ExternalCommand(Command):
         stdin = None
         if self.stdin is not None:
             # wrap strings in StrinIO so that they behaves like a file
-            if isinstance(self.stdin, unicode):
+            if sys.version_info < (3,0,0) and isinstance(self.stdin, unicode) \
+                    or sys.version_info > (3,0,0) and isinstance(cmd, str):
                 stdin = StringIO(self.stdin)
             else:
                 stdin = self.stdin
@@ -502,6 +502,8 @@ class TagListCommand(Command):
     def apply(self, ui):
         tags = self.tags or ui.dbman.get_all_tags()
         blists = ui.get_buffers_of_type(buffers.TagListBuffer)
+        if not isinstance(blists, list):
+            blists = list(blists)
         if blists:
             buf = blists[0]
             buf.tags = tags
@@ -580,8 +582,8 @@ class HelpCommand(Command):
             globalmaps, modemaps = settings.get_keybindings(ui.mode)
 
             # build table
-            maxkeylength = len(max((modemaps).keys() + globalmaps.keys(),
-                                   key=len))
+            connected_keys = list(modemaps.keys()) + list(globalmaps.keys())
+            maxkeylength = len(max(connected_keys, key=len))
             keycolumnwidth = maxkeylength + 2
 
             linewidgets = []
@@ -642,8 +644,7 @@ class HelpCommand(Command):
     (['rest'], {'nargs': '*'}),
 ])
 class ComposeCommand(Command):
-
-    """compose a new email"""
+    """Compose a new email"""
     def __init__(self, envelope=None, headers={}, template=None,
                  sender=u'', subject=u'', to=[], cc=[], bcc=[], attach=None,
                  omit_signature=False, spawn=None, rest=[], **kwargs):

--- a/alot/commands/search.py
+++ b/alot/commands/search.py
@@ -4,9 +4,9 @@
 import argparse
 import logging
 
-from alot.commands import Command, registerCommand
-from alot.commands.globals import PromptCommand
-from alot.commands.globals import MoveCommand
+from . import Command, registerCommand
+from .globals import PromptCommand
+from .globals import MoveCommand
 
 from alot.db.errors import DatabaseROError
 from alot import commands
@@ -212,7 +212,7 @@ class TagCommand(Command):
             searchbuffer.result_count += (hitcount_after - hitcount_before)
             ui.update()
 
-        tags = filter(lambda x: x, self.tagsstring.split(','))
+        tags = [x for x in self.tagsstring.split(',') if x]
 
         try:
             if self.action == 'add':

--- a/alot/commands/taglist.py
+++ b/alot/commands/taglist.py
@@ -1,8 +1,9 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from alot.commands import Command, registerCommand
-from alot.commands.globals import SearchCommand
+
+from . import Command, registerCommand
+from .globals import SearchCommand
 
 MODE = 'taglist'
 

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -1,41 +1,42 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
+
+import argparse
+import sys
+
+try:
+    from email.utils import getaddresses, parseaddr
+    from io import StringIO
+except ImportError:
+    from email.Utils import getaddresses, parseaddr
+    from cStringIO import StringIO
+import logging
+import mailcap
 import os
 import re
-import logging
-import tempfile
-import argparse
-from twisted.internet.defer import inlineCallbacks
 import subprocess
-from email.Utils import getaddresses, parseaddr
-from email.message import Message
-import mailcap
-from cStringIO import StringIO
+import tempfile
 
-from alot.commands import Command, registerCommand
-from alot.commands.globals import ExternalCommand
-from alot.commands.globals import FlushCommand
-from alot.commands.globals import ComposeCommand
-from alot.commands.globals import MoveCommand
-from alot.commands.globals import CommandCanceled
-from alot.commands.envelope import SendCommand
+from twisted.internet.defer import inlineCallbacks
+
+from . import Command, registerCommand
+from .globals import (CommandCanceled, ComposeCommand, ExternalCommand,
+                      FlushCommand, MoveCommand)
+from .envelope import SendCommand
 from alot import completion
-from alot.db.utils import decode_header
-from alot.db.utils import encode_header
-from alot.db.utils import extract_headers
-from alot.db.utils import extract_body
+from alot.completion import ContactsCompleter
+from alot.db.utils import (decode_header, encode_header, extract_body,
+                           extract_headers)
 from alot.db.envelope import Envelope
 from alot.db.attachment import Attachment
 from alot.db.errors import DatabaseROError
 from alot.settings import settings
-from alot.helper import parse_mailcap_nametemplate
-from alot.helper import split_commandstring
-from alot.helper import email_as_string
+from alot.helper import (email_as_string, parse_mailcap_nametemplate,
+                         split_commandstring)
 from alot.utils.booleanaction import BooleanAction
-from alot.completion import ContactsCompleter
-
 from alot.widgets.globals import AttachmentWidget
+
 
 MODE = 'thread'
 
@@ -597,7 +598,8 @@ class PipeCommand(Command):
         :type done_msg: str
         """
         Command.__init__(self, **kwargs)
-        if isinstance(cmd, unicode):
+        if sys.version_info < (3,0,0) and isinstance(cmd, unicode) \
+            or sys.version_info > (3,0,0) and isinstance(cmd, str):
             cmd = split_commandstring(cmd)
         self.cmd = cmd
         self.whole_thread = all
@@ -1048,7 +1050,8 @@ class TagCommand(Command):
 
             tbuffer.refresh()
 
-        tags = filter(lambda x: x, self.tagsstring.split(','))
+        tags = [x for x in self.tagsstring.split(',') if x]
+
         try:
             for mt in messagetrees:
                 m = mt.get_message()

--- a/alot/crypto.py
+++ b/alot/crypto.py
@@ -1,11 +1,16 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-import os
 
-from cStringIO import StringIO
-from alot.errors import GPGProblem, GPGCode
+import os
+try:
+    from io import StringIO
+except ImportError:
+    from cStringIO import StringIO
+
 import gpgme
+
+from alot.errors import GPGProblem, GPGCode
 
 
 def _hash_algo_name(hash_algo):

--- a/alot/db/__init__.py
+++ b/alot/db/__init__.py
@@ -2,6 +2,7 @@
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 
-from thread import Thread
-from message import Message
+from .message import Message
+from .thread import Thread
+
 DB_ENC = 'UTF-8'

--- a/alot/db/attachment.py
+++ b/alot/db/attachment.py
@@ -1,21 +1,20 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
+
+from copy import deepcopy
+from email import charset
+charset.add_charset('utf-8', charset.QP, charset.QP, 'utf-8')
+from email.header import Header
 import os
 import tempfile
-import email.charset as charset
-from email.header import Header
-from copy import deepcopy
-charset.add_charset('utf-8', charset.QP, charset.QP, 'utf-8')
-import alot.helper as helper
-from alot.helper import string_decode
 
-from alot.db.utils import decode_header
+from .utils import decode_header
+from alot import helper
 
 
 class Attachment(object):
-
-    """represents a mail attachment"""
+    """Represents a mail attachment"""
 
     def __init__(self, emailpart):
         """
@@ -28,7 +27,7 @@ class Attachment(object):
         desc = '%s:%s (%s)' % (self.get_content_type(),
                                self.get_filename(),
                                helper.humanize_size(self.get_size()))
-        return string_decode(desc)
+        return helper.string_decode(desc)
 
     def get_filename(self):
         """

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -1,18 +1,23 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-import email
+
 from datetime import datetime
-import email.charset as charset
+from email import charset, message_from_string
+try:
+    from email.utils import parseaddr
+except ImportError:
+    from email.Utils import parseaddr
 charset.add_charset('utf-8', charset.QP, charset.QP, 'utf-8')
+
 from notmuch import NullPointerError
 
-import alot.helper as helper
+from .attachment import Attachment
+from .utils import (decode_header, extract_headers, extract_body,
+                    message_from_file)
+from alot import helper
 from alot.settings import settings
 
-from .utils import extract_headers, extract_body, message_from_file
-from alot.db.utils import decode_header
-from .attachment import Attachment
 
 
 class Message(object):
@@ -73,7 +78,7 @@ class Message(object):
                 self._email = message_from_file(f_mail)
                 f_mail.close()
             except IOError:
-                self._email = email.message_from_string(warning)
+                self._email = message_from_string(warning)
         return self._email
 
     def get_date(self):
@@ -142,7 +147,7 @@ class Message(object):
 
         :rtype: (str,str)
         """
-        return email.Utils.parseaddr(self._from)
+        return parseaddr(self._from)
 
     def get_headers_string(self, headers):
         """

--- a/alot/db/thread.py
+++ b/alot/db/thread.py
@@ -3,7 +3,7 @@
 # For further details see the COPYING file
 from datetime import datetime
 
-from message import Message
+from .message import Message
 from alot.settings import settings
 
 
@@ -141,10 +141,12 @@ class Thread(object):
             self._authors = []
             seen = {}
             msgs = self.get_messages().keys()
-            msgs_with_date = filter(lambda m: m.get_date() is not None, msgs)
-            msgs_without_date = filter(lambda m: m.get_date() is None, msgs)
+
+            msgs_with_date = [m for m in msgs if m.get_date() is not None]
+            msgs_without_date = [m for m in msgs if m.get_date() is None]
             # sort messages with date and append the others
-            msgs_with_date.sort(None, lambda m: m.get_date())
+            msgs_with_date.sort(key=lambda m: m.get_date())
+            # msgs_with_date.sort(None, lambda m: m.get_date())
             msgs = msgs_with_date + msgs_without_date
             for m in msgs:
                 pair = m.get_author()
@@ -208,7 +210,7 @@ class Thread(object):
         """
         if not self._messages:  # if not already cached
             query = self._dbman.query('thread:' + self._id)
-            thread = query.search_threads().next()
+            thread = next(query.search_threads())
 
             def accumulate(acc, msg):
                 M = Message(self._dbman, msg, thread=self)

--- a/alot/foreign/__init__.py
+++ b/alot/foreign/__init__.py
@@ -1,5 +1,4 @@
 try:
-    import functools.lru_cache as lru_cache
-except:
-    from lru_cache import lru_cache as lru_cache
-
+    from functoons import lru_cache
+except ImportError:
+    from .lru_cache import lru_cache

--- a/alot/foreign/urwidtrees/__init__.py
+++ b/alot/foreign/urwidtrees/__init__.py
@@ -1,13 +1,13 @@
 try:
     # lru_cache is part of the stdlib from v3.2 onwards
-    import functools.lru_cache as lru_cache
-except:
+    from functools import lru_cache
+except ImportError:
     # on older versions we use a backport
-    import lru_cache as lru_cache
+    from .lru_cache import lru_cache
 
-from tree import Tree, SimpleTree
-from decoration import DecoratedTree, CollapsibleTree
-from decoration import IndentedTree, CollapsibleIndentedTree
-from decoration import ArrowTree, CollapsibleArrowTree
-from nested import NestedTree
-from widgets import TreeBox
+from .tree import Tree, SimpleTree
+from .decoration import (ArrowTree, CollapsibleArrowTree, DecoratedTree,
+                         CollapsibleTree, IndentedTree,
+                         CollapsibleIndentedTree)
+from .nested import NestedTree
+from .widgets import TreeBox

--- a/alot/foreign/urwidtrees/decoration.py
+++ b/alot/foreign/urwidtrees/decoration.py
@@ -1,8 +1,12 @@
 # Copyright (C) 2013  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
-from tree import Tree, SimpleTree
-import urwid
+
 import logging
+
+import urwid
+
+from .tree import Tree, SimpleTree
+
 
 NO_SPACE_MSG = 'too little space for requested decoration'
 
@@ -220,7 +224,7 @@ class IndentedTree(DecoratedTree):
         indent = self._tree.depth(pos) * self._indent
         cols = [(indent, urwid.SolidFill(' ')), widget]
         # construct a Columns, defining all spacer as Box widgets
-        line = urwid.Columns(cols, box_columns=range(len(cols))[:-1])
+        line = urwid.Columns(cols, box_columns=range(len(cols)-1))
         return line
 
 
@@ -287,7 +291,7 @@ class CollapsibleIndentedTree(CollapseIconMixin, IndentedTree):
 
         cols.append(widget)  # original widget ]
         # construct a Columns, defining all spacer as Box widgets
-        line = urwid.Columns(cols, box_columns=range(len(cols))[:-1])
+        line = urwid.Columns(cols, box_columns=range(len(cols)-1))
 
         return line
 
@@ -472,7 +476,7 @@ class ArrowTree(IndentedTree):
             # add the original widget for this line
             cols.append(original_widget)
             # construct a Columns, defining all spacer as Box widgets
-            line = urwid.Columns(cols, box_columns=range(len(cols))[:-1])
+            line = urwid.Columns(cols, box_columns=range(len(cols)-1))
         return line
 
 

--- a/alot/foreign/urwidtrees/example1.py
+++ b/alot/foreign/urwidtrees/example1.py
@@ -3,8 +3,9 @@
 # This file is released under the GNU GPL, version 3 or a later revision.
 
 import urwid
-from tree import SimpleTree
-from widgets import TreeBox
+
+from .tree import SimpleTree
+from .widgets import TreeBox
 
 
 # define some colours

--- a/alot/foreign/urwidtrees/example2.arrows.py
+++ b/alot/foreign/urwidtrees/example2.arrows.py
@@ -2,10 +2,11 @@
 # Copyright (C) 2013  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 
-from example1 import construct_example_tree, palette  # example data
-from decoration import ArrowTree  # for Decoration
-from widgets import TreeBox
 import urwid
+
+from .decoration import ArrowTree  # for Decoration
+from .example1 import construct_example_tree, palette  # example data
+from .widgets import TreeBox
 
 if __name__ == "__main__":
     # get example tree

--- a/alot/foreign/urwidtrees/example3.collapse.py
+++ b/alot/foreign/urwidtrees/example3.collapse.py
@@ -2,10 +2,11 @@
 # Copyright (C) 2013  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 
-from example1 import construct_example_tree, palette  # example data
-from decoration import CollapsibleIndentedTree  # for Decoration
-from widgets import TreeBox
 import urwid
+
+from .decoration import CollapsibleIndentedTree  # for Decoration
+from .example1 import construct_example_tree, palette  # example data
+from .widgets import TreeBox
 
 if __name__ == "__main__":
     # get some SimpleTree

--- a/alot/foreign/urwidtrees/example4.filesystem.py
+++ b/alot/foreign/urwidtrees/example4.filesystem.py
@@ -2,12 +2,14 @@
 # Copyright (C) 2013  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 
-import urwid
 import os
-from example1 import palette  # example data
-from widgets import TreeBox
-from tree import Tree
-from decoration import CollapsibleArrowTree
+
+import urwid
+
+from .decoration import CollapsibleArrowTree
+from .example1 import palette  # example data
+from .tree import Tree
+from .widgets import TreeBox
 
 
 # define selectable urwid.Text widgets to display paths

--- a/alot/foreign/urwidtrees/example5.nested.py
+++ b/alot/foreign/urwidtrees/example5.nested.py
@@ -2,14 +2,16 @@
 # Copyright (C) 2013  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 
-from example1 import palette, construct_example_tree  # example data
-from example1 import FocusableText  # Selectable Text used for nodes
-from widgets import TreeBox
-from tree import SimpleTree
-from nested import NestedTree
-from decoration import ArrowTree, CollapsibleArrowTree  # decoration
-import urwid
 import logging
+
+import urwid
+
+from .decoration import ArrowTree, CollapsibleArrowTree  # decoration
+from .example1 import palette, construct_example_tree  # example data
+from .example1 import FocusableText  # Selectable Text used for nodes
+from .widgets import TreeBox
+from .tree import SimpleTree
+from .nested import NestedTree
 
 
 if __name__ == "__main__":

--- a/alot/foreign/urwidtrees/lru_cache.py
+++ b/alot/foreign/urwidtrees/lru_cache.py
@@ -5,7 +5,9 @@ from collections import namedtuple
 from functools import update_wrapper
 from threading import Lock
 
+
 _CacheInfo = namedtuple("CacheInfo", ["hits", "misses", "maxsize", "currsize"])
+
 
 def lru_cache(maxsize=100, typed=False):
     """Least-recently-used cache decorator.

--- a/alot/foreign/urwidtrees/nested.py
+++ b/alot/foreign/urwidtrees/nested.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2013  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
-from tree import Tree
-from decoration import DecoratedTree, CollapseMixin
+
+from .decoration import DecoratedTree, CollapseMixin
+from .tree import Tree
 
 
 class NestedTree(Tree):

--- a/alot/foreign/urwidtrees/widgets.py
+++ b/alot/foreign/urwidtrees/widgets.py
@@ -1,13 +1,16 @@
 # Copyright (C) 2013  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 
-import urwid
 import logging
-from urwid import WidgetWrap, ListBox
-from urwid import signals
-from decoration import DecoratedTree, CollapseMixin
-from nested import NestedTree
-from lru_cache import lru_cache
+
+from urwid import ListBox, ListWalker, WidgetWrap, signals
+
+from .decoration import DecoratedTree, CollapseMixin
+from .nested import NestedTree
+try:
+    from functoons import lru_cache
+except ImportError:
+    from .lru_cache import lru_cache
 
 # The following are used to check dynamically if a tree offers sub-APIs
 
@@ -25,7 +28,7 @@ def implementsCollapseAPI(tree):
     return res
 
 
-class TreeListWalker(urwid.ListWalker):
+class TreeListWalker(ListWalker):
     """
     ListWalker to walk through a class:`Tree`.
 

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -412,6 +412,9 @@ def guess_mimetype(blob):
     else:
         raise Exception('Unknown magic API')
 
+    if sys.version > (3,0,0) and isinstance(magictype, bytes):
+        magictype = magictype.decode('utf-8')
+
     # libmagic does not always return proper mimetype strings, cf. issue #459
     if re.match(r'\w+\/\w+', magictype):
         mimetype = magictype

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -651,7 +651,7 @@ def encode_as_string(string, encoding='UTF-8'):
     :return: str
     """
     if sys.version_info < (3,0,0):
-        string.encode(encoding)
+        return string.encode(encoding)
     else:
         return string
 

--- a/alot/init.py
+++ b/alot/init.py
@@ -1,17 +1,17 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-import sys
+
 import logging
 import os
+import sys
 
 import alot
+from alot.commands import *
+from alot.db.manager import DBManager
 from alot.settings import settings
 from alot.settings.errors import ConfigError
-from alot.db.manager import DBManager
 from alot.ui import UI
-from alot.commands import *
-from alot.commands import CommandParseError
 
 from twisted.python import usage
 
@@ -34,7 +34,7 @@ class SubcommandOptions(usage.Options):
         return optstr
 
     def opt_version(self):
-        print alot.__version__
+        print(alot.__version__)
         sys.exit(0)
 
 
@@ -101,7 +101,7 @@ class Options(usage.Options):
                    ['compose', None, ComposeOptions, "compose a new message"]]
 
     def opt_version(self):
-        print alot.__version__
+        print(alot.__version__)
         sys.exit(0)
 
 
@@ -110,9 +110,9 @@ def main():
     args = Options()
     try:
         args.parseOptions()  # When given no argument, parses sys.argv[1:]
-    except usage.UsageError, errortext:
-        print '%s' % errortext
-        print 'Try --help for usage details.'
+    except usage.UsageError as e:
+        print('%s' % e.message)
+        print('Try --help for usage details.')
         sys.exit(1)
 
     # logging
@@ -155,7 +155,7 @@ def main():
     try:
         settings.read_config(alotconfig)
         settings.read_notmuch_config(notmuchconfig)
-    except (ConfigError, OSError, IOError), e:
+    except (ConfigError, OSError, IOError) as e:
         sys.exit(e)
 
     # store options given by config swiches to the settingsManager:
@@ -179,7 +179,7 @@ def main():
                 cmdstring += ' ' + args.subOptions.rest
         else:
             cmdstring = settings.get('initial_command')
-    except CommandParseError, e:
+    except CommandParseError as e:
         sys.exit(e)
 
     # set up and start interface

--- a/alot/settings/__init__.py
+++ b/alot/settings/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from alot.settings.manager import SettingsManager
+
+from .manager import SettingsManager
 
 settings = SettingsManager()

--- a/alot/settings/checks.py
+++ b/alot/settings/checks.py
@@ -1,10 +1,15 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
+
 import mailbox
 import re
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
+
 from urwid import AttrSpec, AttrSpecError
-from urlparse import urlparse
 from validate import VdtTypeError
 from validate import is_list
 from validate import ValidateError, VdtValueTooLongError, VdtValueError
@@ -43,7 +48,7 @@ def attr_triple(value):
         mono = AttrSpec(acc['1fg'], acc['1bg'], 1)
         normal = AttrSpec(acc['16fg'], acc['16bg'], 16)
         high = AttrSpec(acc['256fg'], acc['256bg'], 256)
-    except AttrSpecError, e:
+    except AttrSpecError as e:
         raise ValidateError(e.message)
     return mono, normal, high
 
@@ -142,5 +147,5 @@ def gpg_key(value):
     """
     try:
         return crypto.get_key(value)
-    except GPGProblem, e:
+    except GPGProblem as e:
         raise ValidateError(e.message)

--- a/alot/settings/theme.py
+++ b/alot/settings/theme.py
@@ -3,12 +3,9 @@
 # For further details see the COPYING file
 import os
 
-from utils import read_config
-from checks import align_mode
-from checks import attr_triple
-from checks import width_tuple
-from checks import force_list
-from errors import ConfigError
+from .utils import read_config
+from .checks import align_mode, attr_triple, force_list, width_tuple
+from .errors import ConfigError
 
 DEFAULTSPATH = os.path.join(os.path.dirname(__file__), '..', 'defaults')
 DUMMYDEFAULT = ('default',) * 6

--- a/alot/settings/utils.py
+++ b/alot/settings/utils.py
@@ -1,10 +1,12 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
+
 from configobj import ConfigObj, ConfigObjError, flatten_errors
-from validate import Validator
-from errors import ConfigError
 from urwid import AttrSpec
+from validate import Validator
+
+from .errors import ConfigError
 
 
 def read_config(configpath=None, specpath=None, checks={}):

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -1,19 +1,16 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-import urwid
+
 import logging
+import urwid
 from twisted.internet import reactor, defer
 
-from settings import settings
-from buffers import BufferlistBuffer
-from commands import commandfactory
-from commands import CommandCanceled
-from alot.commands import CommandParseError
-from alot.helper import split_commandline
-from alot.helper import string_decode
-from alot.widgets.globals import CompleteEdit
-from alot.widgets.globals import ChoiceWidget
+from alot.buffers import BufferlistBuffer
+from alot.commands import CommandCanceled, CommandParseError, commandfactory
+from alot.helper import split_commandline, string_decode
+from alot.settings import settings
+from alot.widgets.globals import ChoiceWidget, CompleteEdit
 
 
 class UI(object):
@@ -123,7 +120,7 @@ class UI(object):
                 if not self._locked:
                     try:
                         self.apply_commandline(cmdline)
-                    except CommandParseError, e:
+                    except CommandParseError as e:
                         self.notify(e.message, priority='error')
                 # move keys are always passed
                 elif cmdline in ['move up', 'move down', 'move page up',
@@ -423,7 +420,7 @@ class UI(object):
         :type t: alot.buffers.Buffer
         :rtype: list
         """
-        return filter(lambda x: isinstance(x, t), self.buffers)
+        return [x for x in self.buffers if isinstance(x, t)]
 
     def clear_notify(self, messages):
         """
@@ -443,8 +440,8 @@ class UI(object):
             self._notificationbar = None
         self.update()
 
-    def choice(self, message, choices={'y': 'yes', 'n': 'no'},
-               select=None, cancel=None, msg_position='above'):
+    def choice(self, message, choices=None, select=None, cancel=None,
+               msg_position='above'):
         """
         prompt user to make a choice.
 
@@ -463,8 +460,11 @@ class UI(object):
         :type msg_position: str
         :rtype:  :class:`twisted.defer.Deferred`
         """
-        assert select in choices.values() + [None]
-        assert cancel in choices.values() + [None]
+        if choices is None:
+            choices = {'y': 'yes', 'n': 'no'},
+
+        assert select in choices.values() or select is None
+        assert cancel in choices.values() or cancel is None
         assert msg_position in ['left', 'above']
 
         d = defer.Deferred()  # create return deferred

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -461,7 +461,7 @@ class UI(object):
         :rtype:  :class:`twisted.defer.Deferred`
         """
         if choices is None:
-            choices = {'y': 'yes', 'n': 'no'},
+            choices = {'y': 'yes', 'n': 'no'}
 
         assert select in choices.values() or select is None
         assert cancel in choices.values() or cancel is None

--- a/alot/utils/booleanaction.py
+++ b/alot/utils/booleanaction.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
+
 import argparse
 
 

--- a/alot/walker.py
+++ b/alot/walker.py
@@ -1,8 +1,10 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-import urwid
+
 import logging
+
+import urwid
 
 
 class PipeWalker(urwid.ListWalker):

--- a/alot/widgets/bufferlist.py
+++ b/alot/widgets/bufferlist.py
@@ -5,6 +5,7 @@
 """
 Widgets specific to Bufferlist mode
 """
+
 import urwid
 
 

--- a/alot/widgets/globals.py
+++ b/alot/widgets/globals.py
@@ -5,9 +5,11 @@
 """
 This contains alot-specific :class:`urwid.Widget` used in more than one mode.
 """
-import urwid
-import re
+
 import operator
+import re
+
+import urwid
 
 from alot.helper import string_decode
 from alot.settings import settings
@@ -124,8 +126,6 @@ class CompleteEdit(urwid.Edit):
         self.history = list(history)  # we temporarily add stuff here
         self.historypos = None
 
-        if not isinstance(edit_text, unicode):
-            edit_text = string_decode(edit_text)
         self.start_completion_pos = len(edit_text)
         self.completions = None
         urwid.Edit.__init__(self, edit_text=edit_text, **kwargs)
@@ -140,7 +140,7 @@ class CompleteEdit(urwid.Edit):
                     self.completions += self.completer.complete(self.edit_text,
                                                                 self.edit_pos)
                     self.focus_in_clist = 1
-                except CompletionError, e:
+                except CompletionError as e:
                     if self.on_error is not None:
                         self.on_error(e)
 

--- a/alot/widgets/search.py
+++ b/alot/widgets/search.py
@@ -4,13 +4,13 @@
 """
 Widgets specific to search mode
 """
+
 import urwid
 
-from alot.settings import settings
+from .globals import TagWidget
+from .utils import AttrFlipWidget
 from alot.helper import shorten_author_string
-from alot.helper import tag_cmp
-from alot.widgets.utils import AttrFlipWidget
-from alot.widgets.globals import TagWidget
+from alot.settings import settings
 
 
 class ThreadlineWidget(urwid.AttrMap):
@@ -98,7 +98,7 @@ class ThreadlineWidget(urwid.AttrMap):
 
         elif name == 'content':
             if self.thread:
-                msgs = self.thread.get_messages().keys()
+                msgs = list(self.thread.get_messages().keys())
             else:
                 msgs = []
             # sort the most recent messages first
@@ -115,8 +115,7 @@ class ThreadlineWidget(urwid.AttrMap):
                 fallback_focus = struct[name]['focus']
                 tag_widgets = [TagWidget(t, fallback_normal, fallback_focus)
                                for t in self.thread.get_tags()]
-                tag_widgets.sort(tag_cmp,
-                                 lambda tag_widget: tag_widget.translated)
+                tag_widgets.sort(key=lambda tag_widget: tag_widget.translated)
             else:
                 tag_widgets = []
             cols = []

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -1,19 +1,20 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
+
 """
 Widgets specific to thread mode
 """
-import urwid
+
 import logging
 
-from alot.settings import settings
-from alot.db.utils import decode_header, X_SIGNATURE_MESSAGE_HEADER
-from alot.helper import tag_cmp
-from alot.widgets.globals import TagWidget
-from alot.widgets.globals import AttachmentWidget
+import urwid
+
+from .globals import AttachmentWidget, TagWidget
+from alot.db.utils import (decode_header, extract_body,
+                           X_SIGNATURE_MESSAGE_HEADER)
 from alot.foreign.urwidtrees import Tree, SimpleTree, CollapsibleTree
-from alot.db.utils import extract_body
+from alot.settings import settings
 
 
 class MessageSummaryWidget(urwid.WidgetWrap):
@@ -45,7 +46,8 @@ class MessageSummaryWidget(urwid.WidgetWrap):
         thread_tags = message.get_thread().get_tags(intersection=True)
         outstanding_tags = set(message.get_tags()).difference(thread_tags)
         tag_widgets = [TagWidget(t, attr, focus_att) for t in outstanding_tags]
-        tag_widgets.sort(tag_cmp, lambda tag_widget: tag_widget.translated)
+
+        tag_widgets.sort(key=lambda tag_widget: tag_widget.translated)
         for tag_widget in tag_widgets:
             if not tag_widget.hidden:
                 cols.append(('fixed', tag_widget.width(), tag_widget))
@@ -270,7 +272,6 @@ class MessageTree(CollapsibleTree):
 
         if headers is None:
             # collect all header/value pairs in the order they appear
-            headers = mail.keys()
             for key, value in mail.items():
                 dvalue = decode_header(value, normalize=normalize)
                 lines.append((key, dvalue))

--- a/alot/widgets/utils.py
+++ b/alot/widgets/utils.py
@@ -5,6 +5,7 @@
 """
 Utility Widgets not specific to alot
 """
+
 import urwid
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 import alot
 
 


### PR DESCRIPTION
Changes to enable support of Py3k:

- Change all `map`, `filter`, `.keys` etc calls which return values considered
  to be subscriptable to list comprehensions or wrap them with `list`. Left as
  is same functions and methcds which values considered to be only iterated.
- Switch to explicit relative imports. Also minor rearrange imports to be more
  PEP8fy.
- Add reserve imports for new Py3k stdlib module structure: urllib, StringIO,
  etc
- Switch to setuptools
- Consider interpreter version on string/unicode/bytes conversions
- Minor PEP8 changes
- Switch to new exceptions syntax