### PR TITLE
add account option alias_regexp

### DIFF
--- a/alot/account.py
+++ b/alot/account.py
@@ -33,6 +33,8 @@ class Account(object):
     """this accounts main email address"""
     aliases = []
     """list of alternative addresses"""
+    alias_regexp = []
+    """regex matching alternative addresses"""
     realname = None
     """real name used to format from-headers"""
     gpg_key = None
@@ -47,13 +49,15 @@ class Account(object):
     """addressbook (:class:`addressbook.AddressBook`)
        managing this accounts contacts"""
 
-    def __init__(self, address=None, aliases=None, realname=None,
-                 gpg_key=None, signature=None, signature_filename=None,
-                 signature_as_attachment=False, sent_box=None,
-                 sent_tags=['sent'], draft_box=None, draft_tags=['draft'],
-                 abook=None, sign_by_default=False, **rest):
+    def __init__(self, address=None, aliases=None, alias_regexp=None,
+                realname=None, gpg_key=None, signature=None,
+                signature_filename=None, signature_as_attachment=False,
+                sent_box=None, sent_tags=['sent'], draft_box=None,
+                draft_tags=['draft'], abook=None, sign_by_default=False,
+                **rest):
         self.address = address
         self.aliases = aliases
+        self.alias_regexp = alias_regexp
         self.realname = realname
         self.gpg_key = gpg_key
         self.signature = signature

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -72,11 +72,13 @@ def determine_sender(mail, action='reply'):
     # pick the most important account that has an address in candidates
     # and use that accounts realname and the address found here
     for account in my_accounts:
-        acc_addresses = account.get_addresses()
+        acc_addresses = map(re.escape, account.get_addresses())
+        if account.alias_regexp is not None:
+            acc_addresses.append(account.alias_regexp)
         for alias in acc_addresses:
             if realname is not None:
                 break
-            regex = re.compile(re.escape(alias), flags=re.IGNORECASE)
+            regex = re.compile('^' + alias + '$', flags=re.IGNORECASE)
             for seen_name, seen_address in candidate_addresses:
                 if regex.match(seen_address):
                     logging.debug("match!: '%s' '%s'" % (seen_address, alias))

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -243,6 +243,9 @@ prefer_plaintext = boolean(default=False)
         # used to clear your addresses/ match account when formatting replies
         aliases = force_list(default=list())
 
+        # a regex for catching further aliases (like + extensions).
+        alias_regexp = string(default=None)
+
         # sendmail command. This is the shell command used to send out mails via the sendmail protocol
         sendmail_command = string(default='sendmail -t')
 

--- a/docs/source/configuration/accounts.rst
+++ b/docs/source/configuration/accounts.rst
@@ -13,6 +13,7 @@ Here is an example configuration
         [[work]]
             realname = Bruce Wayne
             address = b.wayne@wayneenterprises.com
+            alias_regexp = b.wayne\+.+@wayneenterprises.com
             gpg_key = D7D6C5AA
             sendmail_command = msmtp --account=wayne -t
             sent_box = maildir:///home/bruce/mail/work/Sent


### PR DESCRIPTION
This adds wildcard support for + extensions and just about any extension scheme you can imagine.

I used the name alias_regexp to stay consistent with the regexp option under abook.