### PR TITLE
Fix docstring for alot.addressbook.AddressBook.

### DIFF
--- a/alot/addressbook/__init__.py
+++ b/alot/addressbook/__init__.py
@@ -15,7 +15,7 @@ class AddressBook(object):
 
         This is an abstract class that leaves :meth:`get_contacts`
         unspecified. See :class:`AbookAddressBook` and
-        :class:`MatchSdtoutAddressbook` for implementations.
+        :class:`ExternalAddressbook` for implementations.
     """
     def __init__(self, ignorecase=True):
         self.reflags = re.IGNORECASE if ignorecase else 0


### PR DESCRIPTION
The name of the referenced class was changed in
637b679003b353d2630fed8ca942f3ab522e68b5.