### PR TITLE
[QC] Turn methods with no `self` usage into staticmethods

### DIFF
--- a/alot/account.py
+++ b/alot/account.py
@@ -95,7 +95,8 @@ class Account(object):
         their importance"""
         return [self.address] + self.aliases
 
-    def store_mail(self, mbx, mail):
+    @staticmethod
+    def store_mail(mbx, mail):
         """
         stores given mail in mailbox. If mailbox is maildir, set the S-flag and
         return path to newly added mail. Oherwise this will return `None`.

--- a/alot/completion.py
+++ b/alot/completion.py
@@ -484,7 +484,8 @@ class CommandLineCompleter(Completer):
         """
         self._commandcompleter = CommandCompleter(dbman, mode, currentbuffer)
 
-    def get_context(self, line, pos):
+    @staticmethod
+    def get_context(line, pos):
         """
         computes start and end position of substring of line that is the
         command string under given position

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -107,7 +107,8 @@ class SettingsManager(object):
         self._accounts = self._parse_accounts(self._config)
         self._accountmap = self._account_table(self._accounts)
 
-    def _parse_accounts(self, config):
+    @staticmethod
+    def _parse_accounts(config):
         """
         read accounts information from config
 
@@ -148,7 +149,8 @@ class SettingsManager(object):
                 accounts.append(newacc)
         return accounts
 
-    def _account_table(self, accounts):
+    @staticmethod
+    def _account_table(accounts):
         """
         creates a lookup table (emailaddress -> account) for a given list of
         accounts

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -242,7 +242,8 @@ class UI(object):
         d.addErrback(errorHandler)
         return d
 
-    def _unhandeled_input(self, key):
+    @staticmethod
+    def _unhandeled_input(key):
         """
         Called by :class:`urwid.MainLoop` if a keypress was passed to the root
         widget by `self._input_filter` but is not handled in any widget. We
@@ -329,7 +330,8 @@ class UI(object):
         self._passall = True
         return d  # return deferred
 
-    def exit(self):
+    @staticmethod
+    def exit():
         """
         shuts down user interface without cleaning up.
         Use a :class:`alot.commands.globals.ExitCommand` for a clean shutdown.

--- a/alot/widgets/search.py
+++ b/alot/widgets/search.py
@@ -177,7 +177,7 @@ class ThreadlineWidget(urwid.AttrMap):
     def get_thread(self):
         return self.thread
 
-    def _get_theme(self, component, focus=False):
+    def _get_theme(component, focus=False):
         path = ['search', 'threadline', component]
         if focus:
             path.append('focus')


### PR DESCRIPTION
Fix some comments by quantifycode.  The other potential @staticmethods that QC reports are overwriting a super class method or are being overwritten in a subclass.  I didn't want to change the signature for those because some of the classes in the hierarchy might use the self parameter and then the signatures would differ.