### PR TITLE
[RFC] Fix addressbook completion

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 import argparse
 import code
 import email
+import email.utils
 import glob
 import logging
 import os
@@ -805,7 +806,7 @@ class ComposeCommand(Command):
             accounts = settings.get_accounts()
             if len(accounts) == 1:
                 a = accounts[0]
-                fromstring = "%s <%s>" % (a.realname, a.address)
+                fromstring = email.utils.formataddr((a.realname, a.address))
                 self.envelope.add('From', fromstring)
             else:
                 cmpl = AccountCompleter()

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -287,7 +287,16 @@ class ReplyCommand(Command):
 
     @staticmethod
     def clear_my_address(my_addresses, value):
-        """return recipient header without the addresses in my_addresses"""
+        """return recipient header without the addresses in my_addresses
+
+        :param my_addresses: a list of my email addresses (no real name part)
+        :type my_addresses: list(str)
+        :param value: a list of recipient or sender strings (with or without
+            real names as taken from email headers)
+        :type value: list(str)
+        :returns: a new, potentially shortend list
+        :rtype: list(str)
+        """
         new_value = []
         for name, address in getaddresses(value):
             if address not in my_addresses:

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -10,7 +10,7 @@ import os
 import re
 import subprocess
 import tempfile
-from email.utils import getaddresses, parseaddr
+from email.utils import getaddresses, parseaddr, formataddr
 from email.message import Message
 
 from twisted.internet.defer import inlineCallbacks
@@ -102,7 +102,7 @@ def determine_sender(mail, action='reply'):
     logging.debug('using realname: "%s"', realname)
     logging.debug('using address: %s', address)
 
-    from_value = address if realname == '' else '%s <%s>' % (realname, address)
+    from_value = formataddr((realname, address))
     return from_value, account
 
 
@@ -291,10 +291,7 @@ class ReplyCommand(Command):
         new_value = []
         for name, address in getaddresses(value):
             if address not in my_addresses:
-                if name != '':
-                    new_value.append('"%s" <%s>' % (name, address))
-                else:
-                    new_value.append(address)
+                new_value.append(formataddr((name, address)))
         return new_value
 
     @staticmethod
@@ -306,9 +303,7 @@ class ReplyCommand(Command):
         res = dict()
         for name, address in getaddresses(recipients):
             res[address] = name
-        urecipients = ['"{}" <{}>'.format(n, a) if n != ''
-                       else a
-                       for a, n in res.iteritems()]
+        urecipients = [formataddr((n, a)) for a, n in res.iteritems()]
         return sorted(urecipients)
 
 

--- a/alot/completion.py
+++ b/alot/completion.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import abc
 import argparse
+import email.utils
 import glob
 import logging
 import os
@@ -227,14 +228,11 @@ class AbooksCompleter(Completer):
             except AddressbookError as e:
                 raise CompletionError(e)
         if self.addressesonly:
-            returnlist = [(email, len(email)) for (name, email) in res]
+            returnlist = [(addr, len(addr)) for (name, addr) in res]
         else:
             returnlist = []
-            for name, email in res:
-                if name:
-                    newtext = "%s <%s>" % (name, email)
-                else:
-                    newtext = email
+            for name, addr in res:
+                newtext = email.utils.formataddr((name, addr))
                 returnlist.append((newtext, len(newtext)))
         return returnlist
 
@@ -278,7 +276,8 @@ class AccountCompleter(StringlistCompleter):
 
     def __init__(self, **kwargs):
         accounts = settings.get_accounts()
-        resultlist = ["%s <%s>" % (a.realname, a.address) for a in accounts]
+        resultlist = [email.utils.formataddr((a.realname, a.address))
+                      for a in accounts]
         StringlistCompleter.__init__(self, resultlist, match_anywhere=True,
                                      **kwargs)
 

--- a/tests/commands/thread_test.py
+++ b/tests/commands/thread_test.py
@@ -13,10 +13,10 @@ from alot.commands import thread
 
 class Test_ensure_unique_address(unittest.TestCase):
 
-    foo = '"foo" <foo@example.com>'
-    foo2 = '"foo the fanzy" <foo@example.com>'
-    bar = '"bar" <bar@example.com>'
-    baz = '"baz" <baz@example.com>'
+    foo = 'foo <foo@example.com>'
+    foo2 = 'foo the fanzy <foo@example.com>'
+    bar = 'bar <bar@example.com>'
+    baz = 'baz <baz@example.com>'
 
     def test_unique_lists_are_unchanged(self):
         expected = sorted([self.foo, self.bar])

--- a/tests/commands/thread_test.py
+++ b/tests/commands/thread_test.py
@@ -34,3 +34,49 @@ class Test_ensure_unique_address(unittest.TestCase):
             [self.foo, self.foo2])
         expected = [self.foo2]
         self.assertListEqual(actual, expected)
+
+
+class TestClearMyAddress(unittest.TestCase):
+
+    me1 = 'me@example.com'
+    me2 = 'ME@example.com'
+    me_named = 'alot team <me@example.com>'
+    you = 'you@example.com'
+    named = 'somebody you know <somebody@example.com>'
+    imposter = 'alot team <imposter@example.com>'
+    mine = [me1, me2]
+
+    def test_empty_input_returns_empty_list(self):
+        self.assertListEqual(
+            thread.ReplyCommand.clear_my_address(self.mine, []), [])
+
+    def test_only_my_emails_result_in_empty_list(self):
+        expected = []
+        actual = thread.ReplyCommand.clear_my_address(self.mine,
+                                                      self.mine+[self.me_named])
+        self.assertListEqual(actual, expected)
+
+    def test_other_emails_are_untouched(self):
+        input_ = [self.you, self.me1, self.me_named, self.named]
+        expected = [self.you, self.named]
+        actual = thread.ReplyCommand.clear_my_address(self.mine, input_)
+        self.assertListEqual(actual, expected)
+
+    def test_case_matters(self):
+        expected = [self.me1]
+        mine = [self.me2]
+        actual = thread.ReplyCommand.clear_my_address(mine, expected)
+        self.assertListEqual(actual, expected)
+
+    def test_same_address_with_different_real_name_is_removed(self):
+        input_ = [self.me_named, self.you]
+        mine = [self.me1]
+        expected = [self.you]
+        actual = thread.ReplyCommand.clear_my_address(mine, input_)
+        self.assertListEqual(actual, expected)
+
+    def test_real_name_is_never_considered(self):
+        expected = [self.imposter]
+        mine = 'alot team'
+        actual = thread.ReplyCommand.clear_my_address(mine, expected)
+        self.assertListEqual(actual, expected)

--- a/tests/completion_test.py
+++ b/tests/completion_test.py
@@ -13,31 +13,33 @@ import mock
 from alot import completion
 
 
-class AbooksCompleterTest(unittest.TestCase):
+def _mock_lookup(query):
+    """Look up the query from fixed list of names and email addresses."""
+    abook = [
+        ("", "no-real-name@example.com"),
+        ("foo", "foo@example.com"),
+        ("comma, person", "comma@example.com"),
+        ("single 'quote' person", "squote@example.com"),
+        ('double "quote" person', "dquote@example.com"),
+        ("""all 'fanzy' "stuff" at, once""", "all@example.com")
+    ]
+    results = []
+    for name, email in abook:
+        if query in name or query in email:
+            results.append((name, email))
+    return results
 
-    @staticmethod
-    def _mock_lookup(query):
-        """Look up the query from fixed list of names and email addresses."""
-        abook = [
-            ("", "no-real-name@example.com"),
-            ("foo", "foo@example.com"),
-            ("comma, person", "comma@example.com"),
-            ("single 'quote' person", "squote@example.com"),
-            ('double "quote" person', "dquote@example.com"),
-            ("""all 'fanzy' "stuff" at, once""", "all@example.com")
-        ]
-        results = []
-        for name, email in abook:
-            if query in name or query in email:
-                results.append((name, email))
-        return results
+
+class AbooksCompleterTest(unittest.TestCase):
+    """Tests for the address book completion class."""
 
     @classmethod
     def setUpClass(cls):
         abook = mock.Mock()
-        abook.lookup = cls._mock_lookup
+        abook.lookup = _mock_lookup
         cls.empty_abook_completer = completion.AbooksCompleter([])
         cls.example_abook_completer = completion.AbooksCompleter([abook])
+
     def test_empty_address_book_returns_empty_list(self):
         actual = self.__class__.empty_abook_completer.complete('real-name', 9)
         expected = []
@@ -49,6 +51,7 @@ class AbooksCompleterTest(unittest.TestCase):
         self.assertEqual(len(actual), 1)
         self.assertEqual(len(expected), 1)
         self.assertTupleEqual(actual[0], expected[0])
+
     def test_empty_real_name_returns_plain_email_address(self):
         actual = self.__class__.example_abook_completer.complete("real-name", 9)
         expected = [("no-real-name@example.com", 24)]

--- a/tests/completion_test.py
+++ b/tests/completion_test.py
@@ -1,0 +1,86 @@
+# encoding=utf-8
+# Copyright (C) 2017  Lucas Hoffmann
+# This file is released under the GNU GPL, version 3 or a later revision.
+# For further details see the COPYING file
+
+"""Tests for the alot.completion module."""
+from __future__ import absolute_import
+
+import unittest
+
+import mock
+
+from alot import completion
+
+
+class AbooksCompleterTest(unittest.TestCase):
+
+    @staticmethod
+    def _mock_lookup(query):
+        """Look up the query from fixed list of names and email addresses."""
+        abook = [
+            ("", "no-real-name@example.com"),
+            ("foo", "foo@example.com"),
+            ("comma, person", "comma@example.com"),
+            ("single 'quote' person", "squote@example.com"),
+            ('double "quote" person', "dquote@example.com"),
+            ("""all 'fanzy' "stuff" at, once""", "all@example.com")
+        ]
+        results = []
+        for name, email in abook:
+            if query in name or query in email:
+                results.append((name, email))
+        return results
+
+    @classmethod
+    def setUpClass(cls):
+        abook = mock.Mock()
+        abook.lookup = cls._mock_lookup
+        cls.empty_abook_completer = completion.AbooksCompleter([])
+        cls.example_abook_completer = completion.AbooksCompleter([abook])
+    def test_empty_address_book_returns_empty_list(self):
+        actual = self.__class__.empty_abook_completer.complete('real-name', 9)
+        expected = []
+        self.assertListEqual(actual, expected)
+
+    def _assert_only_one_list_entry(self, actual, expected):
+        """Check that the given lists are both of length 1 and the tuple at the
+        first positions are equal."""
+        self.assertEqual(len(actual), 1)
+        self.assertEqual(len(expected), 1)
+        self.assertTupleEqual(actual[0], expected[0])
+    def test_empty_real_name_returns_plain_email_address(self):
+        actual = self.__class__.example_abook_completer.complete("real-name", 9)
+        expected = [("no-real-name@example.com", 24)]
+        self._assert_only_one_list_entry(actual, expected)
+
+    def test_simple_address_with_real_name(self):
+        actual = self.__class__.example_abook_completer.complete("foo", 3)
+        expected = [("foo <foo@example.com>", 21)]
+        self.assertListEqual(actual, expected)
+
+    @unittest.expectedFailure
+    def test_real_name_with_comma(self):
+        actual = self.__class__.example_abook_completer.complete("comma", 5)
+        expected = [('"comma, person" <comma@example.com>', 32)]
+        self.assertListEqual(actual, expected)
+
+    @unittest.expectedFailure
+    def test_real_name_with_single_quotes(self):
+        actual = self.__class__.example_abook_completer.complete("squote", 6)
+        expected = [(""""single 'quote' person" <squote@example.com>""", 47)]
+        self._assert_only_one_list_entry(actual, expected)
+
+    @unittest.expectedFailure
+    def test_real_name_double_quotes(self):
+        actual = self.__class__.example_abook_completer.complete("dquote", 6)
+        expected = [("", 0)]
+        expected = [(""""double 'quote' person" <dquote@example.com>""", 47)]
+        self._assert_only_one_list_entry(actual, expected)
+
+    @unittest.expectedFailure
+    def test_real_name_with_quotes_and_comma(self):
+        actual = self.__class__.example_abook_completer.complete("all", 3)
+        expected = [(r""""all 'fanzy' \"stuff\" at, once" <all@example.com>""",
+                     50)]
+        self._assert_only_one_list_entry(actual, expected)

--- a/tests/completion_test.py
+++ b/tests/completion_test.py
@@ -62,26 +62,22 @@ class AbooksCompleterTest(unittest.TestCase):
         expected = [("foo <foo@example.com>", 21)]
         self.assertListEqual(actual, expected)
 
-    @unittest.expectedFailure
     def test_real_name_with_comma(self):
         actual = self.__class__.example_abook_completer.complete("comma", 5)
-        expected = [('"comma, person" <comma@example.com>', 32)]
+        expected = [('"comma, person" <comma@example.com>', 35)]
         self.assertListEqual(actual, expected)
 
-    @unittest.expectedFailure
     def test_real_name_with_single_quotes(self):
         actual = self.__class__.example_abook_completer.complete("squote", 6)
-        expected = [(""""single 'quote' person" <squote@example.com>""", 47)]
+        expected = [("single 'quote' person <squote@example.com>", 42)]
         self._assert_only_one_list_entry(actual, expected)
 
-    @unittest.expectedFailure
     def test_real_name_double_quotes(self):
         actual = self.__class__.example_abook_completer.complete("dquote", 6)
         expected = [("", 0)]
-        expected = [(""""double 'quote' person" <dquote@example.com>""", 47)]
+        expected = [(r""""double \"quote\" person" <dquote@example.com>""", 46)]
         self._assert_only_one_list_entry(actual, expected)
 
-    @unittest.expectedFailure
     def test_real_name_with_quotes_and_comma(self):
         actual = self.__class__.example_abook_completer.complete("all", 3)
         expected = [(r""""all 'fanzy' \"stuff\" at, once" <all@example.com>""",


### PR DESCRIPTION
There are some fine corner cases when generating a TO header from an address book.  Characters like `,'"` might need special treatment.  I opend this PR early (the code is not yet finished) in order to discuss some of the things with you.

Related: #990, #889

Points to check, discuss and decide:
* [x] look up the RFC how To headers have to be formatted
* [ ] write test cases for all corner cases
* [x] decide how we want to treat which special chars in To headers and if we should add quotes in cases where they are not needed, "just to have it look uniform"
* [x] implement our decisions in alot.completion.AbooksCompleter
* [ ] check the test for proper coding style (@dcbaker is this how I should write the tests and the mock stuff?)
* [ ] more tests?
* [ ] you name it …

At the moment I just wrote some tests to show you what I think are the cases we have to take care of.