### PR TITLE
Settings for enabling mouse

### DIFF
--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -35,6 +35,9 @@ themes_dir = string(default=None)
 # name of the theme to use
 theme = string(default=None)
 
+# enable mouse support - mouse tracking will be handled by urwid
+handle_mouse = boolean(default=True)
+
 # headers that get displayed by default
 displayed_headers = force_list(default=list(From,To,Cc,Bcc,Subject))
 

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -96,7 +96,7 @@ class UI(object):
 
         # set up main loop
         self.mainloop = urwid.MainLoop(self.root_widget,
-                                       handle_mouse=True,
+                                       handle_mouse=settings.get('handle_mouse'),
                                        event_loop=urwid.TwistedEventLoop(),
                                        unhandled_input=self._unhandeled_input,
                                        input_filter=self._input_filter)

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -289,6 +289,16 @@
     :default: "Fwd: "
 
 
+.. _handle-mouse:
+
+.. describe:: handle_mouse
+
+     enable mouse support - mouse tracking will be handled by urwid
+
+    :type: boolean
+    :default: True
+
+
 .. _history-size:
 
 .. describe:: history_size


### PR DESCRIPTION
Enabling mouse support disables the possibility to select text using the mouse in the terminal window. This commit adds a setting, `handle_mouse`, that can be used to turn off mouse support which restores this behaviour.

Setting `handle_mouse = False` in the config file disables mouse support in `alot`. The default value is `True` as not to conflict with the previous commit that enabled mouse support.

*Updated*: Making this a PR for the mouse setting only. Also, holding `<shift>` seems to be a workaround for selecting text in a terminal that is running a program tracking the mouse.