### PR TITLE
Improve and fix building of docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,6 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
+PYTHON        = python
 PAPER         =
 BUILDDIR      = build
 
@@ -43,13 +44,16 @@ help:
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 
 $(COMMAND_OPTION_TABLES): ../alot/commands/__init__.py
-	python source/generate_commands.py
+	$(PYTHON) source/generate_commands.py
 
 $(CONFIG_OPTION_TABLES): ../alot/defaults/alot.rc.spec
-	python source/generate_configs.py
+	$(PYTHON) source/generate_configs.py
 
 clean:
 	-rm -rf $(BUILDDIR)/*
+
+cleanall: clean
+	-rm -rf $(CONFIG_OPTION_TABLES) $(COMMAND_OPTION_TABLES)
 
 html: $(CONFIG_OPTION_TABLES) $(COMMAND_OPTION_TABLES)
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/source/generate_commands.py
+++ b/docs/source/generate_commands.py
@@ -1,7 +1,7 @@
 import sys
 import os
 HERE = os.path.dirname(__file__)
-sys.path.append(os.path.join(HERE, '..', '..', '..'))
+sys.path.append(os.path.join(HERE, '..', '..'))
 from alot.commands import *
 from alot.commands import COMMANDS
 import alot.buffers
@@ -58,7 +58,7 @@ def rstify_parser(parser):
         if len(parser._positionals._group_actions) == 1:
             out += "    argument\n"
             a = parser._positionals._group_actions[0]
-            out += ' '*8 + parser._positionals._group_actions[0].help
+            out += ' '*8 + str(parser._positionals._group_actions[0].help)
             if a.choices:
                 out += ". valid choices are: %s." % ','.join(['\`%s\`' % s for s
                                                               in a.choices])

--- a/docs/source/generate_configs.py
+++ b/docs/source/generate_configs.py
@@ -1,7 +1,7 @@
 import sys
 import os
 HERE = os.path.dirname(__file__)
-sys.path.append(os.path.join(HERE, '..', '..', '..'))
+sys.path.append(os.path.join(HERE, '..', '..'))
 from alot.commands import COMMANDS
 from configobj import ConfigObj
 from validate import Validator


### PR DESCRIPTION
I noticed some problems with the building of the docs when working on a new branch (saving cmd history to disk, PR coming soon).  I also notices this before: https://github.com/pazz/alot/pull/854#issuecomment-195501799  One of the commit here is also cherry picked from there.

About b5dd5b8:  Why were the generated files stored in git?  Was it necessary for readthedocs (maybe this is now fixed by 0f078ae)?  Otherwise I can replace b5dd5b8 with a commit that updates all generated files.
