### PR TITLE
Start using travis.ci to check auto generated docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: python
+
+python:
+  # We can add more version strings here when we support other python
+  # versions.
+  - "2.7"
+
+# Install or mock dependencies for alot as the package has to be imported
+# during generation of the docs.
+install:
+  - pip install configobj urwid twisted python-magic
+  # urwid has to be installed when installing urwidtrees otherwise the process
+  # fails.
+  - pip install urwidtrees
+  # Mock all "difficult" dependencies of alot in order to be able to import
+  # alot when rebuilding the documentation.  Notmuch would have to be
+  # installed by hand in order to get a recent enough version on travis.
+  - printf '%s = None\n' NotmuchError NullPointerError > notmuch.py
+  - touch gpgme.py
+
+script:
+  # First remove the generated docs.
+  - make -C docs cleanall
+  # Regenerate them
+  - make -C docs html SPHINXBUILD=true
+  # Check that the generated docs where already commited.
+  - git diff --exit-code


### PR DESCRIPTION
For starters only the auto generated part of the docs is regenerated in order
to check that the last author did regenerate and commit them.

Some dependencies of alot are mocked to speed up installation.  Especially
notmuch would need to be build manually as the version available on travis is
to old.

This is a follow up PR for #886.  A proof of concept about the behaviour of this test in case of failure can be seen in the branch [mini-travis-proof-of-concept](https://travis-ci.org/lucc/alot/branches).  This branch should pass.

In order to start using the travis.ci @pazz has to log in at https://travis.ci (with your github account) and set things up (not hard I did it some time ago for my fork but don't remember the exact steps).