### PR TITLE
fix interpolation in config files #902.

### DIFF
--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -119,7 +119,7 @@ class SettingsManager(object):
         if 'accounts' in config:
             for acc in config['accounts'].sections:
                 accsec = config['accounts'][acc]
-                args = dict(config['accounts'][acc])
+                args = dict(config['accounts'][acc].items())
 
                 # create abook for this account
                 abook = accsec['abook']


### PR DESCRIPTION
Configobj's string interpolation feature does not work as expected in
account sections of alot configuration files.
The reason is that interpolation is done in ConfigObj.__getitem__
which alot does not use directly for account sections.
This patch causes all values to be read via ConfigObj.__getitem__
explicitly.