### PR TITLE
Use footnote-links to clean up badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,15 @@
 Alot is an experimental terminal MUA based on [notmuch mail][notmuch].
 It is written in python using the [urwid][urwid] toolkit.
 
+[![Build Status][travis-img]][travis]
+[![Code Issues][quantcode-img]][quantcode]
+
 Have a look at the [user manual][docs] for installation notes, advanced usage,
 customization and hacking guides.
 
 Do comment on the code or file issues!
 
 Most of the developers hang out in `#alot@freenode`, feel free to ask questions or make suggestions there.
-
-Badges
-------
-
-[![Build Status][travis-img]][travis]
-[![Code Issues][quantcode-img]][quantcode]
 
 Current features include:
 -------------------------

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ It is written in python using the [urwid][urwid] toolkit.
 Have a look at the [user manual][docs] for installation notes, advanced usage,
 customization and hacking guides.
 
-Do comment on the code or file issues! 
+Do comment on the code or file issues!
 
 Most of the developers hang out in `#alot@freenode`, feel free to ask questions or make suggestions there.
 
 Badges
 ------
 
-[![Build Status](https://travis-ci.org/pazz/alot.svg?branch=master)](https://travis-ci.org/pazz/alot)
-[![Code Issues](https://www.quantifiedcode.com/api/v1/project/c5aaa4739c5b4f6eb75eaaf8c01da679/badge.svg)](https://www.quantifiedcode.com/app/project/c5aaa4739c5b4f6eb75eaaf8c01da679)
+[![Build Status][travis-img]][travis]
+[![Code Issues][quantcode-img]][quantcode]
 
 Current features include:
 -------------------------
@@ -52,3 +52,8 @@ See the [manual][docs] for more usage info.
 [urwid]: http://excess.org/urwid/
 [docs]: http://alot.rtfd.org
 [features]: https://github.com/pazz/alot/issues?labels=feature
+[travis]: https://travis-ci.org/pazz/alot
+[quantcode]: https://www.quantifiedcode.com/app/project/c5aaa4739c5b4f6eb75eaaf8c01da679
+
+[travis-img]: https://travis-ci.org/pazz/alot.svg?branch=master
+[quantcode-img]: https://www.quantifiedcode.com/api/v1/project/c5aaa4739c5b4f6eb75eaaf8c01da679/badge.svg

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Current features include:
 
 
 Basic Usage
-===========
+-----------
 The arrow keys, `page-up/down`, `j`, `k` and `Space` can be used to move the focus.
 `Escape` cancels prompts and `Enter` selects. Hit `:` at any time and type in commands
 to the prompt.


### PR DESCRIPTION
Per @lucc's comments in #923:

> The first few lines start to look patched together more and more. Maybe we can find a way to say
> things in a nicer looking way or we don't say everything at the top.
>
> But that can all be done in another PR. The badges are good and seem to point to the right place.

IMO footnote links make the source nicer to look at.