### PR TITLE
Default to not handling mouse

### DIFF
--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -36,7 +36,7 @@ themes_dir = string(default=None)
 theme = string(default=None)
 
 # enable mouse support - mouse tracking will be handled by urwid
-handle_mouse = boolean(default=True)
+handle_mouse = boolean(default=False)
 
 # headers that get displayed by default
 displayed_headers = force_list(default=list(From,To,Cc,Bcc,Subject))

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -296,7 +296,7 @@
      enable mouse support - mouse tracking will be handled by urwid
 
     :type: boolean
-    :default: True
+    :default: False
 
 
 .. _history-size:


### PR DESCRIPTION
As discussed elsewhere, handling the mouse was not done before, and
breaks work flows that include using the mouse for other things
(middle-clock paste). This only changes the default option to False.