### PR TITLE
helper: Use kibi and mibibytes instead of kilo and megabytes

### DIFF
--- a/alot/helper.py
+++ b/alot/helper.py
@@ -511,8 +511,10 @@ def tag_cmp(a, b):
 
 def humanize_size(size):
     """Create a nice human readable representation of the given number
-    (understood as bytes) using the "K" and "M" suffixes to indicate kilo- and
-    megabytes.  They are understood to be 1024 based.
+    (understood as bytes) using the "KiB" and "MiB" suffixes to indicate
+    kibibytes and mebibytes. A kibibyte is defined as 1024 bytes (as opposed to
+    a kilobyte which is 1000 bytes) and a mibibyte is 1024**2 bytes (as opposed
+    to a megabyte which is 1000**2 bytes).
 
     :param size: the number to convert
     :type size: int
@@ -520,8 +522,8 @@ def humanize_size(size):
     :rtype: str
     """
     for factor, format_string in ((1, '%i'),
-                                  (1024, '%iK'),
-                                  (1024 * 1024, '%.1fM')):
+                                  (1024, '%iKiB'),
+                                  (1024 * 1024, '%.1fMiB')):
         if size / factor < 1024:
             return format_string % (float(size) / factor)
     return format_string % (size / factor)

--- a/tests/helper_test.py
+++ b/tests/helper_test.py
@@ -80,23 +80,23 @@ class TestHumanizeSize(unittest.TestCase):
         readable = helper.humanize_size(1023)
         self.assertEqual(readable, "1023")
         readable = helper.humanize_size(1024)
-        self.assertEqual(readable, "1K")
+        self.assertEqual(readable, "1KiB")
         readable = helper.humanize_size(1234)
-        self.assertEqual(readable, "1K")
+        self.assertEqual(readable, "1KiB")
 
     def test_numbers_above_1048576_are_converted_to_megabyte(self):
         readable = helper.humanize_size(1024*1024-1)
-        self.assertEqual(readable, "1023K")
+        self.assertEqual(readable, "1023KiB")
         readable = helper.humanize_size(1024*1024)
-        self.assertEqual(readable, "1.0M")
+        self.assertEqual(readable, "1.0MiB")
 
     def test_megabyte_numbers_are_converted_with_precision_1(self):
         readable = helper.humanize_size(1234*1024)
-        self.assertEqual(readable, "1.2M")
+        self.assertEqual(readable, "1.2MiB")
 
     def test_numbers_are_not_converted_to_gigabyte(self):
         readable = helper.humanize_size(1234*1024*1024)
-        self.assertEqual(readable, "1234.0M")
+        self.assertEqual(readable, "1234.0MiB")
 
 
 class TestSplitCommandline(unittest.TestCase):


### PR DESCRIPTION
Technically a kilobyte (and it's derivatives like megabytes and
gigabytes) are defined as powers of 1000, while a kibibyte (and it's
derivatives like mibibytes and gibibytes) are defined as powers of 1024.

This patch fixes incorrect language and formatting in the humanize_size
function which defined a kilobyte as 1024.

See this wikipedia article for more information:
https://en.wikipedia.org/wiki/Kibibyte