### PR TITLE
Suggest `notmuch address --format=json` in the docs

### DIFF
--- a/docs/source/configuration/contacts_completion.rst
+++ b/docs/source/configuration/contacts_completion.rst
@@ -64,8 +64,8 @@ Both respect the `ignorecase` option which defaults to `True` and results in cas
 
         .. code-block:: ini
 
-           command = "notmuch address --output=recipients date:1Y.. AND from:my@address.org"
-           regexp = (\"?(?P<name>.+)\"?)?\s*<(?P<email>.*@.+?)>
+           command = 'notmuch address --format=json --output=recipients date:1Y.. AND from:my@address.org'
+           regexp = '\[?{"name": "(?P<name>.*)", "address": "(?P<email>.+)", "name-addr": ".*"}[,\]]?'
            shellcommand_external_filtering = False
 
     Don't hesitate to send me your custom `regexp` values to list them here.


### PR DESCRIPTION
The old regex that was suggested to capture addresses for completion from the
command `notmuch address` was bogus.  The json output format is much more
predictable.

Reported in #990.