### PR TITLE
Add a .desktop file.

### DIFF
--- a/extra/alot.desktop
+++ b/extra/alot.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=alot
+Categories=Office;Email;ConsoleOnly;
+GenericName=Email client
+Comment=Terminal MUA using notmuch mail
+Exec=alot compose %u
+Terminal=true
+Type=Application
+MimeType=x-scheme-handler/mailto;


### PR DESCRIPTION
This file can enable desktop environments to use alot for mailto links and
display it in application menus.  It also enables alot to be used with
xdg-email(1) and friends.