### PR TITLE
Replace None passed to comprehensions with identity function

### DIFF
--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -63,7 +63,7 @@ class BufferlistBuffer(Buffer):
 
     modename = 'bufferlist'
 
-    def __init__(self, ui, filtfun=None):
+    def __init__(self, ui, filtfun=lambda x: x):
         self.filtfun = filtfun
         self.ui = ui
         self.isinitialized = False
@@ -617,7 +617,7 @@ class TagListBuffer(Buffer):
 
     modename = 'taglist'
 
-    def __init__(self, ui, alltags=None, filtfun=None):
+    def __init__(self, ui, alltags=None, filtfun=lambda x: x):
         self.filtfun = filtfun
         self.ui = ui
         self.tags = alltags or []

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -485,7 +485,7 @@ class BufferFocusCommand(Command):
 class OpenBufferlistCommand(Command):
 
     """open a list of active buffers"""
-    def __init__(self, filtfun=None, **kwargs):
+    def __init__(self, filtfun=lambda x: x, **kwargs):
         """
         :param filtfun: filter to apply to displayed list
         :type filtfun: callable (str->bool)
@@ -508,7 +508,7 @@ class OpenBufferlistCommand(Command):
 class TagListCommand(Command):
 
     """opens taglist buffer"""
-    def __init__(self, filtfun=None, tags=None, **kwargs):
+    def __init__(self, filtfun=lambda x: x, tags=None, **kwargs):
         """
         :param filtfun: filter to apply to displayed list
         :type filtfun: callable (str->bool)


### PR DESCRIPTION
One of the differences between map/filter and a comprehension is what
happens with None. For map and filter passing None as the function will
be treated as an identity function (equivalent to lambda x: x), for
comprehensions however, this will raise an exception (calling NoneType).

The fix is rather simple, instead of making the default of filtfun None,
make it an identity function. I've used lambda x: x since it's easy,
although defining an identity function in a utility library might be
preferable since lambdas are slower than normal functions.

Fixes #958