### PR TITLE
RFE: implement folder tree buffer

### DIFF
--- a/alot/__init__.py
+++ b/alot/__init__.py
@@ -1,5 +1,5 @@
 __productname__ = 'alot'
-__version__ = '0.3.7'
+__version__ = '0.3.8.dev'
 __copyright__ = "Copyright (C) 2012-15 Patrick Totzke"
 __author__ = "Patrick Totzke"
 __author_email__ = "patricktotzke@gmail.com"

--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -5,6 +5,7 @@ import urwid
 import os
 from notmuch import NotmuchError
 import logging
+from alot.widgets.account import AccountTree
 
 from settings import settings
 import commands
@@ -18,7 +19,7 @@ from alot.widgets.globals import AttachmentWidget
 from alot.widgets.bufferlist import BufferlineWidget
 from alot.widgets.search import ThreadlineWidget
 from alot.widgets.thread import ThreadTree
-from urwidtrees import ArrowTree, TreeBox, NestedTree
+from urwidtrees import ArrowTree, TreeBox, NestedTree, CollapsibleArrowTree
 
 
 class Buffer(object):
@@ -112,6 +113,97 @@ class BufferlistBuffer(Buffer):
 
     def focus_first(self):
         self.body.set_focus(0)
+
+
+class FolderTreeBuffer(Buffer):
+    """list folders in a tree"""
+
+    modename = 'folders'
+
+    def __init__(self, ui, account):
+        """
+        :param ui: main UI
+        :type ui: :class:`~alot.ui.UI`
+        :param account: account to display
+        :type account: :class:`~alot.db.account.Account`
+        """
+        self.ui = ui
+        self.isinitialized = False
+        self.folder_list = None
+        self.account = account
+        self.rebuild()
+        Buffer.__init__(self, ui, self.body)
+
+    def get_info(self):
+        """ for status bar """
+        info = {}
+        info['folders_count'] = self.account.get_folders_count()
+        info['folders_count_positive'] = 's' * (not (self.account.get_folders_count() == 1))
+        return info
+
+    def rebuild(self):
+        logging.debug("Rebuild folders.")
+        focused_now = self.get_focused()
+        self.account.refresh()
+
+        self._tree = AccountTree(self.account)
+
+        bars_att = settings.get_theming_attribute('folders', 'arrow_bars')
+        heads_att = settings.get_theming_attribute('folders', 'arrow_heads')
+        self._arrow_tree = CollapsibleArrowTree(
+            self._tree,
+            arrow_tip_att=heads_att,
+            arrow_att=bars_att,
+        )
+        self.body = TreeBox(self._arrow_tree)
+        if focused_now:
+            self.body.set_focus(focused_now)
+
+    def refresh(self):
+        """refresh buffer with updated information"""
+        self.body.refresh()
+
+    def get_focused(self):
+        try:
+            focused_now = self.body.get_focus()[1]
+        except AttributeError:
+            return None
+        else:
+            logging.debug("Focused now: %s", repr(focused_now))
+            return focused_now
+
+    def get_current_folder(self):
+        focused = self.get_focused()
+        if focused is not None:
+            folder = self._tree[focused].folder
+            return folder
+
+    def focus_first(self):
+        self.body.set_focus(self._arrow_tree.root)
+
+    def focus_last(self):
+        self.body.set_focus(next(self._arrow_tree.positions(reverse=True)))
+
+    def focus_parent(self):
+        """move focus to parent of currently focussed folder"""
+        newpos = self._tree.parent_position(self.get_focused())
+        if newpos is not None:
+            self.body.set_focus(newpos)
+
+    def focus_next_unread(self):
+        self.body.set_focus(self._tree.next_unread(self.get_focused()))
+
+    def focus_previous_unread(self):
+        self.body.set_focus(self._tree.previous_unread(self.get_focused()))
+
+    def is_collapsed(self, pos):
+        return self._arrow_tree.is_collapsed(pos)
+
+    def collapse(self):
+        return self._arrow_tree.collapse(self.body.get_focus()[1])
+
+    def expand(self):
+        return self._arrow_tree.expand(self.body.get_focus()[1])
 
 
 class EnvelopeBuffer(Buffer):

--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -5,7 +5,7 @@ import urwid
 import os
 from notmuch import NotmuchError
 import logging
-from alot.widgets.account import AccountTree
+from alot.widgets.folders import FoldersTree
 
 from settings import settings
 import commands
@@ -146,7 +146,7 @@ class FolderTreeBuffer(Buffer):
         focused_now = self.get_focused()
         self.account.refresh()
 
-        self._tree = AccountTree(self.account)
+        self._tree = FoldersTree(self.account)
 
         bars_att = settings.get_theming_attribute('folders', 'arrow_bars')
         heads_att = settings.get_theming_attribute('folders', 'arrow_heads')

--- a/alot/commands/__init__.py
+++ b/alot/commands/__init__.py
@@ -37,6 +37,7 @@ COMMANDS = {
     'search': {},
     'envelope': {},
     'bufferlist': {},
+    'folders': {},
     'taglist': {},
     'thread': {},
     'global': {},

--- a/alot/commands/folders.py
+++ b/alot/commands/folders.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# This file is released under the GNU GPL, version 3 or a later revision.
+# For further details see the COPYING file
+
+import logging
+import argparse
+
+from alot.commands import Command, registerCommand
+from alot.commands.globals import MoveCommand
+from alot import buffers
+
+
+MODE = 'folders'
+
+
+@registerCommand(MODE, 'fold', forced={'visible': False}, help='fold folders')
+@registerCommand(MODE, 'unfold', forced={'visible': True}, help='unfold folders')
+class ChangeDisplaymodeCommand(Command):
+    """ fold or unfold folder """
+    repeatable = True
+
+    def __init__(self, visible=None, **kwargs):
+        """
+        :param visible: unfold if `True`, fold if `False`, ignore if `None`
+        :type visible: True, False, 'toggle' or None
+        """
+        self.visible = visible
+        Command.__init__(self)
+
+    def apply(self, ui):
+        logging.debug('change display mode of folder')
+        folder_buffer = ui.current_buffer
+
+        # collapse/expand depending on new 'visible' value
+        if self.visible is False:
+            folder_buffer.collapse()
+        elif self.visible is True:  # could be None
+            folder_buffer.expand()
+        folder_buffer.refresh()
+
+
+@registerCommand(MODE, 'open', help='open folder')
+class OpenFolderCommand(Command):
+    """ open selected folder """
+    def __init__(self, **kwargs):
+        Command.__init__(self)
+
+    def apply(self, ui):
+        folder_buffer = ui.current_buffer
+        current_folder = folder_buffer.get_current_folder()
+        query = current_folder.get_query_string()
+        logging.debug("Opening search buffer for '%s'", query)
+        open_searches = ui.get_buffers_of_type(buffers.SearchBuffer)
+        to_be_focused = None
+        for sb in open_searches:
+            if sb.querystring == query:
+                to_be_focused = sb
+        if to_be_focused:
+            if ui.current_buffer != to_be_focused:
+                ui.buffer_focus(to_be_focused)
+            else:
+                # refresh an already displayed search
+                ui.current_buffer.rebuild()
+                ui.update()
+        else:
+            ui.buffer_open(buffers.SearchBuffer(ui, query))
+
+
+@registerCommand(MODE, 'move', help='move focus in search buffer',
+                 arguments=[(['movement'], {
+                     'nargs': argparse.REMAINDER,
+                     'help': 'unread next, unread previous'})])
+class MoveFocusCommand(MoveCommand):
+
+    def apply(self, ui):
+        logging.debug(self.movement)
+        fbuffer = ui.current_buffer
+        if self.movement == 'unread next':
+            fbuffer.focus_next_unread()
+        elif self.movement == 'unread previous':
+            fbuffer.focus_previous_unread()
+        elif self.movement == 'parent':
+            fbuffer.focus_parent()
+        else:
+            MoveCommand.apply(self, ui)
+        ui.current_buffer.refresh()
+
+
+@registerCommand(MODE, 'mark_as_read', help='mark threads in selected folder as read')
+class MarkFolderAsRead(Command):
+    """ remove 'unread' tag from all threads in folder """
+    def apply(self, ui):
+        folder_buffer = ui.current_buffer
+        current_folder = folder_buffer.get_current_folder()
+        logging.debug('removing \'unread\' tag from folder %s', current_folder)
+        current_folder.remove_unread_tags()
+        # current_folder.refresh()
+        folder_buffer.rebuild()
+        # yes, we are refreshing whole buffer even though when we could
+        # refresh only the single folder -- it's superfast, so we don't
+        # care
+        ui.update()

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -19,6 +19,7 @@ from alot.completion import CommandLineCompleter
 from alot.commands import CommandCanceled
 from alot.commands.utils import get_keys
 from alot import buffers
+from alot.db.account import Account
 from alot.widgets.utils import DialogBox
 from alot import helper
 from alot.db.errors import DatabaseLockedError
@@ -477,6 +478,21 @@ class OpenBufferlistCommand(Command):
         else:
             bl = buffers.BufferlistBuffer(ui, self.filtfun)
             ui.buffer_open(bl)
+
+
+@registerCommand(MODE, 'folders')
+class OpenFolderlistCommand(Command):
+    """ display a tree view of maildir folders """
+    def apply(self, ui):
+        f_buffers = ui.get_buffers_of_type(buffers.FolderTreeBuffer)
+        if f_buffers:
+            ui.buffer_focus(f_buffers[0])
+        else:
+            account = Account(
+                ui.dbman,
+            )
+            folder_buffer = buffers.FolderTreeBuffer(ui, account)
+            ui.buffer_open(folder_buffer)
 
 
 @registerCommand(MODE, 'taglist', arguments=[

--- a/alot/db/account.py
+++ b/alot/db/account.py
@@ -1,15 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import logging
-import datetime
 from collections import OrderedDict
 
-from alot.db.manager import DBManager
 from alot.db.folder import Folder
 from alot.settings import settings
-
-
-logging.basicConfig(level=logging.DEBUG)
 
 
 class Account(object):
@@ -45,7 +40,6 @@ class Account(object):
         """
         find maildir folders on filesystem and create hierarchy out of it
         """
-        n = datetime.datetime.now()
         all_dirs = self._dbman.get_all_folders()
         for d in all_dirs:
             try:
@@ -55,7 +49,6 @@ class Account(object):
             self._folders_list.append((d, basename))
         # it could make sense to make this configurable
         self._folders_list = sorted(self._folders_list, key=lambda y: y[0].lower())
-        logging.debug("maildir folders lookup took %s", datetime.datetime.now() - n)
 
     def get_root(self):
         return self.root_folder
@@ -136,12 +129,3 @@ class Account(object):
 
     def __str__(self):
         return "Account"
-
-
-if __name__ == '__main__':
-    import sys
-    logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
-    dbman = DBManager()
-    a = Account(dbman)
-    from pprint import pprint
-    pprint(a.refresh())

--- a/alot/db/account.py
+++ b/alot/db/account.py
@@ -19,27 +19,31 @@ class Account(object):
         """
         logging.debug("initializing Account")
         self._dbman = dbman
-        self._init_vars()
+
+        # these variables are initialized every time get_fs_folders is called
+        # list of paths
+        self._folders_list = None
+        # mapping between rel_path and class Folder
+        self._folder_mapping = None
+        # class Folder -> children
+        self._folders = None
+        # list of Folders
+        self._unread_folders = None
 
         try:
             self.root_folder = Folder(self._dbman, settings.get_main_addresses()[0], '')
         except TypeError:
             self.root_folder = Folder(self._dbman, "root", '')
 
-    def _init_vars(self):
-        """ initiate variables """
-        # list of paths
-        self._folders_list = []
-        # mapping between rel_path and class Folder
-        self._folder_mapping = {}
-        # class Folder -> children
-        self._folders = OrderedDict()
-        self._unread_folders = []
-
     def get_fs_folders(self):
         """
         find maildir folders on filesystem and create hierarchy out of it
         """
+        self._folders_list = []
+        self._folder_mapping = {}
+        self._folders = OrderedDict()
+        self._unread_folders = []
+
         all_dirs = self._dbman.get_all_folders()
         for d in all_dirs:
             try:
@@ -123,7 +127,6 @@ class Account(object):
 
     def refresh(self):
         """ refresh all folders """
-        self._init_vars()
         self.get_fs_folders()
         return self.get_folders()
 

--- a/alot/db/account.py
+++ b/alot/db/account.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import datetime
+from collections import OrderedDict
+
+from alot.db.manager import DBManager
+from alot.db.folder import Folder
+from alot.settings import settings
+
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+class Account(object):
+    """
+    represents IMAP account with maildir folders
+    """
+
+    def __init__(self, dbman):
+        """
+        :param dbman: db manager that is used for further lookups
+        :type dbman: :class:`~alot.db.DBManager`
+        """
+        logging.debug("initializing Account")
+        self._dbman = dbman
+        self._init_vars()
+
+        try:
+            self.root_folder = Folder(self._dbman, settings.get_main_addresses()[0], '')
+        except TypeError:
+            self.root_folder = Folder(self._dbman, "root", '')
+
+    def _init_vars(self):
+        """ initiate variables """
+        # list of paths
+        self._folders_list = []
+        # mapping between rel_path and class Folder
+        self._folder_mapping = {}
+        # class Folder -> children
+        self._folders = OrderedDict()
+        self._unread_folders = []
+
+    def get_fs_folders(self):
+        """
+        find maildir folders on filesystem and create hierarchy out of it
+        """
+        n = datetime.datetime.now()
+        all_dirs = self._dbman.get_all_folders()
+        for d in all_dirs:
+            try:
+                basename = d.rsplit('/', 1)[1]
+            except IndexError:
+                basename = d
+            self._folders_list.append((d, basename))
+        # it could make sense to make this configurable
+        self._folders_list = sorted(self._folders_list, key=lambda y: y[0].lower())
+        logging.debug("maildir folders lookup took %s", datetime.datetime.now() - n)
+
+    def get_root(self):
+        return self.root_folder
+
+    def get_folder(self, rel_path):
+        """ return folder specified via relative path """
+        return self._folder_mapping[rel_path]
+
+    def get_children(self, folder):
+        try:
+            return self._folders[folder]
+        except KeyError:
+            return []
+
+    def get_folders_count(self):
+        return len(self._folders)
+
+    def get_next_unread(self, folder):
+        try:
+            index = self._unread_folders.index(folder)
+        except ValueError:
+            return self._unread_folders[0]
+        try:
+            return self._unread_folders[index + 1]
+        except IndexError:
+            return self._unread_folders[0]
+
+    def get_previous_unread(self, folder):
+        try:
+            index = self._unread_folders.index(folder)
+        except ValueError:
+            return self._unread_folders[-1]
+        try:
+            return self._unread_folders[index - 1]
+        except IndexError:
+            return self._unread_folders[-1]
+
+    def get_folders(self):
+        """
+        process folders by querying notmuch
+        """
+        if not self._folders:  # if not already cached
+            self._folders[self.root_folder] = []
+            # make inbox first
+            inbox_list = [(index, item) for index, item in enumerate(self._folders_list)
+                          if item[1].lower() == 'inbox']
+            try:
+                index, inbox = inbox_list[0]
+            except IndexError:
+                pass
+            else:
+                f = Folder(self._dbman, inbox[1], inbox[0])
+                del self._folders_list[index]
+                self._folders.setdefault(f, [])
+                self._folder_mapping[inbox[0]] = f
+                self._folders[self.root_folder].append(f)
+
+            for rel_path, basename in self._folders_list:
+                nice_name = basename[1:] if basename.startswith(".") else basename
+                f = Folder(self._dbman, nice_name, rel_path)
+                self._folders.setdefault(f, [])
+                self._folder_mapping[rel_path] = f
+
+                parent_path = rel_path.rsplit('/', 1)[0]
+                if parent_path == rel_path:
+                    self._folders[self.root_folder].append(f)
+                else:
+                    self._folders[self.get_folder(parent_path)].append(f)
+                if f.count > 0:
+                    self._unread_folders.append(f)
+        return self._folders
+
+    def refresh(self):
+        """ refresh all folders """
+        self._init_vars()
+        self.get_fs_folders()
+        return self.get_folders()
+
+    def __str__(self):
+        return "Account"
+
+
+if __name__ == '__main__':
+    import sys
+    logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
+    dbman = DBManager()
+    a = Account(dbman)
+    from pprint import pprint
+    pprint(a.refresh())

--- a/alot/db/account.py
+++ b/alot/db/account.py
@@ -9,7 +9,7 @@ from alot.settings import settings
 
 class Account(object):
     """
-    represents IMAP account with maildir folders
+    Account represents a collection of folders defined in notmuch config at database -> path
     """
 
     def __init__(self, dbman):

--- a/alot/db/folder.py
+++ b/alot/db/folder.py
@@ -2,7 +2,7 @@
 
 
 class Folder(object):
-    """ wrappar on top of notmuch query for a folder """
+    """ wrapper on top of notmuch query for a folder """
 
     def __init__(self, dbman, folder_name, rel_path):
         self.dbman = dbman

--- a/alot/db/folder.py
+++ b/alot/db/folder.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+
+class Folder(object):
+    """ wrappar on top of notmuch query for a folder """
+
+    def __init__(self, dbman, folder_name, rel_path):
+        self.dbman = dbman
+        self.folder_name = folder_name
+        self.query_folder_name = rel_path if not rel_path.startswith('/') else rel_path[1:]
+        if rel_path:  # root folder has no relative path
+            self.query = 'folder:"%s"' % self.query_folder_name
+            self.unread_query = 'folder:"%s" tag:unread' % self.query_folder_name
+        else:
+            self.query = ''
+            self.unread_query = 'tag:unread'
+        self.count = 0
+        self.refresh()
+
+    def __str__(self):
+        return "[%d] %s" % (self.count, self.folder_name)
+
+    def __unicode__(self):
+        return unicode(self.__str__())
+
+    def __repr__(self):
+        return "Folder([%d] %s (%s))" % (self.count, self.folder_name, self.query)
+
+    def get_id(self):
+        return self.query_folder_name
+
+    def get_query_string(self):
+        return self.query
+
+    def remove_unread_tags(self):
+        self.dbman.untag(self.unread_query, ['unread'])
+        self.dbman.flush()
+
+    def refresh(self):
+        self.count = self.dbman.count_messages(self.unread_query)
+        return self.count

--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -304,6 +304,48 @@ class DBManager(object):
         db = Database(path=self.path)
         return [t for t in db.get_all_tags()]
 
+    def get_all_folders(self):
+        """
+        query notmuch and return list of all maildir folders
+
+        :return: list of folders
+        """
+        mode = Database.MODE.READ_ONLY
+        db = Database(path=self.path, mode=mode)
+        root_dir_path = db.get_path()
+        logging.info("root directory is %r", root_dir_path)
+
+        result = []
+
+        IMAP_FOLDERS = {"cur", "new", "tmp"}
+
+        def recursive_search(root_dir, relative_path):
+            child_dirs = list_child_dirs(root_dir, relative_path)
+            for child_dir in child_dirs:
+                path = os.path.join(relative_path, child_dir)
+                logging.debug("recursive search in %s", path)
+                recursive_search(root_dir, path)
+
+        def list_child_dirs(root_dir, relative_path):
+            abs_path = os.path.join(root_dir, relative_path)
+            nm_dir = db.get_directory(abs_path)
+            l = []
+            if nm_dir:
+                filenames = nm_dir.get_child_directories()
+                folder_set = set(filenames)
+                # notmuch returns {cur,new,tmp} folders for root folders of account
+                if not folder_set.issubset(IMAP_FOLDERS):
+                    for f in folder_set:
+                        folder_rel_path = os.path.join(relative_path, f)
+                        logging.debug("new folder: %s", folder_rel_path)
+                        result.append(folder_rel_path)
+                        l.append(folder_rel_path)
+            return l
+
+        recursive_search(root_dir_path, "")
+
+        return result
+
     def async(self, cbl, fun):
         """
         return a pair (pipe, process) so that the process writes

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -105,6 +105,11 @@ show_statusbar = boolean(default=True)
 # * `{pending_writes}`: number of pending write operations to the index
 bufferlist_statusbar = mixed_list(string, string, default=list('[{buffer_no}: bufferlist]','{input_queue} total messages: {total_messages}'))
 
+
+# * `{folders_count}`: number of matching messages
+# * `{folders_count_positive}`: 's' if result count is greater than 0.
+folders_statusbar = mixed_list(string, string, default=list(' ', '{folders_count} folders'))
+
 # Format of the status-bar in search mode.
 # This is a pair of strings to be left and right aligned in the status-bar.
 # Apart from the global variables listed at :ref:`bufferlist_statusbar <bufferlist-statusbar>`

--- a/alot/defaults/default.bindings
+++ b/alot/defaults/default.bindings
@@ -30,6 +30,15 @@ q = exit
     x = close
     enter = open
 
+[folders]
+    enter = open
+    c = fold
+    e = unfold
+    s = mark_as_read
+    n = move unread next
+    N = move unread previous
+    'g h' = move parent
+
 [search]
     enter = select
     a = toggletags inbox

--- a/alot/defaults/default.theme
+++ b/alot/defaults/default.theme
@@ -20,6 +20,12 @@
     line_focus = 'standout','','yellow','light gray','#ff8','g58'
     line_even = 'default','','light gray','black','default','g3'
     line_odd = 'default','','light gray','black','default','default'
+[folders]
+    line_focus = 'standout','','yellow','light gray','#ff8','g58'
+    line_empty = 'default','','light gray','black','#888','default'
+    line = 'default','','light gray','black','light gray','default'
+    arrow_heads = '','','light red','','#c00',''
+    arrow_bars = '','','light red','','#a00',''
 [taglist]
     line_focus = 'standout','','yellow','light gray','#ff8','g58'
     line_even = 'default','','light gray','black','default','g3'

--- a/alot/defaults/theme.spec
+++ b/alot/defaults/theme.spec
@@ -17,6 +17,12 @@
     line_focus = attrtriple
     line_even = attrtriple
     line_odd = attrtriple
+[folders]
+    line_focus = attrtriple
+    line_empty = attrtriple
+    line = attrtriple
+    arrow_bars = attrtriple
+    arrow_heads = attrtriple
 
 [taglist]
     line_focus = attrtriple

--- a/alot/widgets/account.py
+++ b/alot/widgets/account.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import urwid
+from urwidtrees import Tree
+from alot.settings import settings
+
+
+class FolderWidget(urwid.WidgetWrap):
+    """
+    special widget for displaying folder, so we can distinguish between
+    empty and focused folders
+    """
+    def __init__(self, folder):
+        self.folder = folder
+        self.txt = urwid.Text(str(folder), wrap='clip')
+        if folder.count > 0:
+            normal_att = settings.get_theming_attribute('folders', 'line')
+        else:
+            normal_att = settings.get_theming_attribute('folders', 'line_empty')
+        focus_att = settings.get_theming_attribute('folders', 'line_focus')
+        line = urwid.AttrMap(self.txt, normal_att, focus_att)
+        logging.debug("line = %s", line)
+        urwid.WidgetWrap.__init__(self, line)
+
+    def selectable(self):
+        return True
+
+    def keypress(self, size, key):
+        return key
+
+
+class AccountTree(Tree):
+    """
+    Implementation of Tree interface for Account
+    """
+    def __init__(self, account):
+        self._account = account
+        self.root_folder = account.get_root()
+        self.root = None
+        self._parent_of = {}
+        self._first_child_of = {}
+        self._last_child_of = {}
+        self._next_sibling_of = {}
+        self._prev_sibling_of = {}
+        self._folders = {}
+
+        def accumulate(folder, odd=True):
+            """recursively read msg and its replies"""
+            folder_id = folder.get_id()
+            logging.debug("folder = %s", folder)
+            self._folders[folder_id] = FolderWidget(folder)
+            odd = not odd
+            last = None
+            self._first_child_of[folder_id] = None
+            for child_folder in self._account.get_children(folder):
+                child_folder_id = child_folder.get_id()
+                if self._first_child_of[folder_id] is None:
+                    self._first_child_of[folder_id] = child_folder_id
+                self._parent_of[child_folder_id] = folder_id
+                self._prev_sibling_of[child_folder_id] = last
+                self._next_sibling_of[last] = child_folder_id
+                last = child_folder_id
+                odd = accumulate(child_folder, odd)
+            self._last_child_of[folder_id] = last
+            return odd
+
+        last = None
+        f_id = self.root_folder.get_id()
+        self._prev_sibling_of[f_id] = last
+        self._next_sibling_of[last] = f_id
+        accumulate(self.root_folder)
+        self.root = f_id
+        last = f_id
+        self._next_sibling_of[last] = None
+
+    def next_unread(self, pos):
+       folder = self._folders[pos].folder
+       return self._account.get_next_unread(folder).get_id()
+
+    def previous_unread(self, pos):
+        folder = self._folders[pos].folder
+        return self._account.get_previous_unread(folder).get_id()
+
+    # Tree API
+    def __getitem__(self, pos):
+        return self._folders.get(pos)
+
+    def parent_position(self, pos):
+        return self._parent_of.get(pos, None)
+
+    def first_child_position(self, pos):
+        return self._first_child_of.get(pos, None)
+
+    def last_child_position(self, pos):
+        return self._last_child_of.get(pos, None)
+
+    def next_sibling_position(self, pos):
+        return self._next_sibling_of.get(pos, None)
+
+    def prev_sibling_position(self, pos):
+        return self._prev_sibling_of.get(pos, None)

--- a/alot/widgets/folders.py
+++ b/alot/widgets/folders.py
@@ -30,9 +30,9 @@ class FolderWidget(urwid.WidgetWrap):
         return key
 
 
-class AccountTree(Tree):
+class FoldersTree(Tree):
     """
-    Implementation of Tree interface for Account
+    Implementation of Tree interface for maildir folders
     """
     def __init__(self, account):
         self._account = account

--- a/alot/widgets/folders.py
+++ b/alot/widgets/folders.py
@@ -75,8 +75,8 @@ class FoldersTree(Tree):
         self._next_sibling_of[last] = None
 
     def next_unread(self, pos):
-       folder = self._folders[pos].folder
-       return self._account.get_next_unread(folder).get_id()
+        folder = self._folders[pos].folder
+        return self._account.get_next_unread(folder).get_id()
 
     def previous_unread(self, pos):
         folder = self._folders[pos].folder

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,7 +18,8 @@ COMMAND_OPTION_TABLES = source/usage/modes/bufferlist.rst \
 			source/usage/modes/global.rst \
 			source/usage/modes/search.rst \
 			source/usage/modes/taglist.rst \
-			source/usage/modes/thread.rst
+			source/usage/modes/thread.rst \
+			source/usage/modes/folders.rst
 
 
 .PHONY: html help clean dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest

--- a/docs/source/usage/commands.rst
+++ b/docs/source/usage/commands.rst
@@ -23,6 +23,8 @@ See the sections below for which commands are available in which (UI) mode.
     commands while listing active buffers
 :doc:`modes/taglist`
     commands while listing all tagstrings present in the notmuch database
+:doc:`modes/folders`
+    commands available when displaying tree view of maildir folders
 
 .. toctree::
    :maxdepth: 2
@@ -34,4 +36,5 @@ See the sections below for which commands are available in which (UI) mode.
    modes/envelope
    modes/bufferlist
    modes/taglist
+   modes/folders
 

--- a/docs/source/usage/modes/folders.rst
+++ b/docs/source/usage/modes/folders.rst
@@ -1,0 +1,45 @@
+.. CAUTION: THIS FILE IS AUTO-GENERATED!
+
+
+Commands in `folders` mode
+--------------------------
+The following commands are available in folders mode
+
+.. _cmd.folders.fold:
+
+.. describe:: fold
+
+    fold folders
+
+
+.. _cmd.folders.move:
+
+.. describe:: move
+
+    move focus in search buffer
+
+    argument
+        unread next, unread previous
+
+
+.. _cmd.folders.open:
+
+.. describe:: open
+
+    open folder
+
+
+.. _cmd.folders.unfold:
+
+.. describe:: unfold
+
+    unfold folders
+
+
+.. _cmd.folders.mark-as-read:
+
+.. describe:: mark_as_read
+
+    mark threads in selected folder as read
+
+

--- a/extra/themes/mutt
+++ b/extra/themes/mutt
@@ -25,6 +25,12 @@
     line_even = '','','light gray','black','light gray','black'
     line_odd = '','','light gray','black','light gray','black'
     line_focus = 'standout','','black','dark cyan','black','dark cyan'
+[folders]
+    line_focus = 'standout','','black','dark cyan','black','dark cyan'
+    line_empty = '','','light gray','black','light gray','black'
+    line = '','','light gray','black','light gray','black'
+    arrow_heads = '','','dark red','black','dark red','black'
+    arrow_bars = '','','dark red','black','dark red','black'
 [thread]
     arrow_heads = '','','dark red','black','dark red','black'
     arrow_bars = '','','dark red','black','dark red','black'

--- a/extra/themes/solarized
+++ b/extra/themes/solarized
@@ -66,6 +66,13 @@
     line_focus = 'standout','default','%(16_base2)s','%(16_yellow)s','%(256_base2)s','%(256_yellow)s'
     line_even = 'default','default','%(16_base00)s','%(16_base3)s','%(256_base00)s','%(256_base3)s'
     line_odd = 'default','default','%(16_base00)s','%(16_base2)s','%(256_base00)s','%(256_base2)s'
+[folders]
+    line_focus = 'standout','default','%(16_base02)s','%(16_yellow)s','%(256_base02)s','%(256_yellow)s'
+    line_empty = 'default','default','%(16_base0)s','%(16_base3)s','%(256_base0)s','%(256_base3)s'
+    line = 'default','default','%(16_base3)s','%(16_base3)s','%(256_base3)s','%(256_base3)s'
+    arrow_bars = 'default','default','%(16_orange)s','%(16_base3)s','%(256_orange)s','%(256_base3)s'
+    arrow_heads = 'default','default','%(16_orange)s','%(16_base3)s','%(256_orange)s','%(256_base3)s'
+
 [thread]
     attachment = 'default','default','%(16_base00)s','%(16_base3)s','%(256_base00)s','%(256_base3)s'
     attachment_focus = 'underline','default','%(16_base2)s','%(16_yellow)s','%(256_base2)s','%(256_yellow)s'

--- a/extra/themes/solarized_dark
+++ b/extra/themes/solarized_dark
@@ -67,6 +67,12 @@
     line_focus = 'standout','default','%(16_base02)s','%(16_yellow)s','%(256_base02)s','%(256_yellow)s'
     line_even = 'default','default','%(16_base0)s','%(16_base03)s','%(256_base0)s','%(256_base03)s'
     line_odd = 'default','default','%(16_base0)s','%(16_base02)s','%(256_base0)s','%(256_base02)s'
+[folders]
+    line_focus = 'standout','default','%(16_base02)s','%(16_yellow)s','%(256_base02)s','%(256_yellow)s'
+    line_empty = 'default','default','%(16_base0)s','%(16_base03)s','%(256_base0)s','%(256_base03)s'
+    line = 'default','default','%(16_base3)s','%(16_base03)s','%(256_base3)s','%(256_base03)s'
+    arrow_bars = 'default','default','%(16_orange)s','%(16_base03)s','%(256_orange)s','%(256_base03)s'
+    arrow_heads = 'default','default','%(16_orange)s','%(16_base03)s','%(256_orange)s','%(256_base03)s'
 [thread]
     attachment = 'default','default','%(16_base0)s','%(16_base03)s','%(256_base0)s','%(256_base03)s'
     attachment_focus = 'underline','default','%(16_base02)s','%(16_yellow)s','%(256_base02)s','%(256_yellow)s'

--- a/extra/themes/sup
+++ b/extra/themes/sup
@@ -25,6 +25,12 @@
     line_even = '','','light gray','black','light gray','g0'
     line_odd = '','','light gray','black','light gray','g0'
     line_focus = 'standout','','black','dark cyan','black','dark cyan'
+[folders]
+    line_focus = 'standout','','black','dark cyan','black','dark cyan'
+    line_empty = '','','light gray','black','light gray','g0'
+    line = '','','light gray','black','light gray','g0'
+    arrow_heads = '','','black','black','g0','g0'
+    arrow_bars = '','','black','black','g0','g0'
 [thread]
     arrow_heads = '','','black','black','g0','g0'
     arrow_bars = '','','black','black','g0','g0'

--- a/extra/themes/tomorrow
+++ b/extra/themes/tomorrow
@@ -79,6 +79,12 @@ error = 'dark red'
     line_focus = 'standout','default','%(16_focus_fg)s','%(16_focus_bg)s','%(256_focus_fg)s','%(256_focus_bg)s'
     line_even = 'default','default','%(16_text_fg)s','%(16_normal_bg)s','%(256_text_fg)s','%(256_normal_bg)s'
     line_odd = 'default','default','%(16_text_fg)s','%(16_normal_bg)s','%(256_text_fg)s','%(256_normal_bg)s'
+[folders]
+    line_focus = 'standout','default','%(16_focus_fg)s','%(16_focus_bg)s','%(256_focus_fg)s','%(256_focus_bg)s'
+    line_empty = 'default','default','%(16_text_fg)s','%(16_normal_bg)s','%(256_text_fg)s','%(256_normal_bg)s'
+    line = 'default','default','%(16_text_fg)s','%(16_normal_bg)s','%(256_text_fg)s','%(256_normal_bg)s'
+    arrow_bars = 'default','default','%(16_tags_fg)s','%(16_tags_bg)s','%(256_tags_fg)s','%(256_tags_bg)s'
+    arrow_heads = 'default','default','%(16_tags_fg)s','%(16_tags_bg)s','%(256_tags_fg)s','%(256_tags_bg)s'
 [thread]
     attachment = 'default','default','%(16_text_fg)s','%(16_text_bg)s','%(256_text_fg)s','%(256_text_bg)s'
     attachment_focus = 'underline','default','%(16_gray_bg)s','%(16_alternate)s','%(256_gray_bg)s','%(256_alternate)s'


### PR DESCRIPTION
Related to #331 
## Contains
- discover maildir structure
- query notmuch for # of unread msgs in folders
- display as tree
- theming:
  - empty folders
  - not empty folders
  - focused folders
- configuration
  - path to maildir
  - blacklisted folders
- enable (un)folding
- implement refresh
## Bugs

(these should be addressed **before** merging)
- [x] ~~collapse/expand all doesn't work~~ (IMO doesn't make much sense)
- [x] function next/previous unread folder behaves oddly on subfolders
- [x] get rid of TODOs and FIXMEs from the patch
- [x] docs
  - [x] written docs
  - [x] docstrings
## RFEs

(these may be addressed in subsequent PRs)
- completion for folders when searching
- new command: pre-complete searching for selected folder
- figure out something better for status line of folders buffer (e.g. # of new messages in favorite folders)
