### PR TITLE
Introduce user-configurable ordering in header-based sender selection

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -61,35 +61,38 @@ def determine_sender(mail, action='reply'):
     # extract list of addresses to check for my address
     # X-Envelope-To and Envelope-To are used to store the recipient address
     # if not included in other fields
-    candidate_addresses = getaddresses(mail.get_all('To', []) +
-                                       mail.get_all('Cc', []) +
-                                       mail.get_all('Delivered-To', []) +
-                                       mail.get_all('X-Envelope-To', []) +
-                                       mail.get_all('Envelope-To', []) +
-                                       mail.get_all('From', []))
+    # Process the headers in order of importance: if a mail was sent with
+    # account X, with account Y in e.g. CC or delivered-to, make sure that
+    # account X is the one selected and not account Y.
+    for candidate_header in ['From', 'To', 'Cc', 'Envelope-To',
+                             'X-Envelope-To', 'Delivered-To']:
+        if realname is not None:
+            break
+        candidate_addresses = getaddresses(mail.get_all(candidate_header, []))
 
-    logging.debug('candidate addresses: %s' % candidate_addresses)
-    # pick the most important account that has an address in candidates
-    # and use that accounts realname and the address found here
-    for account in my_accounts:
-        acc_addresses = map(re.escape, account.get_addresses())
-        if account.alias_regexp is not None:
-            acc_addresses.append(account.alias_regexp)
-        for alias in acc_addresses:
-            if realname is not None:
-                break
-            regex = re.compile('^' + alias + '$', flags=re.IGNORECASE)
-            for seen_name, seen_address in candidate_addresses:
-                if regex.match(seen_address):
-                    logging.debug("match!: '%s' '%s'" % (seen_address, alias))
-                    if settings.get(action + '_force_realname'):
-                        realname = account.realname
-                    else:
-                        realname = seen_name
-                    if settings.get(action + '_force_address'):
-                        address = account.address
-                    else:
-                        address = seen_address
+        logging.debug('candidate addresses: %s' % candidate_addresses)
+        # pick the most important account that has an address in candidates
+        # and use that accounts realname and the address found here
+        for account in my_accounts:
+            acc_addresses = map(re.escape, account.get_addresses())
+            if account.alias_regexp is not None:
+                acc_addresses.append(account.alias_regexp)
+            for alias in acc_addresses:
+                if realname is not None:
+                    break
+                regex = re.compile('^' + alias + '$', flags=re.IGNORECASE)
+                for seen_name, seen_address in candidate_addresses:
+                    if regex.match(seen_address):
+                        logging.debug("match!: '%s' '%s'" % (seen_address,
+                                                             alias))
+                        if settings.get(action + '_force_realname'):
+                            realname = account.realname
+                        else:
+                            realname = seen_name
+                        if settings.get(action + '_force_address'):
+                            address = account.address
+                        else:
+                            address = seen_address
 
     # revert to default account if nothing found
     if realname is None:

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -64,8 +64,8 @@ def determine_sender(mail, action='reply'):
     # Process the headers in order of importance: if a mail was sent with
     # account X, with account Y in e.g. CC or delivered-to, make sure that
     # account X is the one selected and not account Y.
-    for candidate_header in ['From', 'To', 'Cc', 'Envelope-To',
-                             'X-Envelope-To', 'Delivered-To']:
+    candidate_headers = settings.get("determine_reply_account_from_headers")
+    for candidate_header in candidate_headers:
         if realname is not None:
             break
         candidate_addresses = getaddresses(mail.get_all(candidate_header, []))

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -64,7 +64,7 @@ def determine_sender(mail, action='reply'):
     # Process the headers in order of importance: if a mail was sent with
     # account X, with account Y in e.g. CC or delivered-to, make sure that
     # account X is the one selected and not account Y.
-    candidate_headers = settings.get("determine_reply_account_from_headers")
+    candidate_headers = settings.get("reply_account_header_priority")
     for candidate_header in candidate_headers:
         if realname is not None:
             break

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -230,10 +230,10 @@ prefer_plaintext = boolean(default=False)
 msg_summary_hides_threadwide_tags = boolean(default=True)
 
 # The list of headers to match to determine sending account for a reply.
-# Headers are searched in the order in which they are specified here, and the first match
-# is used. If multiple accounts match the same header, the one defined first in the account
-# block is used.
-determine_reply_account_from_headers = force_list(default=list(From,To,Cc,Envelope-To,X-Envelope-To,Delivered-To))
+# Headers are searched in the order in which they are specified here, and the first header
+# containing a match is used. If multiple accounts match in that header, the one defined
+# first in the account block is used.
+reply_account_header_priority = force_list(default=list(From,To,Cc,Envelope-To,X-Envelope-To,Delivered-To))
 
 # Key bindings 
 [bindings]

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -229,6 +229,12 @@ prefer_plaintext = boolean(default=False)
 # messages in that thread.
 msg_summary_hides_threadwide_tags = boolean(default=True)
 
+# The list of headers to match to determine sending account for a reply.
+# Headers are searched in the order in which they are specified here, and the first match
+# is used. If multiple accounts match the same header, the one defined first in the account
+# block is used.
+determine_reply_account_from_headers = force_list(default=list(From,To,Cc,Envelope-To,X-Envelope-To,Delivered-To))
+
 # Key bindings 
 [bindings]
     __many__ = string(default=None)


### PR DESCRIPTION
Second attempt at this, based on master again. (Previously #772.)

Introduce a user-configurable ordered header-based sender selection, as
proposed in #771.

In the examples below, assume the accounts are ordered X-Y-Z in the
config file.

Suppose I'm in a conversation, sending mails from account Y. However,
I add my account X to the "CC:" header. If I do not receive any replies
before sending another mail, I want to send it from account Y again,
9 out of 10 times. The old version would prefer account X, because it
lumps all headers in one list and gets a match on account X first.

Suppose I have aliasing in my mailserver, but send mails from several
of these aliases. They are not "aliases" as such, but accounts which
happen to share a mailbox. However, account X is the account where the
mail is ultimately sent to so will always be present in the
"Delivered-To:" header, even if the sender only knows my address for
account Y, which is in the "To:". Obviously, I want any replies to be
sent from account Y, not account X. This is fixed by prioritizing
matches on the "To:" over "Delivered-To:".

The only case which this patch doesn't fix is when somebody replies
in the first situation, adding both addresses to the "To:" header.
In this case, however, I would be fine manually editing the proposed
sender address.
