### PR TITLE
Drop little used helper

### DIFF
--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -36,13 +36,15 @@ class Message(object):
         self._id = msg.get_message_id()
         self._thread_id = msg.get_thread_id()
         self._thread = thread
-        casts_date = lambda: datetime.fromtimestamp(msg.get_date())
-        self._datetime = helper.safely_get(casts_date,
-                                           ValueError, None)
+        try:
+            self._datetime = datetime.fromtimestamp(msg.get_date())
+        except ValueError:
+            self._datetime = None
         self._filename = msg.get_filename()
-        author = helper.safely_get(lambda: msg.get_header('From'),
-                                   NullPointerError)
-        self._from = decode_header(author)
+        try:
+            self._from = decode_header(msg.get_header('From'))
+        except NullPointerError:
+            self._from = ''
         self._email = None  # will be read upon first use
         self._attachments = None  # will be read upon first use
         self._tags = set(msg.get_tags())

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -57,24 +57,6 @@ def split_commandstring(cmdstring):
     return shlex.split(cmdstring)
 
 
-def safely_get(clb, E, on_error=''):
-    """
-    returns result of :func:`clb` and falls back to `on_error`
-    in case exception `E` is raised.
-
-    :param clb: function to evaluate
-    :type clb: callable
-    :param E: exception to catch
-    :type E: Exception
-    :param on_error: default string returned when exception is caught
-    :type on_error: str
-    """
-    try:
-        return clb()
-    except E:
-        return on_error
-
-
 def string_sanitize(string, tab_width=8):
     r"""
     strips, and replaces non-printable characters


### PR DESCRIPTION
The safely_get helper is just a wrapper around try/except, and is used
twice in the whole code base, in the same function. It really doesn't
even end up saving code because to get around line wrapping a lambda is
assigned (which is not the greatest style wise), it ends up saving one
line of code when it's called, and the function itself is 16 lines long.