### PR TITLE
Even more cleanups

### DIFF
--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -362,12 +362,12 @@ class ThreadBuffer(Buffer):
 
         bars_att = settings.get_theming_attribute('thread', 'arrow_bars')
         heads_att = settings.get_theming_attribute('thread', 'arrow_heads')
-        A = ArrowTree(self._tree,
-                      indent=2,
-                      childbar_offset=0,
-                      arrow_tip_att=heads_att,
-                      arrow_att=bars_att,
-                      )
+        A = ArrowTree(
+            self._tree,
+            indent=2,
+            childbar_offset=0,
+            arrow_tip_att=heads_att,
+            arrow_att=bars_att)
         self._nested_tree = NestedTree(A, interpret_covered=True)
         self.body = TreeBox(self._nested_tree)
         self.message_count = self.thread.get_total_messages()

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -30,8 +30,9 @@ from ..utils.booleanaction import BooleanAction
 MODE = 'envelope'
 
 
-@registerCommand(MODE, 'attach', arguments=[
-    (['path'], {'help': 'file(s) to attach (accepts wildcads)'})])
+@registerCommand(
+    MODE, 'attach',
+    arguments=[(['path'], {'help': 'file(s) to attach (accepts wildcads)'})])
 class AttachCommand(Command):
     """attach files to the mail"""
     repeatable = True
@@ -443,13 +444,18 @@ class ToggleHeaderCommand(Command):
         ui.current_buffer.toggle_all_headers()
 
 
-@registerCommand(MODE, 'sign', forced={'action': 'sign'}, arguments=[
-    (['keyid'], {'nargs': argparse.REMAINDER, 'help': 'which key id to use'})],
+@registerCommand(
+    MODE, 'sign', forced={'action': 'sign'},
+    arguments=[
+        (['keyid'],
+         {'nargs': argparse.REMAINDER, 'help': 'which key id to use'})],
     help='mark mail to be signed before sending')
 @registerCommand(MODE, 'unsign', forced={'action': 'unsign'},
                  help='mark mail not to be signed before sending')
-@registerCommand(MODE, 'togglesign', forced={'action': 'toggle'}, arguments=[
-    (['keyid'], {'nargs': argparse.REMAINDER, 'help': 'which key id to use'})],
+@registerCommand(
+    MODE, 'togglesign', forced={'action': 'toggle'}, arguments=[
+        (['keyid'],
+         {'nargs': argparse.REMAINDER, 'help': 'which key id to use'})],
     help='toggle sign status')
 class SignCommand(Command):
     """toggle signing this email"""
@@ -497,25 +503,30 @@ class SignCommand(Command):
         ui.current_buffer.rebuild()
 
 
-@registerCommand(MODE, 'encrypt', forced={'action': 'encrypt'}, arguments=[
-    (['--trusted'], {'action': 'store_true', 'help': 'only add trusted keys'}),
-    (['keyids'], {'nargs': argparse.REMAINDER,
-                  'help': 'keyid of the key to encrypt with'})],
+@registerCommand(
+    MODE, 'encrypt', forced={'action': 'encrypt'}, arguments=[
+        (['--trusted'], {'action': 'store_true',
+                         'help': 'only add trusted keys'}),
+        (['keyids'], {'nargs': argparse.REMAINDER,
+                      'help': 'keyid of the key to encrypt with'})],
     help='request encryption of message before sendout')
-@registerCommand(MODE, 'unencrypt', forced={'action': 'unencrypt'},
-                 help='remove request to encrypt message before sending')
-@registerCommand(MODE, 'toggleencrypt', forced={'action': 'toggleencrypt'},
-                 arguments=[
-                     (['--trusted'], {'action': 'store_true',
-                                      'help': 'only add trusted keys'}),
-                     (['keyids'], {'nargs': argparse.REMAINDER,
+@registerCommand(
+    MODE, 'unencrypt', forced={'action': 'unencrypt'},
+    help='remove request to encrypt message before sending')
+@registerCommand(
+    MODE, 'toggleencrypt', forced={'action': 'toggleencrypt'},
+    arguments=[
+        (['--trusted'], {'action': 'store_true',
+                         'help': 'only add trusted keys'}),
+        (['keyids'], {'nargs': argparse.REMAINDER,
                       'help': 'keyid of the key to encrypt with'})],
-                 help='toggle if message should be encrypted before sendout')
-@registerCommand(MODE, 'rmencrypt', forced={'action': 'rmencrypt'},
-                 arguments=[
-                     (['keyids'], {'nargs': argparse.REMAINDER,
+    help='toggle if message should be encrypted before sendout')
+@registerCommand(
+    MODE, 'rmencrypt', forced={'action': 'rmencrypt'},
+    arguments=[
+        (['keyids'], {'nargs': argparse.REMAINDER,
                       'help': 'keyid of the key to encrypt with'})],
-                 help='do not encrypt to given recipient key')
+    help='do not encrypt to given recipient key')
 class EncryptCommand(Command):
     def __init__(self, action=None, keyids=None, trusted=False, **kwargs):
         """

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -64,7 +64,7 @@ class ExitCommand(Command):
 
 @registerCommand(MODE, 'search', usage='search query', arguments=[
     (['--sort'], {'help': 'sort order', 'choices': [
-                  'oldest_first', 'newest_first', 'message_id', 'unsorted']}),
+        'oldest_first', 'newest_first', 'message_id', 'unsorted']}),
     (['query'], {'nargs': argparse.REMAINDER, 'help': 'search string'})])
 class SearchCommand(Command):
 
@@ -123,11 +123,11 @@ class PromptCommand(Command):
         logging.info('open command shell')
         mode = ui.mode or 'global'
         cmpl = CommandLineCompleter(ui.dbman, mode, ui.current_buffer)
-        cmdline = yield ui.prompt('',
-                                  text=self.startwith,
-                                  completer=cmpl,
-                                  history=ui.commandprompthistory,
-                                  )
+        cmdline = yield ui.prompt(
+            '',
+            text=self.startwith,
+            completer=cmpl,
+            history=ui.commandprompthistory)
         logging.debug('CMDLINE: %s', cmdline)
 
         # interpret and apply commandline
@@ -150,14 +150,16 @@ class RefreshCommand(Command):
         ui.update()
 
 
-@registerCommand(MODE, 'shellescape', arguments=[
-    (['--spawn'], {'action': BooleanAction, 'default': None,
-                   'help': 'run in terminal window'}),
-    (['--thread'], {'action': BooleanAction, 'default': None,
-                    'help': 'run in separate thread'}),
-    (['--refocus'], {'action': BooleanAction, 'help': 'refocus current buffer \
-                     after command has finished'}),
-    (['cmd'], {'help': 'command line to execute'})],
+@registerCommand(
+    MODE, 'shellescape', arguments=[
+        (['--spawn'], {'action': BooleanAction, 'default': None,
+                       'help': 'run in terminal window'}),
+        (['--thread'], {'action': BooleanAction, 'default': None,
+                        'help': 'run in separate thread'}),
+        (['--refocus'], {'action': BooleanAction,
+                         'help': 'refocus current buffer after command '
+                                 'has finished'}),
+        (['cmd'], {'help': 'command line to execute'})],
     forced={'shell': True},
 )
 class ExternalCommand(Command):
@@ -380,10 +382,11 @@ class CallCommand(Command):
 
 
 @registerCommand(MODE, 'bclose', arguments=[
-    (['--redraw'], {'action': BooleanAction, 'help': 'redraw current buffer \
-                     after command has finished'}),
-    (['--force'], {'action': 'store_true',
-                   'help': 'never ask for confirmation'})])
+    (['--redraw'],
+     {'action': BooleanAction,
+      'help': 'redraw current buffer after command has finished'}),
+    (['--force'],
+     {'action': 'store_true', 'help': 'never ask for confirmation'})])
 class BufferCloseCommand(Command):
 
     """close a buffer"""
@@ -429,8 +432,9 @@ class BufferCloseCommand(Command):
                  help='focus previous buffer')
 @registerCommand(MODE, 'bnext', forced={'offset': +1},
                  help='focus next buffer')
-@registerCommand(MODE, 'buffer', arguments=[
-    (['index'], {'type': int, 'help': 'buffer index to focus'}), ],
+@registerCommand(
+    MODE, 'buffer',
+    arguments=[(['index'], {'type': int, 'help': 'buffer index to focus'})],
     help='focus buffer with given index')
 class BufferFocusCommand(Command):
 
@@ -908,11 +912,12 @@ class ComposeCommand(Command):
             envelope.encrypt = False
 
 
-@registerCommand(MODE, 'move', help='move focus in current buffer',
-                 arguments=[(['movement'], {
-                             'nargs': argparse.REMAINDER,
-                             'help': 'up, down, [half]page up, '
-                                     '[half]page down, first'})])
+@registerCommand(
+    MODE, 'move', help='move focus in current buffer',
+    arguments=[
+        (['movement'],
+         {'nargs': argparse.REMAINDER,
+          'help': 'up, down, [half]page up, [half]page down, first'})])
 class MoveCommand(Command):
 
     """move in widget"""

--- a/alot/commands/search.py
+++ b/alot/commands/search.py
@@ -42,11 +42,11 @@ class OpenThreadCommand(Command):
 
 @registerCommand(MODE, 'refine', help='refine query', arguments=[
     (['--sort'], {'help': 'sort order', 'choices': [
-                  'oldest_first', 'newest_first', 'message_id', 'unsorted']}),
+        'oldest_first', 'newest_first', 'message_id', 'unsorted']}),
     (['query'], {'nargs': argparse.REMAINDER, 'help': 'search string'})])
 @registerCommand(MODE, 'sort', help='set sort order', arguments=[
     (['sort'], {'help': 'sort order', 'choices': [
-                'oldest_first', 'newest_first', 'message_id', 'unsorted']}),
+        'oldest_first', 'newest_first', 'message_id', 'unsorted']}),
 ])
 class RefineCommand(Command):
 
@@ -110,42 +110,50 @@ class RetagPromptCommand(Command):
         return ui.apply_command(PromptCommand('retag ' + initial_tagstring))
 
 
-@registerCommand(MODE, 'tag', forced={'action': 'add'}, arguments=[
-    (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
-                      'default': 'True',
-                      'help': 'postpone a writeout to the index'}),
-    (['--all'], {'action': 'store_true', 'dest': 'allmessages', 'default':
-                 False, 'help': 'retag all messages in search result'}),
-    (['tags'], {'help': 'comma separated list of tags'})],
+@registerCommand(
+    MODE, 'tag', forced={'action': 'add'},
+    arguments=[
+        (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
+                          'default': 'True',
+                          'help': 'postpone a writeout to the index'}),
+        (['--all'], {'action': 'store_true', 'dest': 'allmessages', 'default':
+                     False, 'help': 'retag all messages in search result'}),
+        (['tags'], {'help': 'comma separated list of tags'})],
     help='add tags to all messages in the thread that match the current query',
 )
-@registerCommand(MODE, 'retag', forced={'action': 'set'}, arguments=[
-    (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
-                      'default': 'True',
-                      'help': 'postpone a writeout to the index'}),
-    (['--all'], {'action': 'store_true', 'dest': 'allmessages', 'default':
-                 False, 'help': 'retag all messages in search result'}),
-    (['tags'], {'help': 'comma separated list of tags'})],
+@registerCommand(
+    MODE, 'retag', forced={'action': 'set'},
+    arguments=[
+        (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
+                          'default': 'True',
+                          'help': 'postpone a writeout to the index'}),
+        (['--all'], {'action': 'store_true', 'dest': 'allmessages', 'default':
+                     False, 'help': 'retag all messages in search result'}),
+        (['tags'], {'help': 'comma separated list of tags'})],
     help='set tags of all messages in the thread that match the current query',
 )
-@registerCommand(MODE, 'untag', forced={'action': 'remove'}, arguments=[
-    (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
-                      'default': 'True',
-                      'help': 'postpone a writeout to the index'}),
-    (['--all'], {'action': 'store_true', 'dest': 'allmessages', 'default':
-                 False, 'help': 'retag all messages in search result'}),
-    (['tags'], {'help': 'comma separated list of tags'})],
+@registerCommand(
+    MODE, 'untag', forced={'action': 'remove'},
+    arguments=[
+        (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
+                          'default': 'True',
+                          'help': 'postpone a writeout to the index'}),
+        (['--all'], {'action': 'store_true', 'dest': 'allmessages', 'default':
+                     False, 'help': 'retag all messages in search result'}),
+        (['tags'], {'help': 'comma separated list of tags'})],
     help='remove tags from all messages in the thread that match the query',
 )
-@registerCommand(MODE, 'toggletags', forced={'action': 'toggle'}, arguments=[
-    (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
-                      'default': 'True',
-                      'help': 'postpone a writeout to the index'}),
-    (['tags'], {'help': 'comma separated list of tags'})],
-    help="""flip presence of tags on this thread.
-    A tag is considered present if at least one message contained in this
-    thread is tagged with it. In that case this command will remove the tag
-    from every message in the thread.""")
+@registerCommand(
+    MODE, 'toggletags', forced={'action': 'toggle'},
+    arguments=[
+        (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
+                          'default': 'True',
+                          'help': 'postpone a writeout to the index'}),
+        (['tags'], {'help': 'comma separated list of tags'})],
+    help='flip presence of tags on this thread. A tag is considered present '
+         'if at least one message contained in this thread is tagged with it. '
+         'In that case this command will remove the tag from every message in '
+         'the thread.')
 class TagCommand(Command):
 
     """manipulate message tags"""
@@ -240,10 +248,9 @@ class TagCommand(Command):
             ui.apply_command(commands.globals.FlushCommand(callback=refresh))
 
 
-@registerCommand(MODE, 'move', help='move focus in search buffer',
-                 arguments=[(['movement'], {
-                             'nargs': argparse.REMAINDER,
-                             'help': 'last'})])
+@registerCommand(
+    MODE, 'move', help='move focus in search buffer',
+    arguments=[(['movement'], {'nargs': argparse.REMAINDER, 'help': 'last'})])
 class MoveFocusCommand(MoveCommand):
 
     def apply(self, ui):

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -491,11 +491,12 @@ class EditNewCommand(Command):
                                         omit_signature=True))
 
 
-@registerCommand(MODE, 'fold', forced={'visible': False}, arguments=[
-    (
-        ['query'], {'help': 'query used to filter messages to affect',
-                    'nargs': '*'}),
-],
+@registerCommand(
+    MODE, 'fold', forced={'visible': False},
+    arguments=[
+        (['query'], {'help': 'query used to filter messages to affect',
+                     'nargs': '*'})
+    ],
     help='fold message(s)')
 @registerCommand(MODE, 'unfold', forced={'visible': True}, arguments=[
     (['query'], {'help': 'query used to filter messages to affect',
@@ -599,8 +600,7 @@ class ChangeDisplaymodeCommand(Command):
                            'help': 'display cmd\'s stdout as notification'}),
     (['--field_key'], {'help': 'mailcap field key for decoding',
                        'default': 'copiousoutput'}),
-],
-)
+])
 class PipeCommand(Command):
 
     """pipe message(s) to stdin of a shellcommand"""
@@ -798,8 +798,7 @@ class RemoveCommand(Command):
                         'help': 'call print command once for each message'}),
     (['--add_tags'], {'action': 'store_true',
                       'help': 'add \'Tags\' header to the message'}),
-],
-)
+])
 class PrintCommand(PipeCommand):
 
     """print message(s)"""
@@ -929,7 +928,7 @@ class OpenAttachmentCommand(Command):
             handler_raw_commandstring = entry['view']
             # read parameter
             part = self.attachment.get_mime_representation()
-            parms = tuple('='.join(p) for p in  part.get_params())
+            parms = tuple('='.join(p) for p in part.get_params())
 
             # in case the mailcap defined command contains no '%s',
             # we pipe the files content to the handling command via stdin
@@ -972,11 +971,12 @@ class OpenAttachmentCommand(Command):
             ui.notify('unknown mime type')
 
 
-@registerCommand(MODE, 'move', help='move focus in current buffer',
-                 arguments=[(['movement'], {
-                             'nargs': argparse.REMAINDER,
-                             'help': 'up, down, page up, '
-                                     'page down, first, last'})])
+@registerCommand(
+    MODE, 'move', help='move focus in current buffer',
+    arguments=[
+        (['movement'],
+         {'nargs': argparse.REMAINDER,
+          'help': 'up, down, page up, page down, first, last'})])
 class MoveFocusCommand(MoveCommand):
 
     def apply(self, ui):
@@ -1022,36 +1022,44 @@ class ThreadSelectCommand(Command):
             ui.apply_command(ChangeDisplaymodeCommand(visible='toggle'))
 
 
-@registerCommand(MODE, 'tag', forced={'action': 'add'}, arguments=[
-    (['--all'], {'action': 'store_true',
-     'help': 'tag all messages in thread'}),
-    (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
-                      'help': 'postpone a writeout to the index'}),
-    (['tags'], {'help': 'comma separated list of tags'})],
+@registerCommand(
+    MODE, 'tag', forced={'action': 'add'},
+    arguments=[
+        (['--all'], {'action': 'store_true',
+                     'help': 'tag all messages in thread'}),
+        (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
+                          'help': 'postpone a writeout to the index'}),
+        (['tags'], {'help': 'comma separated list of tags'})],
     help='add tags to message(s)',
 )
-@registerCommand(MODE, 'retag', forced={'action': 'set'}, arguments=[
-    (['--all'], {'action': 'store_true',
-     'help': 'tag all messages in thread'}),
-    (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
-                      'help': 'postpone a writeout to the index'}),
-    (['tags'], {'help': 'comma separated list of tags'})],
+@registerCommand(
+    MODE, 'retag', forced={'action': 'set'},
+    arguments=[
+        (['--all'], {'action': 'store_true',
+                     'help': 'tag all messages in thread'}),
+        (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
+                          'help': 'postpone a writeout to the index'}),
+        (['tags'], {'help': 'comma separated list of tags'})],
     help='set message(s) tags.',
 )
-@registerCommand(MODE, 'untag', forced={'action': 'remove'}, arguments=[
-    (['--all'], {'action': 'store_true',
-     'help': 'tag all messages in thread'}),
-    (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
-                      'help': 'postpone a writeout to the index'}),
-    (['tags'], {'help': 'comma separated list of tags'})],
+@registerCommand(
+    MODE, 'untag', forced={'action': 'remove'},
+    arguments=[
+        (['--all'], {'action': 'store_true',
+                     'help': 'tag all messages in thread'}),
+        (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
+                          'help': 'postpone a writeout to the index'}),
+        (['tags'], {'help': 'comma separated list of tags'})],
     help='remove tags from message(s)',
 )
-@registerCommand(MODE, 'toggletags', forced={'action': 'toggle'}, arguments=[
-    (['--all'], {'action': 'store_true',
-     'help': 'tag all messages in thread'}),
-    (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
-                      'help': 'postpone a writeout to the index'}),
-    (['tags'], {'help': 'comma separated list of tags'})],
+@registerCommand(
+    MODE, 'toggletags', forced={'action': 'toggle'},
+    arguments=[
+        (['--all'], {'action': 'store_true',
+                     'help': 'tag all messages in thread'}),
+        (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
+                          'help': 'postpone a writeout to the index'}),
+        (['tags'], {'help': 'comma separated list of tags'})],
     help='flip presence of tags on message(s)',
 )
 class TagCommand(Command):

--- a/alot/commands/utils.py
+++ b/alot/commands/utils.py
@@ -33,10 +33,10 @@ def get_keys(ui, encrypt_keyids, block_error=False, signed_only=False):
                                  signed_only=signed_only)
         except GPGProblem as e:
             if e.code == GPGCode.AMBIGUOUS_NAME:
-                possible_keys = crypto.list_keys(hint=keyid)
-                tmp_choices = [k.uids[0].uid for k in possible_keys]
-                choices = {str(len(tmp_choices) - x): tmp_choices[x]
-                           for x in range(0, len(tmp_choices))}
+                tmp_choices = (k.uids[0].uid for k in
+                               crypto.list_keys(hint=keyid))
+                choices = {str(i): t for i, t in
+                           enumerate(reversed(tmp_choices), 1)}
                 keyid = yield ui.choice("ambiguous keyid! Which " +
                                         "key do you want to use?",
                                         choices, cancel=None)

--- a/alot/db/attachment.py
+++ b/alot/db/attachment.py
@@ -66,14 +66,14 @@ class Attachment(object):
         if os.path.isdir(path):
             if filename:
                 basename = os.path.basename(filename)
-                FILE = open(os.path.join(path, basename), "w")
+                file_ = open(os.path.join(path, basename), "w")
             else:
-                FILE = tempfile.NamedTemporaryFile(delete=False, dir=path)
+                file_ = tempfile.NamedTemporaryFile(delete=False, dir=path)
         else:
-            FILE = open(path, "w")  # this throws IOErrors for invalid path
-        self.write(FILE)
-        FILE.close()
-        return FILE.name
+            file_ = open(path, "w")  # this throws IOErrors for invalid path
+        self.write(file_)
+        file_.close()
+        return file_.name
 
     def write(self, fhandle):
         """writes content to a given filehandle"""

--- a/alot/db/attachment.py
+++ b/alot/db/attachment.py
@@ -86,8 +86,8 @@ class Attachment(object):
     def get_mime_representation(self):
         """returns mime part that constitutes this attachment"""
         part = deepcopy(self.part)
-        cd = self.part['Content-Disposition']
-        del part['Content-Disposition']
-        part['Content-Disposition'] = Header(cd, maxlinelen=78,
-                                             header_name='Content-Disposition')
+        part['Content-Disposition'] = Header(
+            self.part['Content-Disposition'],
+            maxlinelen=78,
+            header_name='Content-Disposition')
         return part

--- a/alot/db/envelope.py
+++ b/alot/db/envelope.py
@@ -70,6 +70,8 @@ class Envelope(object):
             logging.debug('PARSED TEMPLATE: %s', template)
             logging.debug('BODY: %s', self.body)
         self.body = bodytext or u''
+        # TODO: if this was as collections.defaultdict a number of methods
+        # could be simplified.
         self.headers = headers or {}
         self.attachments = list(attachments) if attachments is not None else []
         self.sign = sign

--- a/alot/db/envelope.py
+++ b/alot/db/envelope.py
@@ -109,7 +109,7 @@ class Envelope(object):
             self.modified_since_sent = True
 
     def __contains__(self, name):
-        return self.headers.__contains__(name)
+        return name in self.headers
 
     def get(self, key, fallback=None):
         """secure getter for header values that allows specifying a `fallback`

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -246,10 +246,11 @@ class Message(object):
 
                 if cd.lower().startswith('attachment'):
                     if ct.lower() not in ['application/pgp-encrypted',
-                                  'application/pgp-signature']:
+                                          'application/pgp-signature']:
                         self._attachments.append(Attachment(part))
                 elif cd.lower().startswith('inline'):
-                    if filename is not None and ct.lower() != 'application/pgp':
+                    if (filename is not None and
+                            ct.lower() != 'application/pgp'):
                         self._attachments.append(Attachment(part))
         return self._attachments
 

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -3,6 +3,7 @@
 # For further details see the COPYING file
 import email
 import email.charset as charset
+import functools
 from datetime import datetime
 
 from notmuch import NullPointerError
@@ -16,6 +17,7 @@ from ..settings import settings
 charset.add_charset('utf-8', charset.QP, charset.QP, 'utf-8')
 
 
+@functools.total_ordering
 class Message(object):
 
     """
@@ -60,10 +62,20 @@ class Message(object):
         """needed for sets of Messages"""
         return hash(self._id)
 
-    def __cmp__(self, other):
-        """needed for Message comparison"""
-        res = cmp(self.get_message_id(), other.get_message_id())
-        return res
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            return self.get_message_id() == other.get_message_id()
+        return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, type(self)):
+            return self.get_message_id() != other.get_message_id()
+        return NotImplemented
+
+    def __lt__(self, other):
+        if isinstance(other, type(self)):
+            return self.get_message_id() < other.get_message_id()
+        return NotImplemented
 
     def get_email(self):
         """returns :class:`email.Message` for this message"""

--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -110,7 +110,7 @@ def message_from_file(handle):
 
     # handle OpenPGP signed data
     if (m.is_multipart() and
-        m.get_content_subtype() == 'signed' and
+            m.get_content_subtype() == 'signed' and
             p.get('protocol') == app_pgp_sig):
         # RFC 3156 is quite strict:
         # * exactly two messages

--- a/alot/settings/theme.py
+++ b/alot/settings/theme.py
@@ -106,11 +106,11 @@ class Theme(object):
         candidates = self._config['search'].sections
         for candidatename in candidates:
             candidate = self._config['search'][candidatename]
-            if candidatename.startswith('threadline') and\
-               (not candidatename == 'threadline') and\
-               matches(candidate, thread):
-                    match = candidate
-                    break
+            if (candidatename.startswith('threadline') and
+                    (not candidatename == 'threadline') and
+                    matches(candidate, thread)):
+                match = candidate
+                break
 
         # fill in values
         res = {}

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -308,7 +308,7 @@ class UI(object):
                                 edit_text=text, history=history,
                                 on_error=cerror)
 
-        for _ in range(tab):  # hit some tabs
+        for _ in xrange(tab):  # hit some tabs
             editpart.keypress((0,), 'tab')
 
         # build promptwidget

--- a/alot/widgets/utils.py
+++ b/alot/widgets/utils.py
@@ -33,8 +33,7 @@ class DialogBox(urwid.WidgetWrap):
                             align='center',
                             valign='top',
                             width=len(title),
-                            height=None,
-                            )
+                            height=None)
         urwid.WidgetWrap.__init__(self, box)
 
     def selectable(self):

--- a/docs/source/usage/modes/global.rst
+++ b/docs/source/usage/modes/global.rst
@@ -12,7 +12,7 @@ The following commands are available globally
     close a buffer
 
     optional arguments
-        :---redraw: redraw current buffer                      after command has finished.
+        :---redraw: redraw current buffer after command has finished.
         :---force: never ask for confirmation.
 
 .. _cmd.global.bprevious:
@@ -94,7 +94,7 @@ The following commands are available globally
     optional arguments
         :---spawn: run in terminal window.
         :---thread: run in separate thread.
-        :---refocus: refocus current buffer                      after command has finished.
+        :---refocus: refocus current buffer after command has finished.
 
 .. _cmd.global.refresh:
 

--- a/docs/source/usage/modes/search.rst
+++ b/docs/source/usage/modes/search.rst
@@ -94,10 +94,7 @@ The following commands are available in search mode
 
 .. describe:: toggletags
 
-    flip presence of tags on this thread.
-    A tag is considered present if at least one message contained in this
-    thread is tagged with it. In that case this command will remove the tag
-    from every message in the thread.
+    flip presence of tags on this thread. A tag is considered present if at least one message contained in this thread is tagged with it. In that case this command will remove the tag from every message in the thread.
 
     argument
         comma separated list of tags


### PR DESCRIPTION
The majority of the changes in this series are whitespace related, and after this series pylint's complaints are down basically to missing docstrings a few other small things here and there. However, this series also contains a few other cleanups and optimizations, including the use of more iterators and fewer (intermediate) concrete objects, not calling dunder methods directly when not necessary, removing useless calls, renaming non-PEP8 variables, and adding TODO's for future cleanups and optimizations (mostly those that are invasive enough that I didn't feel comfortable implementing without unittests.

There are two refactors in here as well, one replaces the `__cmp__` protocol with the rich comparison protocol (`__eq__`, `__lt__`, etc). This is both a performance optimization and is required for python 3, which doesn't have `__cmp__`. The second remove unnecessary concrete instances, and refactors to make use of `enumerate` and `reversed`.

I don't think any of this is too controversial, except for maybe the giant whitespace cleanup patch.