### PR TITLE
Cache pip packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+# Cache pip objects to speed up next build
+cache: pip
+
 # We need a newer version of zlib to build notmuch from source as is available
 # in precise.
 dist: trusty


### PR DESCRIPTION
This saves having to rebuild the pip packages that require building (like twisted) every time a job is run. This can save a bit of time in travis.