### PR TITLE
Remove some irc notifications by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,3 +107,4 @@ script: |
 
 notifications:
     irc: "chat.freenode.net#alot"
+    on_success: change


### PR DESCRIPTION
I did not find a setting to force every master branch build to send notifications. (maybe I missed something: https://docs.travis-ci.com/user/notifications/#IRC-notification) Is that still acceptable?

If we want we can also shorten the message that is send.