### PR TITLE
Replace twisted command line parsing with argparse

### DIFF
--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -22,12 +22,12 @@ def main():
                         version=alot.__version__)
     parser.add_argument('-r', '--read-only', action='store_true',
                         help='open db in read only mode')
-    parser.add_argument('-c', '--config', type=argparse.FileType('r'),
-                        help='config file')
-    parser.add_argument('-n', '--notmuch-config', type=argparse.FileType('r'),
-                        default=os.environ.get(
+    parser.add_argument('-c', '--config', help='config file',
+                        type=lambda x: argparse.FileType('r')(x).name)
+    parser.add_argument('-n', '--notmuch-config', default=os.environ.get(
                             'NOTMUCH_CONFIG',
                             os.path.expanduser('~/.notmuch-config')),
+                        type=lambda x: argparse.FileType('r')(x).name,
                         help='notmuch config')
     parser.add_argument('-C', '--colour-mode',
                         choices=(1, 16, 256), type=int, default=256,

--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -62,9 +62,8 @@ def main():
         root_logger.removeHandler(log_handler)
     root_logger = None
     numeric_loglevel = getattr(logging, options.debug_level.upper(), None)
-    logfilename = os.path.expanduser(options.logfile)
     logformat = '%(levelname)s:%(module)s:%(message)s'
-    logging.basicConfig(level=numeric_loglevel, filename=logfilename,
+    logging.basicConfig(level=numeric_loglevel, filename=options.logfile,
                         filemode='w', format=logformat)
 
     # locate alot config files
@@ -78,10 +77,11 @@ def main():
         alotconfig = options.config
 
     # locate notmuch config
-    notmuchpath = os.environ.get('NOTMUCH_CONFIG', '~/.notmuch-config')
     if options.notmuch_config:
-        notmuchpath = options.notmuch_config
-    notmuchconfig = os.path.expanduser(notmuchpath)
+        notmuchconfig = options.notmuch_config
+    else:
+        notmuchconfig = os.environ.get('NOTMUCH_CONFIG',
+                                       os.path.expanduser('~/.notmuch-config'))
 
     try:
         settings.read_config(alotconfig)

--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -39,8 +39,10 @@ def main():
                         help='logfile [default: %(default)s]')
     # We will handle the subcommands in a seperate run of argparse as argparse
     # does not support optional subcommands until now.
+    subcommands = ('search', 'compose', 'bufferlist', 'taglist', 'pyshell')
     parser.add_argument('command', nargs=argparse.REMAINDER,
-                        help="possible subcommands are 'search' and 'compose'")
+                        help='possible subcommands are {}'.format(
+                            ', '.join(subcommands)))
     options = parser.parse_args()
     if options.command:
         # We have a command after the initial options so we also parse that.
@@ -48,10 +50,9 @@ def main():
         # command that will back this subcommand.
         parser = argparse.ArgumentParser()
         subparsers = parser.add_subparsers(dest='subcommand')
-        subparsers.add_parser('search',
-                              parents=[COMMANDS['global']['search'][1]])
-        subparsers.add_parser('compose',
-                              parents=[COMMANDS['global']['compose'][1]])
+        for subcommand in subcommands:
+            subparsers.add_parser(subcommand,
+                                  parents=[COMMANDS['global'][subcommand][1]])
         command = parser.parse_args(options.command)
     else:
         command = None
@@ -104,7 +105,7 @@ def main():
             cmdstring = settings.get('initial_command')
         except CommandParseError as err:
             sys.exit(err)
-    elif command.subcommand in ('compose', 'search'):
+    elif command.subcommand in subcommands:
         cmdstring = ' '.join(options.command)
 
     # set up and start interface

--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -78,30 +78,20 @@ def main():
                         filemode='w', format=logformat)
 
     # locate alot config files
-    configfiles = [
-        os.path.join(os.environ.get('XDG_CONFIG_HOME',
-                                    os.path.expanduser('~/.config')),
-                     'alot', 'config'),
-    ]
-    if options.config:
-        expanded_path = os.path.expanduser(options.config)
-        if not os.path.exists(expanded_path):
-            msg = 'Config file "%s" does not exist. Goodbye for now.'
-            sys.exit(msg % expanded_path)
-        configfiles.insert(0, expanded_path)
+    if options.config is None:
+        alotconfig = os.path.join(
+            os.environ.get('XDG_CONFIG_HOME', os.path.expanduser('~/.config')),
+            'alot', 'config')
+        if not os.path.exists(alotconfig):
+            alotconfig = None
+    else:
+        alotconfig = options.config
 
     # locate notmuch config
     notmuchpath = os.environ.get('NOTMUCH_CONFIG', '~/.notmuch-config')
     if options.notmuch_config:
         notmuchpath = options.notmuch_config
     notmuchconfig = os.path.expanduser(notmuchpath)
-
-    alotconfig = None
-    # read the first alot config file we find
-    for configfilename in configfiles:
-        if os.path.exists(configfilename):
-            alotconfig = configfilename
-            break  # use only the first
 
     try:
         settings.read_config(alotconfig)

--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -1,9 +1,10 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-import sys
+import argparse
 import logging
 import os
+import sys
 
 import alot
 from alot.settings import settings
@@ -13,115 +14,65 @@ from alot.ui import UI
 from alot.commands import *
 from alot.commands import CommandParseError
 
-from twisted.python import usage
-
-
-class SubcommandOptions(usage.Options):
-    optFlags = []
-
-    def parseArgs(self, *args):
-        self.args = args
-
-    def as_argparse_opts(self):
-        optstr = ''
-        for k, v in self.iteritems():
-            # flags translate int value 0 or 1..
-            if k in [a[0] for a in self.optFlags]:  # if flag
-                optstr += ('--%s ' % k) * v
-            else:
-                if v is not None:
-                    optstr += '--%s \'%s\' ' % (k, v)
-        return optstr
-
-    def opt_version(self):
-        print alot.__version__
-        sys.exit(0)
-
-
-class ComposeOptions(SubcommandOptions):
-    optParameters = [
-        ['sender', '', None, 'From line'],
-        ['subject', '', None, 'subject line'],
-        ['to', [], None, 'recipients'],
-        ['cc', '', None, 'copy to'],
-        ['bcc', '', None, 'blind copy to'],
-        ['template', '', None, 'path to template file'],
-        ['attach', '', None, 'files to attach'],
-    ]
-    optFlags = [
-        ['omit_signature', '', 'do not add signature'],
-    ]
-
-    def parseArgs(self, *args):
-        SubcommandOptions.parseArgs(self, *args)
-        self.rest = ' '.join(args) or None
-
-
-class SearchOptions(SubcommandOptions):
-    accepted = ['oldest_first', 'newest_first', 'message_id', 'unsorted']
-
-    def colourint(val):
-        if val not in accepted:
-            raise ValueError("Unknown sort order")
-        return val
-    colourint.coerceDoc = "Must be one of " + str(accepted)
-    optParameters = [
-        ['sort', 'newest_first', None, 'Sort order'],
-    ]
-
-
-class Options(usage.Options):
-    optFlags = [["read-only", "r", 'open db in read only mode'], ]
-
-    def colourint(val):
-        val = int(val)
-        if val not in [1, 16, 256]:
-            raise ValueError("Not in range")
-        return val
-    colourint.coerceDoc = "Must be 1, 16 or 256"
-
-    def debuglogstring(val):
-        if val not in ['error', 'debug', 'info', 'warning']:
-            raise ValueError("Not in range")
-        return val
-    debuglogstring.coerceDoc = "Must be one of debug,info,warning or error"
-
-    optParameters = [
-        ['config', 'c', None, 'config file'],
-        ['notmuch-config', 'n', None, 'notmuch config'],
-        ['colour-mode', 'C', None, 'terminal colour mode', colourint],
-        ['mailindex-path', 'p', None, 'path to notmuch index'],
-        ['debug-level', 'd', 'info', 'debug log', debuglogstring],
-        ['logfile', 'l', '/dev/null', 'logfile'],
-    ]
-    search_help = "start in a search buffer using the querystring provided "\
-                  "as parameter. See the SEARCH SYNTAX section of notmuch(1)."
-
-    subCommands = [['search', None, SearchOptions, search_help],
-                   ['compose', None, ComposeOptions, "compose a new message"]]
-
-    def opt_version(self):
-        print alot.__version__
-        sys.exit(0)
-
 
 def main():
-    # interpret cml arguments
-    args = Options()
-    try:
-        args.parseOptions()  # When given no argument, parses sys.argv[1:]
-    except usage.UsageError as errortext:
-        print '%s' % errortext
-        print 'Try --help for usage details.'
-        sys.exit(1)
+    # set up the parser to parse the command line options.
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-v', '--version', action='version',
+                        version=alot.__version__)
+    parser.add_argument('-r', '--read-only', action='store_true',
+                        help='open db in read only mode')
+    parser.add_argument('-c', '--config', type=argparse.FileType('r'),
+                        help='config file')
+    parser.add_argument('-n', '--notmuch-config', type=argparse.FileType('r'),
+                        help='notmuch config')
+    parser.add_argument('-C', '--colour-mode',
+                        choices=(1, 16, 256), type=int, default=256,
+                        help='terminal colour mode [default: %(default)s].')
+    parser.add_argument('-p', '--mailindex-path', #type=directory,
+                        help='path to notmuch index')
+    parser.add_argument('-d', '--debug-level', default='info',
+                        choices=('debug', 'info', 'warning', 'error'),
+                        help='debug log [default: %(default)s]')
+    parser.add_argument('-l', '--logfile', default='/dev/null',
+                        type=lambda x: argparse.FileType('w')(x).name,
+                        help='logfile [default: %(default)s]')
+    parser.add_argument('command', nargs=argparse.REMAINDER)
+    options = parser.parse_args()
+    if options.command:
+        # We have a command after the initial options so we also parse that.
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest='subcommand')
+        search = subparsers.add_parser('search')
+        search.add_argument('--sort', default='newest_first',
+                            help='sort order',
+                            choices=('oldest_first', 'newest_first',
+                                     'message_id', 'unsorted'))
+        search.add_argument('terms', nargs='+')
+        compose = subparsers.add_parser('compose')
+        compose.add_argument('--omit_signature', action='store_true',
+                             help='do not add signature')
+        compose.add_argument('--sender', help='From line')
+        compose.add_argument('--subject', help='subject line')
+        compose.add_argument('--to', help='recipients')
+        compose.add_argument('--cc', help='copy to')
+        compose.add_argument('--bcc', help='blind copy to')
+        compose.add_argument('--template', type=argparse.FileType('r'),
+                             help='path to template file')
+        compose.add_argument('--attach', type=argparse.FileType('r'),
+                             help='files to attach')
+
+        command = parser.parse_args(options.command)
+    else:
+        command = None
 
     # logging
     root_logger = logging.getLogger()
     for log_handler in root_logger.handlers:
         root_logger.removeHandler(log_handler)
     root_logger = None
-    numeric_loglevel = getattr(logging, args['debug-level'].upper(), None)
-    logfilename = os.path.expanduser(args['logfile'])
+    numeric_loglevel = getattr(logging, options.debug_level.upper(), None)
+    logfilename = os.path.expanduser(options.logfile)
     logformat = '%(levelname)s:%(module)s:%(message)s'
     logging.basicConfig(level=numeric_loglevel, filename=logfilename,
                         filemode='w', format=logformat)
@@ -132,8 +83,8 @@ def main():
                                     os.path.expanduser('~/.config')),
                      'alot', 'config'),
     ]
-    if args['config']:
-        expanded_path = os.path.expanduser(args['config'])
+    if options.config:
+        expanded_path = os.path.expanduser(options.config)
         if not os.path.exists(expanded_path):
             msg = 'Config file "%s" does not exist. Goodbye for now.'
             sys.exit(msg % expanded_path)
@@ -141,8 +92,8 @@ def main():
 
     # locate notmuch config
     notmuchpath = os.environ.get('NOTMUCH_CONFIG', '~/.notmuch-config')
-    if args['notmuch-config']:
-        notmuchpath = args['notmuch-config']
+    if options.notmuch_config:
+        notmuchpath = options.notmuch_config
     notmuchconfig = os.path.expanduser(notmuchpath)
 
     alotconfig = None
@@ -159,28 +110,25 @@ def main():
         sys.exit(e)
 
     # store options given by config swiches to the settingsManager:
-    if args['colour-mode']:
-        settings.set('colourmode', args['colour-mode'])
+    if options.colour_mode:
+        settings.set('colourmode', options.colour_mode)
 
     # get ourselves a database manager
     indexpath = settings.get_notmuch_setting('database', 'path')
-    indexpath = args['mailindex-path'] or indexpath
-    dbman = DBManager(path=indexpath, ro=args['read-only'])
+    indexpath = options.mailindex_path or indexpath
+    dbman = DBManager(path=indexpath, ro=options.read_only)
 
     # determine what to do
     try:
-        if args.subCommand == 'search':
-            query = ' '.join(args.subOptions.args)
-            cmdstring = 'search %s %s' % (args.subOptions.as_argparse_opts(),
-                                          query)
-        elif args.subCommand == 'compose':
-            cmdstring = 'compose %s' % args.subOptions.as_argparse_opts()
-            if args.subOptions.rest is not None:
-                cmdstring += ' ' + args.subOptions.rest
-        else:
+        if command is None:
             cmdstring = settings.get('initial_command')
-    except CommandParseError as e:
-        sys.exit(e)
+        elif command.subcommand == 'search':
+            query = ' '.join(command.terms)
+            cmdstring = 'search --sort {} {}'.format(command.sort, query)
+        elif command.subcommand == 'compose':
+            cmdstring = ' '.join(options.command)
+    except CommandParseError as err:
+        sys.exit(err)
 
     # set up and start interface
     UI(dbman, cmdstring)

--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -37,7 +37,10 @@ def main():
     parser.add_argument('-l', '--logfile', default='/dev/null',
                         type=lambda x: argparse.FileType('w')(x).name,
                         help='logfile [default: %(default)s]')
-    parser.add_argument('command', nargs=argparse.REMAINDER)
+    # We will handle the subcommands in a seperate run of argparse as argparse
+    # does not support optional subcommands until now.
+    parser.add_argument('command', nargs=argparse.REMAINDER,
+                        help="possible subcommands are 'search' and 'compose'")
     options = parser.parse_args()
     if options.command:
         # We have a command after the initial options so we also parse that.
@@ -111,6 +114,7 @@ def main():
     exit_hook = settings.get_hook('exit')
     if exit_hook is not None:
         exit_hook()
+
 
 if __name__ == "__main__":
     main()

--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -25,6 +25,9 @@ def main():
     parser.add_argument('-c', '--config', type=argparse.FileType('r'),
                         help='config file')
     parser.add_argument('-n', '--notmuch-config', type=argparse.FileType('r'),
+                        default=os.environ.get(
+                            'NOTMUCH_CONFIG',
+                            os.path.expanduser('~/.notmuch-config')),
                         help='notmuch config')
     parser.add_argument('-C', '--colour-mode',
                         choices=(1, 16, 256), type=int, default=256,
@@ -77,16 +80,9 @@ def main():
     else:
         alotconfig = options.config
 
-    # locate notmuch config
-    if options.notmuch_config:
-        notmuchconfig = options.notmuch_config
-    else:
-        notmuchconfig = os.environ.get('NOTMUCH_CONFIG',
-                                       os.path.expanduser('~/.notmuch-config'))
-
     try:
         settings.read_config(alotconfig)
-        settings.read_notmuch_config(notmuchconfig)
+        settings.read_notmuch_config(options.notmuch_config)
     except (ConfigError, OSError, IOError) as e:
         sys.exit(e)
 

--- a/docs/source/usage/synopsis.rst
+++ b/docs/source/usage/synopsis.rst
@@ -1,20 +1,19 @@
 .. code-block:: none
 
     alot [-r] [-c CONFIGFILE] [-n NOTMUCHCONFIGFILE] [-C {1,16,256}] [-p DB_PATH]
-         [-d {debug,info,warning,error}] [-l LOGFILE] [--version] [--help]
-         [command]
+         [-d {debug,info,warning,error}] [-l LOGFILE] [-v] [-h] [command]
 
 Options
 
     -r, --read-only                open db in read only mode
     -c, --config=FILENAME          config file (default: ~/.config/alot/config)
     -n, --notmuch-config=FILENAME  notmuch config (default: $NOTMUCH_CONFIG or ~/.notmuch-config)
-    -C, --colour-mode=COLOUR        terminal colour mode (default: 256). Must be 1, 16 or 256
+    -C, --colour-mode=COLOUR       terminal colour mode (default: 256). Must be 1, 16 or 256
     -p, --mailindex-path=PATH      path to notmuch index
     -d, --debug-level=LEVEL        debug log (default: info). Must be one of debug,info,warning or error
     -l, --logfile=FILENAME         logfile (default: /dev/null)
-    --version                      Display version string and exit
-    --help                         Display  help and exit
+    -v, --version                  Display version string and exit
+    -h, --help                     Display  help and exit
 
 UNIX Signals
     SIGUSR1
@@ -31,3 +30,6 @@ Subommands
     compose
         compose a new message
         See the output of `alot compose --help` for more info on parameters.
+    pyshell
+        start the interactive python shell inside alot
+        See the output of `alot pyshell --help` for more info on parameters.


### PR DESCRIPTION
As discussed in #942.

The command line interface is copied as directly as possible.  But at least the help output is formatted differently.  We still have to test this a litte bit to find out if I did not mess up some corner case with optional subcommands or some defaults for options.

I have some more ideas how to improve this and will try to add some more commits soon.  I will take care not to rebase so you can already have a look at what I put up already.