### PR TITLE
don't indent threads if an option is set

### DIFF
--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -363,12 +363,15 @@ class ThreadBuffer(Buffer):
 
         bars_att = settings.get_theming_attribute('thread', 'arrow_bars')
         heads_att = settings.get_theming_attribute('thread', 'arrow_heads')
-        A = ArrowTree(self._tree,
-                      indent=2,
-                      childbar_offset=0,
-                      arrow_tip_att=heads_att,
-                      arrow_att=bars_att,
-                      )
+        if settings.get('indent_threads'):
+            A = ArrowTree(self._tree,
+                          indent=2,
+                          childbar_offset=0,
+                          arrow_tip_att=heads_att,
+                          arrow_att=bars_att,
+                          )
+        else:
+            A = self._tree
         self._nested_tree = NestedTree(A, interpret_covered=True)
         self.body = TreeBox(self._nested_tree)
         self.message_count = self.thread.get_total_messages()

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -1,3 +1,5 @@
+# indent threads in thread mode
+indent_threads = boolean(default=True)
 
 ask_subject = boolean(default=True) # ask for subject when compose
 


### PR DESCRIPTION
This small change allows the option to prevent indenting threads, via a new config option `indent_threads`.  The default is the current behavior.
