### PR TITLE
Fix version number for development.

### DIFF
--- a/alot/__init__.py
+++ b/alot/__init__.py
@@ -1,5 +1,5 @@
 __productname__ = 'alot'
-__version__ = '0.3.6+'
+__version__ = '0.3.7.dev1'
 __copyright__ = "Copyright (C) 2014 Patrick Totzke"
 __author__ = "Patrick Totzke"
 __author_email__ = "patricktotzke@gmail.com"


### PR DESCRIPTION
Setuptools gave an error message and asked to conform to PEP440.
https://www.python.org/dev/peps/pep-0440/#developmental-releases