### PR TITLE
Add Mailing lists reply

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -117,7 +117,7 @@ class ReplyCommand(Command):
         :type message: `alot.db.message.Message`
         :param all: group reply; copies recipients from Bcc/Cc/To to the reply
         :type all: bool
-        :param listreply: reply to list
+        :param listreply: reply to list; autodetect if unset and enabled in config
         :type listreply: bool
         :param spawn: force spawning of editor in a new terminal
         :type spawn: bool
@@ -163,6 +163,11 @@ class ReplyCommand(Command):
             if not subject.lower().startswith(('re:', rsp.lower())):
                 subject = rsp + subject
         envelope.add('Subject', subject)
+
+        # Auto-detect ML
+        auto_replyto_mailinglist = settings.get('auto_replyto_mailinglist')
+        if auto_replyto_mailinglist and mail['List-Id']:
+            self.listreply = True
 
         # set From-header and sending account
         try:
@@ -227,7 +232,8 @@ class ReplyCommand(Command):
                 to = mail['To']
             logging.debug('mail list reply to: %s' % to)
             # Cleaning the 'To' in this case
-            envelope.__delitem__('To')
+            if envelope.get('To') is not None:
+                envelope.__delitem__('To')
 
         # Finally setup the 'To' header
         envelope.add('To', decode_header(to))

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -103,7 +103,8 @@ def determine_sender(mail, action='reply'):
 
 @registerCommand(MODE, 'reply', arguments=[
     (['--all'], {'action': 'store_true', 'help': 'reply to all'}),
-    (['--list'], {'action': 'store_true', 'dest': 'listreply', 'help': 'reply to list'}),
+    (['--list'], {'action': BooleanAction, 'default': None,
+                  'dest': 'listreply', 'help': 'reply to list'}),
     (['--spawn'], {'action': BooleanAction, 'default': None,
                    'help': 'open editor in new window'})])
 class ReplyCommand(Command):
@@ -111,7 +112,7 @@ class ReplyCommand(Command):
     """reply to message"""
     repeatable = True
 
-    def __init__(self, message=None, all=False, listreply=False, spawn=None, **kwargs):
+    def __init__(self, message=None, all=False, listreply=None, spawn=None, **kwargs):
         """
         :param message: message to reply to (defaults to selected message)
         :type message: `alot.db.message.Message`
@@ -166,8 +167,14 @@ class ReplyCommand(Command):
 
         # Auto-detect ML
         auto_replyto_mailinglist = settings.get('auto_replyto_mailinglist')
-        if auto_replyto_mailinglist and mail['List-Id']:
+        if mail['List-Id'] and self.listreply == None:
+            # mail['List-Id'] is need to enable reply-to-list
+            self.listreply = auto_replyto_mailinglist
+        elif mail['List-Id'] and self.listreply == True:
             self.listreply = True
+        elif self.listreply == False:
+            # In this case we only need the sender
+            self.listreply = False
 
         # set From-header and sending account
         try:

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -103,6 +103,7 @@ def determine_sender(mail, action='reply'):
 
 @registerCommand(MODE, 'reply', arguments=[
     (['--all'], {'action': 'store_true', 'help': 'reply to all'}),
+    (['--list'], {'action': 'store_true', 'dest': 'listreply', 'help': 'reply to list'}),
     (['--spawn'], {'action': BooleanAction, 'default': None,
                    'help': 'open editor in new window'})])
 class ReplyCommand(Command):
@@ -110,17 +111,20 @@ class ReplyCommand(Command):
     """reply to message"""
     repeatable = True
 
-    def __init__(self, message=None, all=False, spawn=None, **kwargs):
+    def __init__(self, message=None, all=False, listreply=False, spawn=None, **kwargs):
         """
         :param message: message to reply to (defaults to selected message)
         :type message: `alot.db.message.Message`
         :param all: group reply; copies recipients from Bcc/Cc/To to the reply
         :type all: bool
+        :param listreply: reply to list
+        :type listreply: bool
         :param spawn: force spawning of editor in a new terminal
         :type spawn: bool
         """
         self.message = message
         self.groupreply = all
+        self.listreply = listreply
         self.force_spawn = spawn
         Command.__init__(self, **kwargs)
 
@@ -210,6 +214,22 @@ class ReplyCommand(Command):
 
         to = ', '.join(recipients)
         logging.debug('reply to: %s' % to)
+
+        if self.listreply:
+            # To choose the target of the reply --list
+            # Reply-To is standart reply target RFC 2822:, RFC 1036: 2.2.1
+            # X-BeenThere is needed by sourceforge ML also winehq
+            # X-Mailing-List is also standart and is used by git-send-mail
+            to = mail['Reply-To'] or mail['X-BeenThere'] or mail['X-Mailing-List']
+            # Some mail server (gmail) will not resend you own mail, so you have
+            # to deal with the one in sent
+            if to is None:
+                to = mail['To']
+            logging.debug('mail list reply to: %s' % to)
+            # Cleaning the 'To' in this case
+            envelope.__delitem__('To')
+
+        # Finally setup the 'To' header
         envelope.add('To', decode_header(to))
 
         # if any of the recipients is a mailinglist that we are subscribed to,

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -209,6 +209,9 @@ followup_to = boolean(default=False)
 # The list of addresses associated to the mailinglists you are subscribed to
 mailinglists = force_list(default=list())
 
+# Automatically switch to list reply mode if appropriate
+auto_replyto_mailinglist = boolean(default=False)
+
 # prefer plaintext alternatives over html content in multipart/alternative
 prefer_plaintext = boolean(default=False)
 

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -56,6 +56,16 @@
     :default: True
 
 
+.. _auto_replyto_mailinglist:
+
+.. describe:: auto_replyto_mailinglist
+
+     Automatically switch to list reply mode if appropriate
+
+    :type: boolean
+    :default: False
+
+
 .. _bufferclose-focus-offset:
 
 .. describe:: bufferclose_focus_offset

--- a/docs/source/usage/modes/thread.rst
+++ b/docs/source/usage/modes/thread.rst
@@ -167,6 +167,7 @@ The following commands are available in thread mode
 
     optional arguments
         :---all: reply to all.
+        :---list: reply to list.
         :---spawn: open editor in new window.
 
 .. _cmd.thread.save:


### PR DESCRIPTION
Hi there,
as I wanted a way to reply quite simply to mailing list, see that 'old' PR:
https://github.com/pazz/alot/pull/479#issuecomment-152750321

Then I started to brew it for my use (I read many mailing list, thanks to notmuch / alot),
and I works well in my case, so here a quick sum up:
* It add --list to ':reply' to change the recipient header directly.
* It also add an option to activate, auto detect to reply to avoid adding --list all the time.
* The auto detect option is off by default so may not break other user's work-flow.

I try to keep it simple, and stick to the Mutt-like (L) Reply to the list,
so I do not added copy sender as cc because, it can be see as bad practice,
but maybe later.

Guillaume.