### PR TITLE
Use open() as a context manager

### DIFF
--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -324,10 +324,9 @@ class EditCommand(Command):
 
             # get input
             # tempfile will be removed on buffer cleanup
-            f = open(self.envelope.tmpfile.name)
             enc = settings.get('editor_writes_encoding')
-            template = string_decode(f.read(), enc)
-            f.close()
+            with open(self.envelope.tmpfile.name) as f:
+                template = string_decode(f.read(), enc)
 
             # call post-edit translate hook
             translate = settings.get_hook('post_edit_translate')

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -733,7 +733,8 @@ class ComposeCommand(Command):
                           priority='error')
                 return
             try:
-                self.envelope.parse_template(open(path).read())
+                with open(path) as f:
+                    self.envelope.parse_template(f.read())
             except Exception as e:
                 ui.notify(str(e), priority='error')
                 return
@@ -792,7 +793,8 @@ class ComposeCommand(Command):
                     self.envelope.attach(sig, filename=name)
                     logging.debug('attached')
                 else:
-                    sigcontent = open(sig).read()
+                    with open(sig) as f:
+                        sigcontent = f.read()
                     enc = helper.guess_encoding(sigcontent)
                     mimetype = helper.guess_mimetype(sigcontent)
                     if mimetype.startswith('text'):

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -70,9 +70,8 @@ class Message(object):
                   "Message file is no longer accessible:\n%s" % path
         if not self._email:
             try:
-                f_mail = open(path)
-                self._email = message_from_file(f_mail)
-                f_mail.close()
+                with open(path) as f:
+                    self._email = message_from_file(f)
             except IOError:
                 self._email = email.message_from_string(warning)
         return self._email

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -465,7 +465,8 @@ def libmagic_version_at_least(version):
 
 # TODO: make this work on blobs, not paths
 def mimewrap(path, filename=None, ctype=None):
-    content = open(path, 'rb').read()
+    with open(path, 'rb') as f:
+        content = f.read()
     if not ctype:
         ctype = guess_mimetype(content)
         # libmagic < 5.12 incorrectly detects excel/powerpoint files as


### PR DESCRIPTION
This little series replaces most uses of open() that are not as a context manager (using the `with` statement) with context manager uses. Using open as a context manager has a number of advantages, it makes visual inspection of correctness easier, it ensures that the file is closed and the fd is released (even if an exception is closed which would otherwise require a try/finally construct), and it uses one line less code than `f = open(...); f.write(...); f.close()`.