### PR TITLE
Add a travis file, prepare to run tests on travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ addons:
     packages:
       # The gpgme build files are needed by the gpgme python module.
       - libgpgme11-dev
+      # The notmuch libs are needed to actually run alot.  The notmuch package
+      # should pull the correct libs.
+      - notmuch
 
 install:
   # urwid needs to be installed first.  The installation of urwidtrees will

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,3 +73,5 @@ script:
   - make -C docs html
   # Minimal test: Start alot in order to quit immediatly.
   - alot --config conf
+  # Run the testsuite.
+  - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 language: python
-sudo: true
 
 python:
   # We can add more version strings here when we support other python
   # versions.
   - "2.7"
 
+addons:
+  apt:
+    packages:
+      # The gpgme build files are needed by the gpgme python module.
+      - libgpgme11-dev
+
 install:
-  - sudo apt-get update
-  # The gpgme build files are needed by the gpgme python module.
-  - sudo apt-get -yqq install libgpgme11-dev
   # urwid needs to be installed first.  The installation of urwidtrees will
   # fail otherwise.
   # TODO This should be fixed upstream.

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,11 @@ install:
   - pip install .
   # Install sphinx for building the documentation of alot.
   - pip install sphinx
+  # Prepare a minimal config file for the final test.
+  - echo 'initial_command=call os._exit(0)' > conf
 
 script:
+  # Build the documentation for alot.
   - make -C docs html
+  # Minimal test: Start alot in order to quit immediatly.
+  - alot --config conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: python
+sudo: true
+
+python:
+  # We can add more version strings here when we support other python
+  # versions.
+  - "2.7"
+
+install:
+  - sudo apt-get update
+  # The gpgme build files are needed by the gpgme python module.
+  - sudo apt-get -yqq install libgpgme11-dev
+  # urwid needs to be installed first.  The installation of urwidtrees will
+  # fail otherwise.
+  # TODO This should be fixed upstream.
+  - pip install urwid
+  # Install alot and the dependencies it declares.
+  - pip install .
+  # Install sphinx for building the documentation of alot.
+  - pip install sphinx
+
+script:
+  - make -C docs html

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ install:
 
 before_script:
   # Prepare a minimal config file for the final test.
+  - touch ~/.notmuch-config
   - echo 'initial_command=call os._exit(0)' > conf
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,38 @@ python:
 addons:
   apt:
     packages:
-      # The gpgme build files are needed by the gpgme python module.
+      # The gpgme build files are needed by the gpgme python module
+      # (a dependency of alot).
       - libgpgme11-dev
       # The notmuch libs are needed to actually run alot.  The notmuch package
-      # should pull the correct libs.
-      - notmuch
+      # should pull the correct libs but currently the available version is
+      # not compatible with alot, so we have to build from source.
+      #- notmuch
+      # Dependencies to build notmuch from source.
+      - libxapian-dev
+      - libtalloc-dev
+      - zlib1g-dev
+
+# Build notmuch and the python notmuch libs manually.  The versions of the
+# notmuch library and the python module which are available in the 12.04 and
+# 14.04 Ubuntu repos do not match and do not fullfill the version requirement
+# for alot.
+before_install:
+  # Clone the notmuch repository and move into it.
+  - git clone git://notmuchmail.org/git/notmuch
+  - cd notmuch
+  # Make and install the library.  We install the library without sudo as we
+  # might want to switch to the travis container later.
+  - ./configure --prefix=$HOME/.local
+  - make
+  - make install
+  # Export the library search path.
+  - export LD_LIBRARY_PATH=$HOME/.local/lib
+  # Install the python bindings.
+  - cd bindings/python
+  - pip install .
+  # Move out of the notmuch dir again.
+  - cd ../../..
 
 install:
   # urwid needs to be installed first.  The installation of urwidtrees will
@@ -23,6 +50,8 @@ install:
   - pip install .
   # Install sphinx for building the documentation of alot.
   - pip install sphinx
+
+before_script:
   # Prepare a minimal config file for the final test.
   - echo 'initial_command=call os._exit(0)' > conf
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: true
 
 python:
   # We can add more version strings here when we support other python
@@ -25,6 +26,12 @@ addons:
 # 14.04 Ubuntu repos do not match and do not fullfill the version requirement
 # for alot.
 before_install:
+  - sudo apt-get update
+  # Until https://github.com/travis-ci/apt-package-whitelist/issues/3215 is
+  # resolved we have to install gmime with sudo.  Afterwards we can swtich to
+  # the container based infrastructure.
+  # gmime is needed to build notmuch from source.
+  - sudo apt-get -yqq install libgmime-2.6-dev
   # Clone the notmuch repository and move into it.
   - git clone git://notmuchmail.org/git/notmuch
   - cd notmuch

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: python
+
+# We need a newer version of zlib to build notmuch from source as is available
+# in precise.
+dist: trusty
+
 sudo: true
 
 python:

--- a/setup.py
+++ b/setup.py
@@ -34,4 +34,5 @@ setup(name='alot',
         'configobj>=4.7.0',
         'pygpgme>=0.2'],
       provides=['alot'],
+      test_suite="test",
       )

--- a/test/corpus.py
+++ b/test/corpus.py
@@ -1,0 +1,45 @@
+import tempfile
+import shutil
+from os import path
+from subprocess import call
+import atexit
+import notmuch
+
+
+class Corpus:
+    def __init__(self):
+        self.TESTDIR = tempfile.mkdtemp()
+        self.TESTCORPUS = path.join(self.TESTDIR, 'corpus')
+        HERE = path.dirname(path.realpath(__file__))
+
+        # copy over corpus
+        shutil.copytree(path.join(HERE,'corpus'), self.TESTCORPUS)
+
+        # create a temporary notmuch database
+        # create notmuch config file
+        notmuchconfig = path.join(self.TESTDIR, 'nmconfig')
+        cfile = open(notmuchconfig, 'w')
+        cfile.write("""
+        [database]
+        path=%s/
+        [new]
+        tags=new;
+        """ % self.TESTCORPUS)
+        cfile.close()
+
+        # index corpus
+        call(["notmuch", "--config=" + notmuchconfig, "new"])
+
+        print "CREATED %s" % self.TESTDIR
+
+    def __del__(self):
+        shutil.rmtree(self.TESTDIR)
+
+    def get_notmuch_msg_by_id(self, mid):
+        """
+        returns the `notmuch.Message` with given MessageID from the corpus
+        """
+        db = notmuch.Database(self.TESTCORPUS)
+        msgs = notmuch.Query(db, 'id:%s' % mid).search_messages()
+        msg = list(msgs)[0]
+        return msg

--- a/test/corpus/mail1.eml
+++ b/test/corpus/mail1.eml
@@ -1,0 +1,7 @@
+Date: Sun, 27 Mar 2016 17:25:35 +0100
+Message-ID: <TESTMAIL1@mail.com>
+Subject: TEST1
+From: sender <sender@test.com>
+To: recipient@test.com
+
+PLAINTEXT

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -1,0 +1,17 @@
+import unittest
+from corpus import Corpus
+import os
+
+
+class TestDatabase(unittest.TestCase):
+    def setUp(self):
+        self.corpus = Corpus()
+
+    def test_messagefile(self):
+        msg = self.corpus.get_notmuch_msg_by_id('TESTMAIL1@mail.com')
+        msgfile = os.path.basename(msg.get_filename())
+        self.assertEqual(msgfile, 'mail1.eml')
+
+    def tearDown(self):
+        del(self.corpus)
+


### PR DESCRIPTION
From the existence of https://github.com/pazz/alot/tree/0.3.8-unittests I take it that it is also planned to run these test somewhere.  So I suggest to use travis and start with this travis file.  I already set up travis for my fork of alot so you can see the build for this PR here: https://travis-ci.org/lucc/alot/branches

I initially did some more tests with travis wich can be found in my fork (branches travis-orig and travis-multi-os).
