### PR TITLE
Add option to add a prefix line to signature

### DIFF
--- a/alot/account.py
+++ b/alot/account.py
@@ -45,6 +45,9 @@ class Account(object):
     """filename of signature file in attachment"""
     signature_as_attachment = None
     """attach signature file instead of appending its content to body text"""
+    signature_prefix = None
+    """line to prefix signature with in body of message"""
+
     abook = None
     """addressbook (:class:`addressbook.AddressBook`)
        managing this accounts contacts"""
@@ -52,9 +55,9 @@ class Account(object):
     def __init__(self, address=None, aliases=None, alias_regexp=None,
                  realname=None, gpg_key=None, signature=None,
                  signature_filename=None, signature_as_attachment=False,
-                 sent_box=None, sent_tags=['sent'], draft_box=None,
-                 draft_tags=['draft'], abook=None, sign_by_default=False,
-                 encrypt_by_default=False,
+                 signature_prefix=None, sent_box=None, sent_tags=['sent'],
+                 draft_box=None, draft_tags=['draft'], abook=None,
+                 sign_by_default=False, encrypt_by_default=False,
                  **rest):
         self.address = address
         self.aliases = aliases
@@ -64,6 +67,7 @@ class Account(object):
         self.signature = signature
         self.signature_filename = signature_filename
         self.signature_as_attachment = signature_as_attachment
+        self.signature_prefix = signature_prefix
         self.sign_by_default = sign_by_default
         self.encrypt_by_default = encrypt_by_default
         self.sent_box = sent_box

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -791,6 +791,10 @@ class ComposeCommand(Command):
                             if mimetype.startswith('text'):
                                 sigcontent = helper.string_decode(sigcontent,
                                                                   enc)
+                                if account.signature_prefix:
+                                    sigcontent = (account.signature_prefix
+                                                  + '\n'
+                                                  + sigcontent)
                                 self.envelope.body += '\n' + sigcontent
                     else:
                         ui.notify('could not locate signature: %s' % sig,

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -296,6 +296,10 @@ msg_summary_hides_threadwide_tags = boolean(default=True)
         # :ref:`signature_as_attachment <signature-as-attachment>` is set to True
         signature_filename = string(default=None)
 
+        # prefix to prepend to signature on the preceding line when signature
+        # is included in body text
+        signature_prefix = string(default=None)
+
         # Outgoing messages will be GPG signed by default if this is set to True.
         sign_by_default = boolean(default=False)
 

--- a/docs/source/configuration/accounts_table
+++ b/docs/source/configuration/accounts_table
@@ -113,6 +113,17 @@
     :default: None
 
 
+.. _signature-prefix:
+
+.. describe:: signature_prefix
+
+     line to prefix signature with if included in message body if
+     :ref:`signature_as_attachment <signature-as-attachment>` is set to False
+
+    :type: string
+    :default: None
+
+
 .. _sign-by-default:
 
 .. describe:: sign_by_default


### PR DESCRIPTION
Adds `signature_prefix` option (default `None`).

For example, if `signature_prefix` is set to "--", a signature file
containing the line "J. Hacker, head widget-frobber" would be rendered
(if included in the message body):

```
--
J. Hacker, head widget-frobber
```

This allows `alot` to emulate the default behavior of other MUAs (e.g.,
`mutt` or `sup`) - many other programs automatically assume a "--"
prefix for the signature file and so adding "--" to the file
itself causes the result to have two "--" lines in `mutt` or `xlock`.
