### PR TITLE
travis: work around sphinx-1.5.2 problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ install:
       printf '%s = None\n' NotmuchError NullPointerError > notmuch.py
       touch gpgme.py
       # install sphinx for building the html docs
-      pip install sphinx
+      pip install sphinx==1.5.1
     else
       pip install .[test]
     fi


### PR DESCRIPTION
This forces travis to install sphinx 1.5.1 which doesn't display the
warnings 1.5.2 does. This is not a proper solution, but a work around so
that the docs test works and remains useful. We still need to implement
a proper fix.

I am not marking this as a fix for the problem, we need to figure out whether we're doing something wrong, or whether this is a bug in sphinx, and address that accordingly.