### PR TITLE
Python3

### DIFF
--- a/alot/crypto.py
+++ b/alot/crypto.py
@@ -1,9 +1,13 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# Copyright (C) 2015 Thomas Levine <_@thomaslevine.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 import os
 
-from cStringIO import StringIO
+try:
+    from cStringIO import StringIO
+except:
+    from io import StringIO
 from alot.errors import GPGProblem, GPGCode
 import gpgme
 

--- a/alot/db/__init__.py
+++ b/alot/db/__init__.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# Copyright (C) 2015 Thomas Levine <_@thomaslevine.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 
-from thread import Thread
-from message import Message
+from .thread import Thread
+from .message import Message
 DB_ENC = 'UTF-8'

--- a/alot/db/thread.py
+++ b/alot/db/thread.py
@@ -1,9 +1,10 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# Copyright (C) 2015 Thomas Levine <_@thomaslevine.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 from datetime import datetime
 
-from message import Message
+from .message import Message
 from alot.settings import settings
 
 

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -22,7 +22,10 @@ import magic
 from twisted.internet import reactor
 from twisted.internet.protocol import ProcessProtocol
 from twisted.internet.defer import Deferred
-from cStringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 import logging
 
 

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# Copyright (C) 2015 Thomas Levine <_@thomaslevine.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 from datetime import timedelta

--- a/alot/init.py
+++ b/alot/init.py
@@ -102,7 +102,7 @@ class Options(usage.Options):
                    ['compose', None, ComposeOptions, "compose a new message"]]
 
     def opt_version(self):
-        print alot.__version__
+        print(alot.__version__)
         sys.exit(0)
 
 
@@ -111,9 +111,9 @@ def main():
     args = Options()
     try:
         args.parseOptions()  # When given no argument, parses sys.argv[1:]
-    except usage.UsageError, errortext:
-        print '%s' % errortext
-        print 'Try --help for usage details.'
+    except usage.UsageError as errortext:
+        print('%s' % errortext)
+        print('Try --help for usage details.')
         sys.exit(1)
 
     # logging

--- a/alot/init.py
+++ b/alot/init.py
@@ -156,7 +156,7 @@ def main():
     try:
         settings.read_config(alotconfig)
         settings.read_notmuch_config(notmuchconfig)
-    except (ConfigError, OSError, IOError), e:
+    except (ConfigError, OSError, IOError) as e:
         sys.exit(e)
 
     # store options given by config swiches to the settingsManager:
@@ -180,7 +180,7 @@ def main():
                 cmdstring += ' ' + args.subOptions.rest
         else:
             cmdstring = settings.get('initial_command')
-    except CommandParseError, e:
+    except CommandParseError as e:
         sys.exit(e)
 
     # set up and start interface

--- a/alot/init.py
+++ b/alot/init.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# Copyright (C) 2015 Thomas Levine <_@thomaslevine.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 import sys
@@ -34,7 +35,7 @@ class SubcommandOptions(usage.Options):
         return optstr
 
     def opt_version(self):
-        print alot.__version__
+        print(alot.__version__)
         sys.exit(0)
 
 

--- a/alot/settings/checks.py
+++ b/alot/settings/checks.py
@@ -5,7 +5,10 @@
 import mailbox
 import re
 from urwid import AttrSpec, AttrSpecError
-from urlparse import urlparse
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
 from validate import VdtTypeError
 from validate import is_list
 from validate import ValidateError, VdtValueTooLongError, VdtValueError

--- a/alot/settings/checks.py
+++ b/alot/settings/checks.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# Copyright (C) 2015 Thomas Levine <_@thomaslevine.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 import mailbox
@@ -43,7 +44,7 @@ def attr_triple(value):
         mono = AttrSpec(acc['1fg'], acc['1bg'], 1)
         normal = AttrSpec(acc['16fg'], acc['16bg'], 16)
         high = AttrSpec(acc['256fg'], acc['256bg'], 256)
-    except AttrSpecError, e:
+    except AttrSpecError as e:
         raise ValidateError(e.message)
     return mono, normal, high
 
@@ -142,5 +143,5 @@ def gpg_key(value):
     """
     try:
         return crypto.get_key(value)
-    except GPGProblem, e:
+    except GPGProblem as e:
         raise ValidateError(e.message)

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# Copyright (C) 2015 Thomas Levine <_@thomaslevine.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 import imp
@@ -13,14 +14,15 @@ from alot.addressbook.abook import AbookAddressBook
 from alot.addressbook.external import ExternalAddressbook
 from alot.helper import pretty_datetime, string_decode
 
-from errors import ConfigError
-from utils import read_config
-from utils import resolve_att
-from checks import force_list
-from checks import mail_container
-from checks import gpg_key
-from checks import attr_triple
-from checks import align_mode
+from .errors import ConfigError
+from .utils import read_config, resolve_att
+from .checks import (
+    force_list,
+    mail_container,
+    gpg_key,
+    attr_triple,
+    align_mode,
+)
 from theme import Theme
 
 

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -23,7 +23,7 @@ from .checks import (
     attr_triple,
     align_mode,
 )
-from theme import Theme
+from .theme import Theme
 
 
 DEFAULTSPATH = os.path.join(os.path.dirname(__file__), '..', 'defaults')

--- a/alot/settings/theme.py
+++ b/alot/settings/theme.py
@@ -1,14 +1,17 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# Copyright (C) 2015 Thomas Levine <_@thomaslevine.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 import os
 
-from utils import read_config
-from checks import align_mode
-from checks import attr_triple
-from checks import width_tuple
-from checks import force_list
-from errors import ConfigError
+from .utils import read_config
+from .checks import (
+    align_mode,
+    attr_triple,
+    width_tuple,
+    force_list,
+)
+from .errors import ConfigError
 
 DEFAULTSPATH = os.path.join(os.path.dirname(__file__), '..', 'defaults')
 DUMMYDEFAULT = ('default',) * 6

--- a/alot/settings/utils.py
+++ b/alot/settings/utils.py
@@ -1,9 +1,10 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# Copyright (C) 2015 Thomas Levine <_@thomaslevine.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 from configobj import ConfigObj, ConfigObjError, flatten_errors
 from validate import Validator
-from errors import ConfigError
+from .errors import ConfigError
 from urwid import AttrSpec
 
 

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# Copyright (C) 2015 Thomas Levine <_@thomaslevine.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 import urwid
@@ -123,7 +124,7 @@ class UI(object):
                 if not self._locked:
                     try:
                         self.apply_commandline(cmdline)
-                    except CommandParseError, e:
+                    except CommandParseError as e:
                         self.notify(e.message, priority='error')
                 # move keys are always passed
                 elif cmdline in ['move up', 'move down', 'move page up',
@@ -191,7 +192,7 @@ class UI(object):
             # translate cmdstring into :class:`Command`
             #try:
             cmd = commandfactory(cmdstring, self.mode)
-            #except CommandParseError, e:
+            #except CommandParseError as e:
              #   self.notify(e.message, priority='error')
               #  return
             # store cmdline for use with 'repeat' command


### PR DESCRIPTION
I got as far as I could until getting stuck on this error, in both Python 2.7 and Python 3.4.
```
$ python2.7 -c 'import alot.init as i; i.main()'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "alot/init.py", line 12, in <module>
    from alot.db.manager import DBManager
  File "alot/db/__init__.py", line 6, in <module>
    from .thread import Thread
  File "alot/db/thread.py", line 7, in <module>
    from .message import Message
  File "alot/db/message.py", line 8, in <module>
    from notmuch import NullPointerError
  File "/Library/Python/2.7/site-packages/notmuch/__init__.py", line 54, in <module>
    from .database import Database
  File "/Library/Python/2.7/site-packages/notmuch/database.py", line 24, in <module>
    from .globals import (
  File "/Library/Python/2.7/site-packages/notmuch/globals.py", line 27, in <module>
    raise ImportError("Could not find shared 'notmuch' library.")
ImportError: Could not find shared 'notmuch' library.
```