### PR TITLE
Custom Headers, Ordered Headers, ask_to option

### DIFF
--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -343,7 +343,9 @@ class EditCommand(Command):
 
         # decode header
         headertext = u''
-        for key in edit_headers:
+        for key in self.envelope.headers:
+            if key not in edit_headers:
+                continue
             vlist = self.envelope.get_all(key)
             if not vlist:
                 # ensure editable headers are present in template

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -830,6 +830,10 @@ class ComposeCommand(Command):
             subject = ''
         self.envelope.add('Subject', subject)
 
+        # add custom headers
+        for (k, v) in settings.custom_headers.iteritems():
+            self.envelope.add(k, v)
+
         if settings.get('compose_ask_tags'):
             comp = TagsCompleter(ui.dbman)
             tagsstring = yield ui.prompt('Tags', completer=comp)

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -801,34 +801,34 @@ class ComposeCommand(Command):
             self.envelope.sign_key = account.gpg_key
 
         # get missing To header
-        if (settings.get('ask_to') and
-                'To' not in self.envelope.headers):
-            allbooks = not settings.get('complete_matching_abook_only')
-            logging.debug(allbooks)
-            if account is not None:
-                abooks = settings.get_addressbooks(order=[account],
-                                                   append_remaining=allbooks)
-                logging.debug(abooks)
-                completer = ContactsCompleter(abooks)
+        if 'To' not in self.envelope.headers:
+            if settings.get('ask_to'):
+                allbooks = not settings.get('complete_matching_abook_only')
+                logging.debug(allbooks)
+                if account is not None:
+                    abooks = settings.get_addressbooks(order=[account],
+                                                       append_remaining=allbooks)
+                    logging.debug(abooks)
+                    completer = ContactsCompleter(abooks)
+                else:
+                    completer = None
+                to = yield ui.prompt('To',
+                                     completer=completer)
+                if to is None:
+                    raise CommandCanceled()
             else:
-                completer = None
-            to = yield ui.prompt('To',
-                                 completer=completer)
-            if to is None:
-                raise CommandCanceled()
-        else:
-            to = ''
-        self.envelope.add('To', to.strip(' \t\n,'))
+                to = ''
+            self.envelope.add('To', to.strip(' \t\n,'))
 
-        if (settings.get('ask_subject') and
-                'Subject' not in self.envelope.headers):
-            subject = yield ui.prompt('Subject')
-            logging.debug('SUBJECT: "%s"' % subject)
-            if subject is None:
-                raise CommandCanceled()
-        else:
-            subject = ''
-        self.envelope.add('Subject', subject)
+        if 'Subject' not in self.envelope.headers:
+            if settings.get('ask_subject'):
+                subject = yield ui.prompt('Subject')
+                logging.debug('SUBJECT: "%s"' % subject)
+                if subject is None:
+                    raise CommandCanceled()
+            else:
+                subject = ''
+            self.envelope.add('Subject', subject)
 
         # add custom headers
         for (k, v) in settings.custom_headers.iteritems():

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -801,7 +801,8 @@ class ComposeCommand(Command):
             self.envelope.sign_key = account.gpg_key
 
         # get missing To header
-        if 'To' not in self.envelope.headers:
+        if (settings.get('ask_to') and
+                'To' not in self.envelope.headers):
             allbooks = not settings.get('complete_matching_abook_only')
             logging.debug(allbooks)
             if account is not None:
@@ -815,17 +816,19 @@ class ComposeCommand(Command):
                                  completer=completer)
             if to is None:
                 raise CommandCanceled()
+        else:
+            to = ''
+        self.envelope.add('To', to.strip(' \t\n,'))
 
-            self.envelope.add('To', to.strip(' \t\n,'))
-
-        if settings.get('ask_subject') and \
-                'Subject' not in self.envelope.headers:
+        if (settings.get('ask_subject') and
+                'Subject' not in self.envelope.headers):
             subject = yield ui.prompt('Subject')
             logging.debug('SUBJECT: "%s"' % subject)
             if subject is None:
                 raise CommandCanceled()
-
-            self.envelope.add('Subject', subject)
+        else:
+            subject = ''
+        self.envelope.add('Subject', subject)
 
         if settings.get('compose_ask_tags'):
             comp = TagsCompleter(ui.dbman)

--- a/alot/db/envelope.py
+++ b/alot/db/envelope.py
@@ -9,6 +9,7 @@ from email.encoders import encode_7or8bit
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.mime.application import MIMEApplication
+from collections import OrderedDict
 
 from alot import __version__
 import logging
@@ -70,7 +71,7 @@ class Envelope(object):
             logging.debug('PARSED TEMPLATE: %s' % template)
             logging.debug('BODY: %s' % self.body)
         self.body = bodytext or u''
-        self.headers = headers or {}
+        self.headers = OrderedDict(headers or {})
         self.attachments = list(attachments)
         self.sign = sign
         self.sign_key = sign_key
@@ -303,7 +304,7 @@ class Envelope(object):
 
             # remove existing content
             if reset:
-                self.headers = {}
+                self.headers = OrderedDict()
 
             # go through multiline, utf-8 encoded headers
             # we decode the edited text ourselves here as

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -1,6 +1,9 @@
 
 ask_subject = boolean(default=True) # ask for subject when compose
 
+# ask for recipient when composing
+ask_to = boolean(default=True)
+
 # automatically remove 'unread' tag when focussing messages in thread mode
 auto_remove_unread = boolean(default=True)
 

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -106,6 +106,15 @@ class SettingsManager(object):
 
         self._accounts = self._parse_accounts(self._config)
         self._accountmap = self._account_table(self._accounts)
+        self.custom_headers = self._parse_custom_headers(self._config)
+
+    def _parse_custom_headers(self, config):
+        """
+        read in custom headers from config file
+        """
+        if 'custom_headers' not in config:
+            return {}
+        return {k:v for (k,v) in config['custom_headers'].iteritems()}
 
     def _parse_accounts(self, config):
         """


### PR DESCRIPTION
Again, just a few more changes that I was interested in for myself, sharing in case they are useful.  This changeset:

* adds an option `ask_to`, for whether to ask for the `To` header when composing mail
* always adds `To` and `Subject` to the `Envelope`, regardless of the values of `ask_to` and `ask_subject` (so that they show up when editing the file)
* modifies `Envelope` to store headers in the order they were added, and uses this to ensure some kind of sane ordering in the file when editing
* allows adding custom headers, via a `custom_headers` section in the config file