### PR TITLE
Add togglemimetree command in thread buffer

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -563,6 +563,7 @@ class ChangeDisplaymodeCommand(Command):
         self.visible = visible
         self.raw = raw
         self.all_headers = all_headers
+        self.mimetree = mimetree
         Command.__init__(self, **kwargs)
 
     def apply(self, ui):
@@ -591,6 +592,11 @@ class ChangeDisplaymodeCommand(Command):
             raw = not mt.display_source if self.raw == 'toggle' else self.raw
             all_headers = not mt.display_all_headers \
                 if self.all_headers == 'toggle' else self.all_headers
+            if self.mimetree == 'toggle':
+                tbuffer.focus_selected_message()
+            mimetree = not mt.display_mimetree \
+                if self.mimetree == 'toggle' else self.mimetree
+
 
             # collapse/expand depending on new 'visible' value
             if visible is False:
@@ -603,6 +609,8 @@ class ChangeDisplaymodeCommand(Command):
                 mt.display_source = raw
             if all_headers is not None:
                 mt.display_all_headers = all_headers
+            if mimetree is not None:
+                mt.display_mimetree = mimetree
             mt.debug()
             # let the messagetree reassemble itself
             mt.reassemble()

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -533,22 +533,29 @@ class EditNewCommand(Command):
     forced={'all_headers': 'toggle'},
     arguments=[(['query'], {'help': 'query used to filter messages to affect',
                             'nargs': '*'})])
+@registerCommand(
+    MODE, 'togglemimetree', help='disply mime tree of the message',
+    forced={'mimetree': 'toggle'},
+    arguments=[(['query'], {'help': 'query used to filter messages to affect',
+                            'nargs': '*'})])
 class ChangeDisplaymodeCommand(Command):
 
     """fold or unfold messages"""
     repeatable = True
 
     def __init__(self, query=None, visible=None, raw=None, all_headers=None,
-                 **kwargs):
+                 mimetree=None, **kwargs):
         """
         :param query: notmuch query string used to filter messages to affect
         :type query: str
         :param visible: unfold if `True`, fold if `False`, ignore if `None`
         :type visible: True, False, 'toggle' or None
-        :param raw: display raw message text.
+        :param raw: display raw message text
         :type raw: True, False, 'toggle' or None
         :param all_headers: show all headers (only visible if not in raw mode)
         :type all_headers: True, False, 'toggle' or None
+        :param mimetree: show the mime tree of the message
+        :type mimetree: True, False, 'toggle' or None
         """
         self.query = None
         if query:

--- a/alot/completion.py
+++ b/alot/completion.py
@@ -474,7 +474,8 @@ class CommandCompleter(Completer):
                     res = self._pathcompleter.complete(params, localpos)
                 elif self.mode == 'thread' and cmd in ['fold', 'unfold',
                                                        'togglesource',
-                                                       'toggleheaders']:
+                                                       'toggleheaders',
+                                                       'togglemimetree']:
                     res = self._querycompleter.complete(params, localpos)
                 elif self.mode == 'thread' and cmd in ['tag', 'retag', 'untag',
                                                        'toggletags']:

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -51,6 +51,7 @@ class Message(object):
             self._from = ''
         self._email = None  # will be read upon first use
         self._attachments = None  # will be read upon first use
+        self._mime_tree = None  # will be read upon first use
         self._tags = set(msg.get_tags())
 
     def __str__(self):
@@ -256,3 +257,21 @@ class Message(object):
         """tests if this messages is in the resultset for `querystring`"""
         searchfor = '( {} ) AND id:{}'.format(querystring, self._id)
         return self._dbman.count_messages(searchfor) > 0
+
+    def get_mime_tree(self):
+        if not self._mime_tree:
+            self._mime_tree = self._get_mimetree(self.get_email())
+        return self._mime_tree
+
+    @classmethod
+    def _get_mimetree(cls, message):
+        label = cls._get_mime_part_info(message)
+        if message.is_multipart():
+            return label, [cls._get_mimetree(m) for m in message.get_payload()]
+        else:
+            return label, None
+
+    @staticmethod
+    def _get_mime_part_info(mime_part):
+        return '{}: {}'.format(mime_part.get_content_type(), 
+                               mime_part.get_filename() or '(no filename)')

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -273,5 +273,8 @@ class Message(object):
 
     @staticmethod
     def _get_mime_part_info(mime_part):
-        return '{}: {}'.format(mime_part.get_content_type(), 
-                               mime_part.get_filename() or '(no filename)')
+        contenttype = mime_part.get_content_type()
+        filename = mime_part.get_filename() or '(no filename)'
+        charset = mime_part.get_content_charset() or ''
+        size = helper.humanize_size(len(mime_part.as_string()))
+        return ' '.join((contenttype, filename, charset, size))

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -319,9 +319,20 @@ class MessageTree(CollapsibleTree):
 
     def _get_mimetree(self):
         if self._mimetree is None:
-            mime_tree = self._message.get_mime_tree()
-            self._mimetree = SimpleTree([mime_tree])
+            mime_tree_txt = self._message.get_mime_tree()
+            mime_tree_widgets = self._text_tree_to_widget_tree(mime_tree_txt)
+            self._mimetree = SimpleTree([mime_tree_widgets])
         return self._mimetree
+
+    def _text_tree_to_widget_tree(self, tree):
+        att = settings.get_theming_attribute('thread', 'body')
+        att_focus = settings.get_theming_attribute('thread', 'body_focus')
+        label, subtrees = tree
+        label = FocusableText(label, att, att_focus)
+        if subtrees is None:
+            return label, None
+        else:
+            return label, [self._text_tree_to_widget_tree(s) for s in subtrees]
 
 
 class ThreadTree(Tree):

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -171,7 +171,9 @@ class MessageTree(CollapsibleTree):
         self._all_headers_tree = None
         self._default_headers_tree = None
         self.display_attachments = True
+        self._mimetree = None
         self._attachments = None
+        self.display_mimetree = False
         self._maintree = SimpleTree(self._assemble_structure())
         CollapsibleTree.__init__(self, self._maintree)
 
@@ -190,6 +192,7 @@ class MessageTree(CollapsibleTree):
         logging.debug('display_source %s', self.display_source)
         logging.debug('display_all_headers %s', self.display_all_headers)
         logging.debug('display_attachements %s', self.display_attachments)
+        logging.debug('display_mimetree %s', self.display_mimetree)
         logging.debug('AHT %s', str(self._all_headers_tree))
         logging.debug('DHT %s', str(self._default_headers_tree))
         logging.debug('MAINTREE %s', str(self._maintree._treelist))
@@ -198,6 +201,9 @@ class MessageTree(CollapsibleTree):
         mainstruct = []
         if self.display_source:
             mainstruct.append((self._get_source(), None))
+        elif self.display_mimetree:
+            mainstruct.append((self._get_headers(), None))
+            mainstruct.append((self._get_mimetree(), None))
         else:
             mainstruct.append((self._get_headers(), None))
 
@@ -310,6 +316,12 @@ class MessageTree(CollapsibleTree):
         value_att = settings.get_theming_attribute('thread', 'header_value')
         gaps_att = settings.get_theming_attribute('thread', 'header')
         return DictList(lines, key_att, value_att, gaps_att)
+
+    def _get_mimetree(self):
+        if self._mimetree is None:
+            mime_tree = self._message.get_mime_tree()
+            self._mimetree = SimpleTree([mime_tree])
+        return self._mimetree
 
 
 class ThreadTree(Tree):

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 
 import logging
 import urwid
-from urwidtrees import Tree, SimpleTree, CollapsibleTree
+from urwidtrees import Tree, SimpleTree, CollapsibleTree, ArrowTree
 
 from .globals import TagWidget
 from .globals import AttachmentWidget
@@ -319,9 +319,10 @@ class MessageTree(CollapsibleTree):
 
     def _get_mimetree(self):
         if self._mimetree is None:
-            mime_tree_txt = self._message.get_mime_tree()
-            mime_tree_widgets = self._text_tree_to_widget_tree(mime_tree_txt)
-            self._mimetree = SimpleTree([mime_tree_widgets])
+            tree = self._message.get_mime_tree()
+            tree = self._text_tree_to_widget_tree(tree)
+            tree = SimpleTree([tree])
+            self._mimetree = ArrowTree(tree)
         return self._mimetree
 
     def _text_tree_to_widget_tree(self, tree):


### PR DESCRIPTION
This is an attempt to implement #862.

The new command `:togglemimetree` will (similar to `:togglesource` and friends) change the displayed message.  It will toggle between the previous used representation and a text representation of the mime tree.

TODO list (also see #862)
- [x] implement basic command logic
- [x] extract a mime tree from the message
- [x] add nicer tree visualisation (line drawings)
  - [ ] nicer indent, formatting and coherence with other ArrowTrees
- [ ] make the mime parts in the tree accessible for other commands (see below)
- [ ] add a command to display a mime part with an external program (mailcap entry)
- [ ] add a command to save a single mime part to disk
- [ ] add a command to pipe a mime part to a shell command

For the line drawing I could use something like https://github.com/jml/tree-format but as we already do display line drawings for the thread tree I suppose there is some code in alot that can maybe help me.  @ Everybody: do you know where it might be?
