### PR TITLE
[RFC] ANSI-escape codes for colourful HTML mails

### DIFF
--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -17,6 +17,9 @@ input_timeout = float(default=1.0)
 # .. note:: this config setting is equivalent to, but independent of, the 'search.exclude_tags' in the notmuch config.
 exclude_tags = force_list(default=list())
 
+# display background colors set by ANSI character escapes
+interpret_ansi_background = boolean(default=True)
+
 # confirm exit
 bug_on_exit = boolean(default=False)
 

--- a/alot/widgets/ansi.py
+++ b/alot/widgets/ansi.py
@@ -1,0 +1,115 @@
+# Copyright (C) 2011-2017  Patrick Totzke <patricktotzke@gmail.com>
+# This file is released under the GNU GPL, version 3 or a later revision.
+# For further details see the COPYING file
+
+import urwid
+
+
+class ANSIText(urwid.WidgetWrap):
+
+    """Selectable Text widget that interprets ANSI color codes"""
+
+    def __init__(self, txt,
+                 default_attr=None,
+                 default_attr_focus=None,
+                 ansi_background=True, **kwds):
+        ct, focus_map = parse_escapes_to_urwid(txt, default_attr,
+                                               default_attr_focus,
+                                               ansi_background)
+        t = urwid.Text(ct, **kwds)
+        attr_map = {default_attr.background: ''}
+        w = urwid.AttrMap(t, attr_map, focus_map)
+        urwid.WidgetWrap.__init__(self, w)
+
+    def selectable(self):
+        return True
+
+    def keypress(self, size, key):
+        return key
+
+ECODES = {
+    '1': {'bold': True},
+    '4': {'underline': True},
+    '7': {'standout': True},
+    '30': {'fg': 'black'},
+    '31': {'fg': 'dark red'},
+    '32': {'fg': 'dark green'},
+    '33': {'fg': 'brown'},
+    '34': {'fg': 'dark blue'},
+    '35': {'fg': 'dark magenta'},
+    '36': {'fg': 'dark cyan'},
+    '37': {'fg': 'light gray'},
+    '40': {'bg': 'black'},
+    '41': {'bg': 'dark red'},
+    '42': {'bg': 'dark green'},
+    '43': {'bg': 'brown'},
+    '44': {'bg': 'dark blue'},
+    '45': {'bg': 'dark magenta'},
+    '46': {'bg': 'dark cyan'},
+    '47': {'bg': 'light gray'},
+}
+
+
+def parse_escapes_to_urwid(text, default_attr=None, default_attr_focus=None,
+                           parse_background=True):
+    """This function converts a text with ANSI escape for terminal
+    attributes and returns a list containing each part of text and its
+    corresponding Urwid Attributes object, it also returns a dictionary which
+    maps all attributes applied here to focused attribute.
+    """
+
+    text = text.split("\033[")
+    urwid_text = [text[0]]
+    urwid_focus = {None: default_attr_focus}
+
+    # Escapes are cumulative so we always keep previous values until it's
+    # changed by another escape.
+    attr = dict(fg=default_attr._foreground_color, bg=default_attr.background,
+                bold=default_attr.bold, underline=default_attr.underline,
+                standout=default_attr.underline)
+    for part in text[1:]:
+        esc_code, esc_substr = part.split('m', 1)
+        esc_code = esc_code.split(';')
+
+        if not esc_code:
+            attr.update(fg=default_attr._foreground_color,
+                        bg=default_attr.background, bold=default_attr.bold,
+                        underline=default_attr.underline,
+                        standout=default_attr.underline)
+        else:
+            i = 0
+            while i < len(esc_code):
+                code = esc_code[i]
+                if code is 0:
+                    attr.update({'bold': default_attr.bold,
+                                 'underline': default_attr.underline,
+                                 'standout': default_attr.standout})
+                if code in ECODES:
+                    attr.update(ECODES[code])
+                # 256 codes
+                elif code == '38':
+                    attr.update(fg='h' + esc_code[i+2])
+                    i += 2
+                elif code == '48':
+                    attr.update(bg='h'+esc_code[i+2])
+                    i += 2
+                i += 1
+
+        # If there is no string in esc_substr we skip it, the above
+        # attributes will accumulate to the next escapes.
+        if esc_substr:
+            # Construct Urwid attributes
+            urwid_fg = attr['fg']
+            urwid_bg = default_attr.background
+            if attr['bold']:
+                urwid_fg += ',bold'
+            if attr['underline']:
+                urwid_fg += ',underline'
+            if attr['standout']:
+                urwid_fg += ',standout'
+            if parse_background:
+                urwid_bg = attr['bg']
+            urwid_attr = urwid.AttrSpec(urwid_fg, urwid_bg)
+            urwid_focus[urwid_attr] = default_attr_focus
+            urwid_text.append((urwid_attr, esc_substr))
+    return urwid_text, urwid_focus

--- a/alot/widgets/ansi.py
+++ b/alot/widgets/ansi.py
@@ -17,7 +17,7 @@ class ANSIText(urwid.WidgetWrap):
                                                default_attr_focus,
                                                ansi_background)
         t = urwid.Text(ct, **kwds)
-        attr_map = {default_attr.background: ''}
+        attr_map = { default_attr.background: ''}
         w = urwid.AttrMap(t, attr_map, focus_map)
         urwid.WidgetWrap.__init__(self, w)
 

--- a/alot/widgets/ansi.py
+++ b/alot/widgets/ansi.py
@@ -17,7 +17,7 @@ class ANSIText(urwid.WidgetWrap):
                                                default_attr_focus,
                                                ansi_background)
         t = urwid.Text(ct, **kwds)
-        attr_map = { default_attr.background: ''}
+        attr_map = {default_attr.background: ''}
         w = urwid.AttrMap(t, attr_map, focus_map)
         urwid.WidgetWrap.__init__(self, w)
 
@@ -26,6 +26,7 @@ class ANSIText(urwid.WidgetWrap):
 
     def keypress(self, size, key):
         return key
+
 
 ECODES = {
     '1': {'bold': True},

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -80,16 +80,17 @@ class TextlinesList(SimpleTree):
         for each line in content.
         """
         structure = []
+        ansi_background = settings.get("interpret_ansi_background")
 
         # depending on this config setting, we either add individual lines
         # or the complete context as focusable objects.
         if settings.get('thread_focus_linewise'):
             for line in content.splitlines():
                 structure.append((ANSIText(line, attr, attr_focus,
-                                           ansi_background=False), None))
+                                           ansi_background), None))
         else:
             structure.append((ANSIText(content, attr, attr_focus,
-                                       ansi_background=False), None))
+                                       ansi_background), None))
         SimpleTree.__init__(self, structure)
 
 

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -6,8 +6,10 @@ Widgets specific to thread mode
 """
 import logging
 import urwid
+
 from urwidtrees import Tree, SimpleTree, CollapsibleTree
 
+from .ansi import ANSIText
 from .globals import TagWidget
 from .globals import AttachmentWidget
 from ..settings.const import settings
@@ -71,20 +73,6 @@ class MessageSummaryWidget(urwid.WidgetWrap):
         return key
 
 
-class FocusableText(urwid.WidgetWrap):
-    """Selectable Text used for nodes in our example"""
-    def __init__(self, txt, att, att_focus):
-        t = urwid.Text(txt)
-        w = urwid.AttrMap(t, att, att_focus)
-        urwid.WidgetWrap.__init__(self, w)
-
-    def selectable(self):
-        return True
-
-    def keypress(self, size, key):
-        return key
-
-
 class TextlinesList(SimpleTree):
     def __init__(self, content, attr=None, attr_focus=None):
         """
@@ -97,9 +85,11 @@ class TextlinesList(SimpleTree):
         # or the complete context as focusable objects.
         if settings.get('thread_focus_linewise'):
             for line in content.splitlines():
-                structure.append((FocusableText(line, attr, attr_focus), None))
+                structure.append((ANSIText(line, attr, attr_focus,
+                                           ansi_background=False), None))
         else:
-            structure.append((FocusableText(content, attr, attr_focus), None))
+            structure.append((ANSIText(content, attr, attr_focus,
+                                       ansi_background=False), None))
         SimpleTree.__init__(self, structure)
 
 

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -370,6 +370,16 @@
     :default: 1.0
 
 
+.. _interpret-ansi-background:
+
+.. describe:: interpret_ansi_background
+
+     display background colors set by ANSI character escapes
+
+    :type: boolean
+    :default: True
+
+
 .. _mailinglists:
 
 .. describe:: mailinglists


### PR DESCRIPTION
This is a rebase of an old branch "0.3.6-feature-color-wip", which I will retire now, and ultimately passes on a proof-of-concept implementation of TextWidgets that interprets [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors).

The aim is to let the html renderer interpret colours from html mails and translate them to ANSI escapes. For instance, elinks can do this:

```
text/html; elinks -force-html -dump -dump-color-mode 3 -dump-charset utf8 -eval 'set document.codepage.assume = "%{charset}"' %s; copiousoutput
```

This feature can be enabled simply by configuring your mailcap as above and should not have any effect
if the browser does not produce these characters.
The boolean config setting can be used to disable interpretation of a subset of escape codes,
those which change the background colour of text (on top of say, changing foreground or character weights).

This is intended as a RFC and is not at all ready to go live!

I'll retire the related issue #612 because that PR is outdated.