### PR TITLE
Unthreaded Search Mode Results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.py[co]
 *.log
 *.swp
+*~
 *.egg-info/
 /bin
 /build

--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -258,7 +258,7 @@ class SearchBuffer(Buffer):
         else:
             order = self.sort_order
 
-        if self._threaded:
+        if self._threaded == 'yes':
             func = self.dbman.get_threads
         else:
             func = self.dbman.get_messages

--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -211,6 +211,7 @@ class SearchBuffer(Buffer):
                 'newest_first': 'oldest_first'}
 
     def __init__(self, ui, initialquery='', sort_order=None):
+        self._threaded = settings.get('threaded')
         self.dbman = ui.dbman
         self.ui = ui
         self.querystring = initialquery
@@ -257,9 +258,14 @@ class SearchBuffer(Buffer):
         else:
             order = self.sort_order
 
+        if self._threaded:
+            func = self.dbman.get_threads
+        else:
+            func = self.dbman.get_messages
         try:
-            self.pipe, self.proc = self.dbman.get_threads(self.querystring,
-                                                          order)
+
+            self.pipe, self.proc = func(self.querystring,
+                                        order)
         except NotmuchError:
             self.ui.notify('malformed query string: %s' % self.querystring,
                            'error')

--- a/alot/commands/search.py
+++ b/alot/commands/search.py
@@ -8,6 +8,7 @@ from alot.commands import Command, registerCommand
 from alot.commands.globals import PromptCommand
 from alot.commands.globals import MoveCommand
 
+from alot.settings import settings
 from alot.db.errors import DatabaseROError
 from alot import commands
 from alot import buffers
@@ -32,12 +33,18 @@ class OpenThreadCommand(Command):
         if not self.thread:
             self.thread = ui.current_buffer.get_selected_thread()
         if self.thread:
-            query = ui.current_buffer.querystring
-            logging.info('open thread view for %s' % self.thread)
+            if settings.get('threaded'):
+                query = ui.current_buffer.querystring
+                logging.info('open thread view for %s' % self.thread)
 
-            sb = buffers.ThreadBuffer(ui, self.thread)
-            ui.buffer_open(sb)
-            sb.unfold_matching(query)
+                sb = buffers.ThreadBuffer(ui, self.thread)
+                ui.buffer_open(sb)
+                sb.unfold_matching(query)
+            else:
+                sb = buffers.ThreadBuffer(ui, self.thread)
+                ui.buffer_open(sb)
+                sb.collapse_all()
+                sb.unfold_matching("id:" + self.thread._mid, True)
 
 
 @registerCommand(MODE, 'refine', help='refine query', arguments=[

--- a/alot/commands/search.py
+++ b/alot/commands/search.py
@@ -33,7 +33,7 @@ class OpenThreadCommand(Command):
         if not self.thread:
             self.thread = ui.current_buffer.get_selected_thread()
         if self.thread:
-            if settings.get('threaded'):
+            if settings.get('threaded') != 'semi':
                 query = ui.current_buffer.querystring
                 logging.info('open thread view for %s' % self.thread)
 

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -1013,7 +1013,7 @@ class ThreadSelectCommand(Command):
         if isinstance(focus, AttachmentWidget):
             logging.info('open attachment')
             ui.apply_command(OpenAttachmentCommand(focus.get_attachment()))
-        else:
+        elif settings.get('threaded') != 'no':
             ui.apply_command(ChangeDisplaymodeCommand(visible='toggle'))
 
 

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -36,6 +36,7 @@ class Message(object):
         self._id = msg.get_message_id()
         self._thread_id = msg.get_thread_id()
         self._thread = thread
+        self._subject = msg.get_header('Subject')
         casts_date = lambda: datetime.fromtimestamp(msg.get_date())
         self._datetime = helper.safely_get(casts_date,
                                            ValueError, None)

--- a/alot/db/thread.py
+++ b/alot/db/thread.py
@@ -297,6 +297,7 @@ class SingleMessageDummyThread(Thread):
         :param message: the wrapped message
         :type message: :class:`alot.db.Message`
         """
+        self._threaded = settings.get('threaded')
         self._dbman = dbman
         self._id = message.get_thread_id()
         self._mid = message.get_message_id()
@@ -396,6 +397,42 @@ class SingleMessageDummyThread(Thread):
         :rtype: list of (str, str)
         """
         return [self.message.get_author()]
+
+    def get_toplevel_messages(self):
+        """
+        returns all toplevel messages contained in this thread.
+        This are all the messages without a parent message
+        (identified by 'in-reply-to' or 'references' header.
+
+        :rtype: list of :class:`~alot.db.message.Message`
+        """
+        if self._threaded == 'semi':
+            return Thread.get_toplevel_messages(self)
+        return [self.message]
+
+    def get_messages(self):
+        """
+        returns all messages in this thread as dict mapping all contained
+        messages to their direct responses.
+
+        :rtype: dict mapping :class:`~alot.db.message.Message` to a list of
+                :class:`~alot.db.message.Message`.
+        """
+        if self._threaded == 'semi':
+            return Thread.get_messages(self)
+        return {self.message: []}
+
+    def get_replies_to(self, msg):
+        """
+        returns all replies to the given message contained in this thread.
+
+        :param msg: parent message to look up
+        :type msg: :class:`~alot.db.message.Message`
+        :returns: list of :class:`~alot.db.message.Message` or `None`
+        """
+        if self._threaded == 'semi':
+            return Thread.get_replies_to(self, msg)
+        return []
 
     def get_subject(self):
         """returns subject string"""

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -1,5 +1,8 @@
+# show search results in threaded mode (versus individual messages)
+threaded = boolean(default=True)
 
-ask_subject = boolean(default=True) # ask for subject when compose
+# ask for subject when compose
+ask_subject = boolean(default=True)
 
 # automatically remove 'unread' tag when focussing messages in thread mode
 auto_remove_unread = boolean(default=True)

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -1,5 +1,5 @@
 # show search results in threaded mode (versus individual messages)
-threaded = boolean(default=True)
+threaded = option('yes', 'semi', 'no', default='yes')
 
 # ask for subject when compose
 ask_subject = boolean(default=True)

--- a/alot/widgets/search.py
+++ b/alot/widgets/search.py
@@ -61,7 +61,7 @@ class ThreadlineWidget(urwid.AttrMap):
             part = AttrFlipWidget(urwid.Text(datestring), struct['date'])
 
         elif name == 'mailcount':
-            if self._threaded:
+            if self._threaded == 'yes':
                 if self.thread:
                     mailcountstring = "(%d)" % self.thread.get_total_messages()
                 else:
@@ -138,7 +138,7 @@ class ThreadlineWidget(urwid.AttrMap):
 
     def rebuild(self):
         self.thread = self.dbman.get_thread(self.id,
-                                            dummy=(not self._threaded))
+                                            dummy=(self._threaded != 'yes'))
         self.widgets = []
         columns = []
         self.structure = settings.get_threadline_theming(self.thread)

--- a/alot/widgets/search.py
+++ b/alot/widgets/search.py
@@ -18,9 +18,10 @@ class ThreadlineWidget(urwid.AttrMap):
     selectable line widget that represents a :class:`~alot.db.Thread`
     in the :class:`~alot.buffers.SearchBuffer`.
     """
-    def __init__(self, tid, dbman):
+    def __init__(self, id, dbman):
+        self._threaded = settings.get('threaded')
         self.dbman = dbman
-        self.tid = tid
+        self.id = id
         self.thread = None  # will be set by refresh()
         self.tag_widgets = []
         self.structure = None
@@ -60,11 +61,14 @@ class ThreadlineWidget(urwid.AttrMap):
             part = AttrFlipWidget(urwid.Text(datestring), struct['date'])
 
         elif name == 'mailcount':
-            if self.thread:
-                mailcountstring = "(%d)" % self.thread.get_total_messages()
+            if self._threaded:
+                if self.thread:
+                    mailcountstring = "(%d)" % self.thread.get_total_messages()
+                else:
+                    mailcountstring = "(?)"
+                mailcountstring = pad(mailcountstring)
             else:
-                mailcountstring = "(?)"
-            mailcountstring = pad(mailcountstring)
+                mailcountstring = ' '
             width = len(mailcountstring)
             mailcount_w = AttrFlipWidget(urwid.Text(mailcountstring),
                                          struct['mailcount'])
@@ -133,7 +137,8 @@ class ThreadlineWidget(urwid.AttrMap):
         return width, part
 
     def rebuild(self):
-        self.thread = self.dbman.get_thread(self.tid)
+        self.thread = self.dbman.get_thread(self.id,
+                                            dummy=(not self._threaded))
         self.widgets = []
         columns = []
         self.structure = settings.get_threadline_theming(self.thread)


### PR DESCRIPTION
I'm not sure if this is something that is wanted in the main project (I can just keep it on my machine if not), but I figured I'd put it up here in case it is useful to others.

Just trying out alot for the first time, and one of the things I missed from mutt was the ability to turn threading off, and just have the search mode view show individual messages.

This changeset implements a couple of different behaviors in this vein, controlled by a config variable `threaded`:

* if `threaded` is `'yes'` (the default), then alot runs as before.
* if `threaded` is `'no'`, then alot will show individual messages instead of threads in search mode, and will only display the single selected message when entering thread mode.
* if `threaded` is `'semi'`, then alot will show individual messages in search mode, and when entering thread mode, it will open the entire thread, but it will focus on the particular message that was selected.