### PR TITLE
Encrypt for the CC and Bcc addresses too

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -7,7 +7,6 @@ import email
 import glob
 import logging
 import os
-import re
 import subprocess
 from StringIO import StringIO
 
@@ -17,7 +16,7 @@ from twisted.internet import threads
 
 from . import Command, registerCommand
 from . import CommandCanceled
-from .utils import get_keys
+from .utils import set_encrypt
 from .. import commands
 
 from .. import buffers
@@ -864,12 +863,12 @@ class ComposeCommand(Command):
             logging.debug("Trying to encrypt message because encrypt=%s and "
                           "encrypt_by_default=%s", self.encrypt,
                           account.encrypt_by_default)
-            yield self._set_encrypt(ui, self.envelope)
+            yield set_encrypt(ui, self.envelope, block_error=self.encrypt)
         elif account.encrypt_by_default == u"trusted":
             logging.debug("Trying to encrypt message because "
                           "account.encrypt_by_default=%s",
                           account.encrypt_by_default)
-            yield self._set_encrypt(ui, self.envelope, trusted_only=True)
+            yield set_encrypt(ui, self.envelope, block_error=self.encrypt, signed_only=True)
         else:
             logging.debug("No encryption by default, encrypt_by_default=%s",
                           account.encrypt_by_default)
@@ -878,38 +877,6 @@ class ComposeCommand(Command):
                                             spawn=self.force_spawn,
                                             refocus=False)
         ui.apply_command(cmd)
-
-    @inlineCallbacks
-    def _set_encrypt(self, ui, envelope, trusted_only=False):
-        """Find and set the encryption keys in an envolope.
-
-        :param ui: the main user interface object
-        :type ui: alot.ui.UI
-        :param envolope: the envolope buffer object
-        :type envolope: alot.buffers.EnvelopeBuffer
-        :param trusted_only: only add keys to the list of encryption
-            keys whose uid is signed (trusted to belong to the key)
-        :type trusted_only: bool
-
-        """
-        encrypt_keys = []
-        for recipient in envelope.headers['To'][0].split(','):
-            recipient = recipient.strip()
-            if not recipient:
-                continue
-            match = re.search("<(.*@.*)>", recipient)
-            if match:
-                recipient = match.group(1)
-            encrypt_keys.append(recipient)
-
-        logging.debug("encryption keys: %s", encrypt_keys)
-        keys = yield get_keys(ui, encrypt_keys, block_error=self.encrypt,
-                              signed_only=trusted_only)
-        if keys:
-            envelope.encrypt_keys.update(keys)
-            envelope.encrypt = True
-        else:
-            envelope.encrypt = False
 
 
 @registerCommand(

--- a/alot/commands/utils.py
+++ b/alot/commands/utils.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2015  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
+import re
+import logging
 from twisted.internet.defer import inlineCallbacks, returnValue
 
 from ..errors import GPGProblem, GPGCode
@@ -8,7 +10,45 @@ from .. import crypto
 
 
 @inlineCallbacks
-def get_keys(ui, encrypt_keyids, block_error=False, signed_only=False):
+def set_encrypt(ui, envelope, block_error=False, signed_only=False):
+    """Find and set the encryption keys in an envolope.
+
+    :param ui: the main user interface object
+    :type ui: alot.ui.UI
+    :param envolope: the envolope buffer object
+    :type envolope: alot.buffers.EnvelopeBuffer
+    :param block_error: wether error messages for the user should expire
+        automatically or block the ui
+    :type block_error: bool
+    :param signed_only: only use keys whose uid is signed (trusted to belong
+        to the key)
+    :type signed_only: bool
+    """
+    encrypt_keys = []
+    for header in ('To', 'Cc'):
+        if header not in envelope.headers:
+            continue
+
+        for recipient in envelope.headers[header][0].split(','):
+            if not recipient:
+                continue
+            match = re.search("<(.*@.*)>", recipient)
+            if match:
+                recipient = match.group(1)
+            encrypt_keys.append(recipient)
+
+    logging.debug("encryption keys: " + str(encrypt_keys))
+    keys = yield _get_keys(ui, encrypt_keys, block_error=block_error,
+                           signed_only=signed_only)
+    if keys:
+        envelope.encrypt_keys.update(keys)
+        envelope.encrypt = True
+    else:
+        envelope.encrypt = False
+
+
+@inlineCallbacks
+def _get_keys(ui, encrypt_keyids, block_error=False, signed_only=False):
     """Get several keys from the GPG keyring.  The keys are selected by keyid
     and are checked if they can be used for encryption.
 


### PR DESCRIPTION
If you activate encrypt on the envelop mode or you reply to an encrypted email by default only addresses in the To header are used to encrypt to, CC and BCC are not taking into account.

I'm solving this issue and also removing duplication of code.
