### PR TITLE
implement msg_focused hook

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -955,6 +955,9 @@ class MoveFocusCommand(MoveCommand):
         # TODO: add next by date..
         tbuffer.body.refresh()
 
+        logging.debug("running current buffer's hooks")
+        tbuffer.run_hooks()
+
 
 @registerCommand(MODE, 'select')
 class ThreadSelectCommand(Command):


### PR DESCRIPTION
This hook can be used, e.g. to automatically use call the
mark-github-notifications-as-read hook whenever a message would be
marked as read by the auto_remove_unread setting.
