### PR TITLE
docs: fix incorrect module/class names

### DIFF
--- a/docs/source/api/settings.rst
+++ b/docs/source/api/settings.rst
@@ -61,11 +61,16 @@ Accounts
 Addressbooks
 ------------
 
-.. module:: alot.addressbooks
+.. module:: alot.addressbook
 
 .. autoclass:: AddressBook
     :members:
-.. autoclass:: MatchSdtoutAddressbook
-    :members:
+
+.. module:: alot.addressbook.abook
+
 .. autoclass:: AbookAddressBook
     :members:
+
+.. module:: alot.addressbook.external
+
+.. autoclass:: ExternalAddressbook


### PR DESCRIPTION
Ran into this trying to update the AUR package for alot to 0.4:

https://aur.archlinux.org/packages/alot

Building the docs was failing.

Hopefully this can be squeezed into a fixup release? would prefer not to have to keep a backported version of this patch in the aur package.