### PR TITLE
alot/commands/globals: fix typo

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -856,7 +856,7 @@ class ComposeCommand(Command):
         if settings.get('compose_ask_tags'):
             comp = TagsCompleter(ui.dbman)
             tagsstring = yield ui.prompt('Tags', completer=comp)
-            tags = [t for t in tagsstring.splie(',') if t]
+            tags = [t for t in tagsstring.split(',') if t]
             if tags is None:
                 raise CommandCanceled()
 


### PR DESCRIPTION
This is a bug, though apparently no one has run into it yet. Found
through inspection.