### PR TITLE
Encrypt on reply to encrypted email and add 'encrypt_by_default' config

### DIFF
--- a/alot/account.py
+++ b/alot/account.py
@@ -51,7 +51,8 @@ class Account(object):
                  gpg_key=None, signature=None, signature_filename=None,
                  signature_as_attachment=False, sent_box=None,
                  sent_tags=['sent'], draft_box=None, draft_tags=['draft'],
-                 abook=None, sign_by_default=False, **rest):
+                 abook=None, sign_by_default=False, encrypt_by_default=False,
+                 **rest):
         self.address = address
         self.aliases = aliases
         self.realname = realname
@@ -60,6 +61,7 @@ class Account(object):
         self.signature_filename = signature_filename
         self.signature_as_attachment = signature_as_attachment
         self.sign_by_default = sign_by_default
+        self.encrypt_by_default = encrypt_by_default
         self.sent_box = sent_box
         self.sent_tags = sent_tags
         self.draft_box = draft_box

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -240,8 +240,10 @@ class ReplyCommand(Command):
             envelope.add('References', '<%s>' % self.message.get_message_id())
 
         # continue to compose
+        encrypt = mail.get_content_subtype() == 'encrypted'
         ui.apply_command(ComposeCommand(envelope=envelope,
-                                        spawn=self.force_spawn))
+                                        spawn=self.force_spawn,
+                                        encrypt=encrypt))
 
     def clear_my_address(self, my_addresses, value):
         """return recipient header without the addresses in my_addresses"""

--- a/alot/commands/utils.py
+++ b/alot/commands/utils.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2015  Patrick Totzke <patricktotzke@gmail.com>
+# This file is released under the GNU GPL, version 3 or a later revision.
+# For further details see the COPYING file
+from twisted.internet.defer import inlineCallbacks, returnValue
+
+from alot.errors import GPGProblem, GPGCode
+from alot import crypto
+
+
+@inlineCallbacks
+def get_keys(ui, encrypt_keyids, block_error=False):
+    keys = {}
+    for keyid in encrypt_keyids:
+        try:
+            key = crypto.get_key(keyid, validate=True, encrypt=True)
+        except GPGProblem as e:
+            if e.code == GPGCode.AMBIGUOUS_NAME:
+                possible_keys = crypto.list_keys(hint=keyid)
+                tmp_choices = [k.uids[0].uid for k in possible_keys]
+                choices = {str(len(tmp_choices) - x): tmp_choices[x]
+                           for x in range(0, len(tmp_choices))}
+                keyid = yield ui.choice("ambiguous keyid! Which " +
+                                        "key do you want to use?",
+                                        choices, cancel=None)
+                if keyid:
+                    encrypt_keyids.append(keyid)
+                continue
+            else:
+                ui.notify(e.message, priority='error', block=block_error)
+                continue
+        keys[crypto.hash_key(key)] = key
+    returnValue(keys)

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -279,6 +279,9 @@ prefer_plaintext = boolean(default=False)
         # Outgoing messages will be GPG signed by default if this is set to True.
         sign_by_default = boolean(default=False)
 
+        # Outgoing messages will be GPG encrypted by default if this is set to True.
+        encrypt_by_default = boolean(default=False)
+
         # The GPG key ID you want to use with this account. If unset, alot will
         # use your default key.
         gpg_key = gpg_key_hint(default=None)

--- a/docs/source/configuration/accounts_table
+++ b/docs/source/configuration/accounts_table
@@ -123,6 +123,16 @@
     :default: False
 
 
+.. _encrypt-by-default:
+
+.. describe:: encrypt_by_default
+
+     Outgoing messages will be GPG encrypted by default if this is set to True.
+
+    :type: boolean
+    :default: False
+
+
 .. _gpg-key:
 
 .. describe:: gpg_key

--- a/docs/source/usage/crypto.rst
+++ b/docs/source/usage/crypto.rst
@@ -39,3 +39,6 @@ and :ref:`toggleencrypt <cmd.envelope.toggleencrypt>` and
 in envelope mode to ask alot to encrypt the mail before sending.
 The :ref:`encrypt <cmd.envelope.encrypt>` command accepts an optional
 hint string as argument to determine the key of the recipient.
+
+You can set the default to-encrypt bit for each :ref:`account <config.accounts>`
+individually using the option :ref:`sign_by_default <sign-by-default>`.


### PR DESCRIPTION
For issue #661.

A fifth try, following up the comments in #767 .

I added an `encrypt_by_default` config option. Also I moved the reply key fetch to `alot.commands.global.ComposeCommand` as @pazz suggested.

Now it blocks the error message only when is a reply to an encrypted message to make sure the user realizes that the email will not be sent encrypted. It don't block in case of `encrypt_by_default` config option neither in case of `:encrypt` command.

How does it look now?