### PR TITLE
Add hooks to all created commands?

### DIFF
--- a/alot/commands/__init__.py
+++ b/alot/commands/__init__.py
@@ -10,19 +10,52 @@ import os
 import re
 
 from ..settings import settings
-from ..helper import split_commandstring, string_decode
+from ..helper import split_commandstring, string_decode, classproperty
 
 
 class Command(object):
 
     """base class for commands"""
     repeatable = False
+    mode = ""
+    cmdname = ""
+
+    @classproperty
+    def id(cls):
+        """Mode and command name of instance as string."""
+        return "{}.{}".format(cls.mode, cls.cmdname)
 
     def __init__(self):
-        self.prehook = None
-        self.posthook = None
+        # set to False if no attempt to fetch hooks from settings. After
+        # looking for hooks, they will contain a callable or None if no
+        # hook was found.
+        self._prehook = False
+        self._posthook = False
+
         self.undoable = False
         self.help = self.__doc__
+
+    @property
+    def prehook(self):
+        """Command pre hook."""
+        if self._prehook is False:
+            get_hook = settings.get_hook
+            mode = type(self).mode
+            cmdname = type(self).cmdname
+            self._prehook = (get_hook('pre_%s_%s' % (mode, cmdname)) or
+                             get_hook('pre_global_%s' % cmdname))
+        return self._prehook
+
+    @property
+    def posthook(self):
+        """Command post hook."""
+        if self._posthook is False:
+            get_hook = settings.get_hook
+            mode = type(self).mode
+            cmdname = type(self).cmdname
+            self._posthook = (get_hook('post_%s_%s' % (mode, cmdname)) or
+                              get_hook('post_global_%s' % cmdname))
+        return self._posthook
 
     def apply(self, caller):
         """code that gets executed when this command is applied"""
@@ -33,6 +66,7 @@ class CommandCanceled(Exception):
     """ Exception triggered when an interactive command has been cancelled
     """
     pass
+
 
 COMMANDS = {
     'search': {},
@@ -134,15 +168,17 @@ class registerCommand(object):
         self.forced = forced or {}
         self.arguments = arguments or []
 
-    def __call__(self, klass):
-        helpstring = self.help or klass.__doc__
+    def __call__(self, class_):
+        helpstring = self.help or class_.__doc__
         argparser = CommandArgumentParser(description=helpstring,
                                           usage=self.usage,
                                           prog=self.name, add_help=False)
         for args, kwargs in self.arguments:
             argparser.add_argument(*args, **kwargs)
-        COMMANDS[self.mode][self.name] = (klass, argparser, self.forced)
-        return klass
+        COMMANDS[self.mode][self.name] = (class_, argparser, self.forced)
+        class_.mode = self.mode
+        class_.cmdname = self.name
+        return class_
 
 
 def commandfactory(cmdline, mode='global'):
@@ -188,13 +224,6 @@ def commandfactory(cmdline, mode='global'):
 
     # create Command
     cmd = cmdclass(**parms)
-
-    # set pre and post command hooks
-    get_hook = settings.get_hook
-    cmd.prehook = get_hook('pre_%s_%s' % (mode, cmdname)) or \
-        get_hook('pre_global_%s' % cmdname)
-    cmd.posthook = get_hook('post_%s_%s' % (mode, cmdname)) or \
-        get_hook('post_global_%s' % cmdname)
 
     return cmd
 

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -631,3 +631,29 @@ def email_as_string(mail):
                            as_string, flags=re.MULTILINE)
 
     return as_string
+
+
+class classproperty(object):
+    """Decorator to emulate 'class properties' using class level methods.
+
+    The decorator is applied to a method to make it a class property. E.g.
+
+    .. code-block
+
+        class Foo(object):
+
+            _some_property = 0.5
+
+            @classproperty
+            def some_property(cls):
+                return cls._some_proprerty
+    """
+
+    def __init__(self, func):
+        """Store method to be used to return property value."""
+        self.__func__ = func
+
+    def __get__(self, instance, cls):
+        """Return value of property."""
+        return self.__func__(cls)
+

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -659,7 +659,7 @@ class UI(object):
             def call_posthook(_):
                 """Callback function that will invoke the post-hook."""
                 if cmd.posthook:
-                    logging.info('calling post-hook')
+                    logging.info('calling post hook for "%s"', cmd.id)
                     return defer.maybeDeferred(cmd.posthook,
                                                ui=self,
                                                dbm=self.dbman,
@@ -669,7 +669,11 @@ class UI(object):
             def call_apply(_):
                 return defer.maybeDeferred(cmd.apply, self)
 
-            prehook = cmd.prehook or (lambda **kwargs: None)
+            if cmd.prehook:
+                logging.info('calling pre hook for "%s"', cmd.id)
+                prehook = cmd.prehook
+            else:
+                prehook = lambda **kwargs: None
             d = defer.maybeDeferred(prehook, ui=self, dbm=self.dbman, cmd=cmd)
             d.addCallback(call_apply)
             d.addCallbacks(call_posthook, self._error_handler)


### PR DESCRIPTION
Here something I made in order to be able to add pre and post hooks to all commands that are run, not only those initiated from the command line. I don't know if this restriction is by design or if it is a bug. Below follows a description of my line of thoughts. There might be a better way to do this, but this is what I could think of with my limited experience with the code base.

Please do comment and tell me what you think.

**Description**
Even though commands have pre and post hooks, this has only been true for commands initiated from the command line.

This commit changes where the hooks are added. Rather than being added in `commands.commandfactory()`, they are now added in `commands.Command.__init__()`. This because not all commands are created using `commands.commandfactory()`.

In order to implement this, a top level dictionary, `REVERSE_COMMANDS`, has been added using command classes as keys and a tuple containing `cmdname` and `mode` as value. Reverse lookup is done using `reverse_lookup_command(klass)` which takes a command class and returns the mode and name of the command.

**Use-case**
The use-case that motivated this change was that I wanted to create a hook that added `format="flowed"` to the `Content-type` header when replying and composing messages. However, it was not possible to do this, since only the  `reply` and `compose` command's hooks were triggerered which do not have access to the message itself.

The chain of commands being queued and applied include `commands.envelope.EditCommand`, but it the command is created from `commands.globals.ComposeCommand`, which in turn is called from the originating `commands.thread.ReplyCommand`.

Neither the `globals.ComposeCommand` nor the `envelope.EditCommand` have any pre or post hook attached to them since they were not created using `commandfactory` which is made for creating commands from the command line.