### PR TITLE
Add option to handle servers with non-standard case-insensitive matching

### DIFF
--- a/alot/account.py
+++ b/alot/account.py
@@ -18,6 +18,132 @@ class StoreMailError(Exception):
     pass
 
 
+class _CaseInsensitiveUnicode(unicode):
+    """A subclass of unicode that matches case insensitive.
+
+    This behaves exactly like a standard Unicode object, except that it
+    overrides the rich comparison methods and __contains__ to do case
+    insensitve comparison.
+    """
+    # TODO: There are some cases that are not going to be handled correctly,
+    # the strip methods, for example, will return a standard Unicode object
+    # rather than a _CaseInsensitveUnicode.
+
+    def __lt__(self, other):
+        if isinstance(other, basestring):
+            return super(_CaseInsensitiveUnicode, self).lower() < other.lower()
+        return super(_CaseInsensitveStr, self).__lt__(other)
+
+    def __le__(self, other):
+        if isinstance(other, basestring):
+            return super(_CaseInsensitiveUnicode, self).lower() <= other.lower()
+        return super(_CaseInsensitveStr, self).__le__(other)
+
+    def __gt__(self, other):
+        if isinstance(other, basestring):
+            return super(_CaseInsensitiveUnicode, self).lower() > other.lower()
+        return super(_CaseInsensitveStr, self).__gt__(other)
+
+    def __ge__(self, other):
+        if isinstance(other, basestring):
+            return super(_CaseInsensitiveUnicode, self).lower() >= other.lower()
+        return super(_CaseInsensitveStr, self).__ge__(other)
+
+    def __eq__(self, other):
+        if isinstance(other, basestring):
+            return super(_CaseInsensitiveUnicode, self).lower() == other.lower()
+        return super(_CaseInsensitveStr, self).__eq__(other)
+
+    def __ne__(self, other):
+        if isinstance(other, basestring):
+            return super(_CaseInsensitiveUnicode, self).lower() != other.lower()
+        return super(_CaseInsensitveStr, self).__ne__(other)
+
+    def __contains__(self, other):
+        if isinstance(other, basestring):
+            return other.lower() in super(_CaseInsensitiveUnicode, self).lower()
+        return super(_CaseInsensitveStr, self).__contains__(other)
+
+    def capitalize(self):
+        return self
+
+    def center(self, *args, **kwargs):
+        return _CaseInsensitiveUnicode(
+            super(_CaseInsensitiveUnicode, self).center(*args, **kwargs))
+
+    def endswith(self, other, *args, **kwargs):
+        return super(_CaseInsensitiveUnicode, self).lower().endswith(
+            other.lower(), *args, **kwargs)
+
+    def expandtabs(self, *args, **kwargs):
+        return _CaseInsensitiveUnicode(
+            super(_CaseInsensitiveUnicode, self).expandtabs(*args, **kwargs))
+
+    def ljust(self, *args, **kwargs):
+        return _CaseInsensitiveUnicode(
+            super(_CaseInsensitiveUnicode, self).ljust(*args, **kwargs))
+
+    def lower(self):
+        return self
+
+    def lstrip(self, *args, **kwargs):
+        return _CaseInsensitiveUnicode(
+            super(_CaseInsensitiveUnicode, self).lstrip(*args, **kwargs))
+
+    def partition(self, *args, **kwargs):
+        return tuple(_CaseInsensitiveUnicode(s) for s in 
+                     super(_CaseInsensitiveUnicode, self).partition(
+                         *args, **kwargs))
+
+    def rjust(self, *args, **kwargs):
+        return _CaseInsensitiveUnicode(
+            super(_CaseInsensitiveUnicode, self).rjust(*args, **kwargs))
+
+    def rpartition(self, *args, **kwargs):
+        return tuple(_CaseInsensitiveUnicode(s) for s in 
+                     super(_CaseInsensitiveUnicode, self).rpartition(
+                         *args, **kwargs))
+
+    def rsplit(self, sep, **kwargs):
+        return [_CaseInsensitiveUnicode(s) for s in 
+                super(_CaseInsensitiveUnicode, self).lower().rsplit(
+                    sep.lower(), **kwargs)]
+
+    def rstrip(self, *args, **kwargs):
+        return _CaseInsensitiveUnicode(
+            super(_CaseInsensitiveUnicode, self).rstrip(*args, **kwargs))
+
+    def split(self, *args, **kwargs):
+        return [_CaseInsensitiveUnicode(s) for s in 
+                super(_CaseInsensitiveUnicode, self).lower().split(
+                    sep.lower(), **kwargs)]
+
+    def splitlines(self, *args, **kwargs):
+        return [_CaseInsensitiveUnicode(s) for s in 
+                super(_CaseInsensitiveUnicode, self).splitlines(*args, **kwargs)]
+
+    def startswith(self, other, *args, **kwargs):
+        return super(_CaseInsensitiveUnicode, self).lower().startswith(
+            other.lower(), *args, **kwargs)
+
+    def swapcase(self):
+        return self
+
+    def title(self):
+        return self
+
+    def translate(self, *args, **kwargs):
+        return _CaseInsensitiveUnicode(
+            super(_CaseInsensitiveUnicode, self).translate(*args, **kwargs))
+
+    def upper(self):
+        return self
+
+    def zfill(self, *args, **kwargs):
+        return _CaseInsensitiveUnicode(
+            super(_CaseInsensitiveUnicode, self).zfill(*args, **kwargs))
+
+
 class Account(object):
     """
     Datastructure that represents an email account. It manages this account's
@@ -54,8 +180,10 @@ class Account(object):
                  signature_filename=None, signature_as_attachment=False,
                  sent_box=None, sent_tags=['sent'], draft_box=None,
                  draft_tags=['draft'], abook=None, sign_by_default=False,
-                 encrypt_by_default=False,
+                 encrypt_by_default=False, non_standard_case_insensitive=False,
                  **rest):
+        if non_standard_case_insensitive:
+            address = _CaseInsensitiveUnicode(address)
         self.address = address
         self.aliases = aliases
         self.alias_regexp = alias_regexp

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -404,7 +404,7 @@ class SettingsManager(object):
         """
 
         for myad in self.get_addresses():
-            if myad in address:
+            if myad == address:
                 return self._accountmap[myad]
         return None
 

--- a/docs/source/configuration/accounts_table
+++ b/docs/source/configuration/accounts_table
@@ -143,3 +143,13 @@
     :type: string
     :default: None
 
+.. _non-standard-case-insensitive:
+
+.. describe:: non_standard_case_insensitive
+
+     If the server will match addresses without regard to case,
+     (foo@example.com == Foo@example.com). This is non-standard behavior, if
+     unsure leave False.
+
+     :type: boolean
+     :default: False

--- a/tests/test_case_insensitive.py
+++ b/tests/test_case_insensitive.py
@@ -1,0 +1,127 @@
+# encoding=utf-8
+# 
+# Copyright © 2016 Dylan Baker
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test module for the _CaseInsenstiveUnicode class."""
+
+from alot.account import _CaseInsensitiveUnicode as CU
+
+import pytest
+
+
+@pytest.fixture
+def inst():
+    return CU('fooBar')
+
+@pytest.fixture
+def spaced():
+    return CU(' fooBar  ')
+
+@pytest.mark.parametrize("value", [
+    'foobarx', 'FOOBARX', u'foobarx', u'FOOBARx'])
+def test_lt(value, inst):
+    assert inst < value
+
+@pytest.mark.parametrize("value", [
+    'foobarx', 'FOOBARX', u'foobarx', u'FOOBARx', 'foobarX', 'FOOBARx',
+    u'foobarX', u'FOOBARx'])
+def test_le(value, inst):
+    assert inst <= value
+
+@pytest.mark.parametrize("value", ['foobA', 'FOOBa', u'foobA', u'FOOBa'])
+def test_gt(value, inst):
+    assert inst > value
+
+@pytest.mark.parametrize("value", [
+    'fooba', 'FOOBA', u'fooba', u'FOOBA', 'fooba', 'FOOBA', u'fooba',
+    u'FOOBA'])
+def test_ge(value, inst):
+    assert inst >= value
+
+@pytest.mark.parametrize("value", [
+    'foobaR', 'FOOBAr', u'foobaR', u'FOOBAr', 'foobar', 'FOOBAR',
+    u'foobar', u'FOOBAR'])
+def test_eq(value, inst):
+    assert inst == value
+
+def test_contains(inst):
+    assert 'foo' in inst
+
+def test_capitalize(inst):
+    # Using "is" is the only straightforward way to test this, since most
+    # copy methods simply return self
+    assert inst.capitalize() is inst
+
+def test_center(inst):
+    assert inst.center(12) == '   {}   '.format(inst)
+
+def test_endswith(inst):
+    assert inst.endswith('BaR')
+
+def test_expandtabs():
+    inst = CU('\tfoo')
+    assert inst.expandtabs(2) == '  Foo'
+
+def test_ljust(inst):
+    assert inst.ljust(7) == 'foObar '
+
+def test_lower(inst):
+    # Using "is" is the only straightforward way to test this, since most
+    # copy methods simply return self
+    assert inst.lower() is inst
+
+def test_lstrip(spaced):
+    assert spaced.lstrip() == 'FoobaR  '
+
+def test_partition(inst):
+    assert ('fOo', 'b', 'Ar') == inst.partition('B')
+
+def test_rjust(inst):
+    assert inst.rjust(7) == ' foObar'
+
+def test_rsplit(inst):
+    assert inst.rsplit(u'b') == ['foo', 'ar']
+
+def test_rstrip(spaced):
+    assert spaced.rstrip() == ' FOObar'
+
+def test_split(inst):
+    assert inst.rsplit('o') == ['f', '', 'Bar']
+
+def test_splitlines():
+    inst = CU('foo\nbar\noink')
+    assert inst.splitlines() == ['foO', 'Bar', 'oiNk']
+
+def test_startswith(inst):
+    assert inst.startswith('FOo')
+
+def test_swapcase(inst):
+    # Using "is" is the only straightforward way to test this, since most
+    # copy methods simply return self
+    assert inst.swapcase() is inst
+
+def test_title(inst):
+    # Using "is" is the only straightforward way to test this, since most
+    # copy methods simply return self
+    assert inst.title() is inst
+
+def test_upper(inst):
+    # Using "is" is the only straightforward way to test this, since most
+    # copy methods simply return self
+    assert inst.upper() is inst
+
+def test_zfill(inst):
+    assert inst.zfill(8) == '00FoobAr'


### PR DESCRIPTION
Some email Servers (some versions of Exchange, possibly others) allow
matching email addresses without regard to case, this is problematic
because alot assumes the standard case sensitive behavior.

This patch addresses this issue by adding a new flag to the accounts
configuration "non_standard_case_insensitive", which defaults to False,
but when set to True will cause alot to match accounts without regard to
case. It does this is a non-intrusive manner using a subclass of unicode
with it's comparison methods overwritten to be case insensitive.

Fixes #847
