### PR TITLE
helper: Don't rely on GNU extensions for strftime

### DIFF
--- a/alot/helper.py
+++ b/alot/helper.py
@@ -235,7 +235,7 @@ def pretty_datetime(d):
     >>> pretty_datetime(now - timedelta(days=356))
     u'Apr 2011'
     """
-    ampm = d.strftime('%P')
+    ampm = d.strftime('%p').lower()
     if len(ampm):
         hourfmt = '%I' + ampm
         hourminfmt = '%I:%M' + ampm


### PR DESCRIPTION
While the reality is that most alot users probably have glibc as their C
library and can therefore rely on %P, it is possible that there are
users or potential users who run a *BSD or other unix-like OS. This
leaves only non-GNU extensions, though some of the extensions are
specified in later POSIX, unix or C specifications.