### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/alot/widgets/search.py
+++ b/alot/widgets/search.py
@@ -54,7 +54,7 @@ class ThreadlineWidget(urwid.AttrMap):
             datestring = ''
             if self.thread:
                 newest = self.thread.get_newest_date()
-                if newest != None:
+                if newest is not None:
                     datestring = settings.represent_datetime(newest)
             datestring = pad(datestring)
             width = len(datestring)

--- a/docs/source/generate_configs.py
+++ b/docs/source/generate_configs.py
@@ -17,7 +17,7 @@ def rewrite_entries(config, path, specpath, sec=None, sort=False):
     file = open(path, 'w')
     file.write(NOTE % specpath)
 
-    if sec == None:
+    if sec is None:
         sec = config
     if sort:
         sec.scalars.sort()
@@ -46,7 +46,7 @@ def rewrite_entries(config, path, specpath, sec=None, sort=False):
                 etype = 'string list'
             description += '\n    :type: %s\n' % etype
 
-        if default != None:
+        if default is not None:
             default = default.replace('*','\\*')
             if etype in ['string', 'string_list', 'gpg_key_hint'] and default != 'None':
                 description += '    :default: "%s"\n\n' % (default)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:pazz:alot?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:pazz:alot?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)