### PR TITLE
Do not crash when emails' date is malformated.

### DIFF
--- a/alot/widgets/search.py
+++ b/alot/widgets/search.py
@@ -54,7 +54,8 @@ class ThreadlineWidget(urwid.AttrMap):
             datestring = ''
             if self.thread:
                 newest = self.thread.get_newest_date()
-                datestring = settings.represent_datetime(newest)
+                if newest != None:
+                    datestring = settings.represent_datetime(newest)
             datestring = pad(datestring)
             width = len(datestring)
             part = AttrFlipWidget(urwid.Text(datestring), struct['date'])


### PR DESCRIPTION
I could not get alot to start, and as a new user, I was a little bit frustrated.

I was getting the following backtrace on start:
````python
Traceback (most recent call last):
  File "/usr/bin/alot", line 20, in <module>
    main()
  File "/usr/share/alot/alot/init.py", line 186, in main
    UI(dbman, cmdstring)
  File "/usr/share/alot/alot/ui.py", line 87, in __init__
    self.mainloop.run()
  File "/usr/lib/python2.7/dist-packages/urwid/main_loop.py", line 278, in run
    self._run()
  File "/usr/lib/python2.7/dist-packages/urwid/main_loop.py", line 376, in _run
    self.event_loop.run()
  File "/usr/lib/python2.7/dist-packages/urwid/main_loop.py", line 1200, in wrapper
    rval = f(*args,**kargs)
  File "/usr/lib/python2.7/dist-packages/urwid/main_loop.py", line 1159, in _twisted_idle_callback
    callback()
  File "/usr/lib/python2.7/dist-packages/urwid/main_loop.py", line 564, in entering_idle
    self.draw_screen()
  File "/usr/lib/python2.7/dist-packages/urwid/main_loop.py", line 578, in draw_screen
    canvas = self._topmost_widget.render(self.screen_size, focus=True)
  File "/usr/lib/python2.7/dist-packages/urwid/widget.py", line 141, in cached_render
    canv = fn(self, size, focus=focus)
  File "/usr/lib/python2.7/dist-packages/urwid/decoration.py", line 225, in render
    canv = self._original_widget.render(size, focus=focus)
  File "/usr/lib/python2.7/dist-packages/urwid/widget.py", line 141, in cached_render
    canv = fn(self, size, focus=focus)
  File "/usr/lib/python2.7/dist-packages/urwid/container.py", line 1083, in render
    focus and self.focus_part == 'body')
  File "/usr/share/alot/alot/buffers.py", line 37, in render
    return self.body.render(size, focus)
  File "/usr/lib/python2.7/dist-packages/urwid/widget.py", line 141, in cached_render
    canv = fn(self, size, focus=focus)
  File "/usr/lib/python2.7/dist-packages/urwid/listbox.py", line 457, in render
    (maxcol, maxrow), focus=focus)
  File "/usr/lib/python2.7/dist-packages/urwid/listbox.py", line 339, in calculate_visible
    self._set_focus_complete( (maxcol, maxrow), focus )
  File "/usr/lib/python2.7/dist-packages/urwid/listbox.py", line 704, in _set_focus_complete
    (maxcol,maxrow), focus)
  File "/usr/lib/python2.7/dist-packages/urwid/listbox.py", line 674, in _set_focus_first_selectable
    (maxcol, maxrow), focus=focus)
  File "/usr/lib/python2.7/dist-packages/urwid/listbox.py", line 342, in calculate_visible
    focus_widget, focus_pos = self.body.get_focus()
  File "/usr/share/alot/alot/walker.py", line 25, in get_focus
    return self._get_at_pos(self.focus)
  File "/usr/share/alot/alot/walker.py", line 58, in _get_at_pos
    widget = self._get_next_item()
  File "/usr/share/alot/alot/walker.py", line 71, in _get_next_item
    next_widget = self.containerclass(next_obj, **self.kwargs)
  File "/usr/share/alot/alot/widgets/search.py", line 27, in __init__
    self.rebuild()
  File "/usr/share/alot/alot/widgets/search.py", line 149, in rebuild
    minw, maxw, align_mode)
  File "/usr/share/alot/alot/widgets/search.py", line 58, in _build_part
    datestring = settings.represent_datetime(newest)
  File "/usr/share/alot/alot/settings/manager.py", line 454, in represent_datetime
    rep = pretty_datetime(d)
  File "/usr/share/alot/alot/helper.py", line 255, in pretty_datetime
    ampm = d.strftime('%P')
AttributeError: 'NoneType' object has no attribute '
````

After some work, I found that the culprit is an email from an e-commerce website whose date field is malformed. Here is how the header shows on alot:
````
  Date             20110109
````

On other emails, date format is always like this:
````
  Date                      Fri, 15 Jan 2016 06:39:17 -0800
````
My patch is naive, in that it fixes the symptom (backtrace above) not the core issue (internal alot structures get messed up when email formatting is off).