### PR TITLE
Removed incorrect backslash-t substitution in envelope.

### DIFF
--- a/alot/db/envelope.py
+++ b/alot/db/envelope.py
@@ -171,7 +171,6 @@ class Envelope(object):
         # Build body text part. To properly sign/encrypt messages later on, we
         # convert the text to its canonical format (as per RFC 2015).
         canonical_format = self.body.encode('utf-8')
-        canonical_format = canonical_format.replace('\\t', ' ' * 4)
         textpart = MIMEText(canonical_format, 'plain', 'utf-8')
 
         # wrap it in a multipart container if necessary


### PR DESCRIPTION
The substitution of the sequence `\t` (backslash followed by lowercase t, not tab) by four spaces when constructing a message alters the message contents (and makes no sense).
