### PR TITLE
Tagging hook

### DIFF
--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -264,6 +264,11 @@ class DBManager(object):
 
     def _append_queue(self, command, afterwards, querystring, tags):
         self.writequeue.append((command, afterwards, querystring, tags))
+        tagging_hook = settings.get_hook('pre_tagging')
+        if tagging_hook:
+            res = tagging_hook(command, querystring, tags)
+            if res:
+                tags = res
 
     def count_messages(self, querystring):
         """returns number of messages that match `querystring`"""

--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -234,9 +234,10 @@ class DBManager(object):
         if self.ro:
             raise DatabaseROError()
         if remove_rest:
-            self.writequeue.append(('set', afterwards, querystring, tags))
+            command = 'set'
         else:
-            self.writequeue.append(('tag', afterwards, querystring, tags))
+            command = 'tag'
+        self._append_queue(command, afterwards, querystring, tags)
 
     def untag(self, querystring, tags, afterwards=None):
         """
@@ -259,7 +260,10 @@ class DBManager(object):
         """
         if self.ro:
             raise DatabaseROError()
-        self.writequeue.append(('untag', afterwards, querystring, tags))
+        self._append_queue('untag', afterwards, querystring, tags)
+
+    def _append_queue(self, command, afterwards, querystring, tags):
+        self.writequeue.append((command, afterwards, querystring, tags))
 
     def count_messages(self, querystring):
         """returns number of messages that match `querystring`"""


### PR DESCRIPTION
Here is an example of a simple hook to keep a log of the tagging commands:

``` python
import json
def pre_tagging(command, query, tags):
    with open('tagging.log', 'a') as h:
        doc = {'command': command, 'query': query, 'tags': tags}
        h.write(json.dumps(doc) + '\n')
```
