### PR TITLE
tests: Instruct pylint to ignore a large swath of warnings

### DIFF
--- a/tests/commands/envelope_tests.py
+++ b/tests/commands/envelope_tests.py
@@ -27,9 +27,14 @@ import mock
 
 from alot.commands import envelope
 
+# When using an assert from a mock a TestCase method might not use self. That's
+# okay.
+# pylint: disable=no-self-use
+
 
 @contextlib.contextmanager
 def temporary_directory(suffix='', prefix='', dir=None):
+    # pylint: disable=redefined-builtin
     """Python3 interface implementation.
 
     Python3 provides a class that can be used as a context manager, which

--- a/tests/commands/init_test.py
+++ b/tests/commands/init_test.py
@@ -12,6 +12,13 @@ import mock
 from alot import commands
 from alot.commands import thread
 
+# Good descriptive test names often don't fit PEP8, which is meant to cover
+# functions meant to be called by humans.
+# pylint: disable=invalid-name
+
+# These are tests, don't worry about names like "foo" and "bar"
+# pylint: disable=blacklisted-name
+
 
 class TestLookupCommand(unittest.TestCase):
 
@@ -39,7 +46,7 @@ class TestRegisterCommand(unittest.TestCase):
         """using registerCommand adds to the COMMANDS dict."""
         with mock.patch('alot.commands.COMMANDS', {'foo': {}}):
             @commands.registerCommand('foo', 'test')
-            def foo():
+            def foo():  # pylint: disable=unused-variable
                 pass
 
             self.assertIn('test', commands.COMMANDS['foo'])

--- a/tests/commands/thread_test.py
+++ b/tests/commands/thread_test.py
@@ -10,6 +10,13 @@ import unittest
 
 from alot.commands import thread
 
+# Good descriptive test names often don't fit PEP8, which is meant to cover
+# functions meant to be called by humans.
+# pylint: disable=invalid-name
+
+# These are tests, don't worry about names like "foo" and "bar"
+# pylint: disable=blacklisted-name
+
 
 class Test_ensure_unique_address(unittest.TestCase):
 

--- a/tests/completion_test.py
+++ b/tests/completion_test.py
@@ -12,6 +12,10 @@ import mock
 
 from alot import completion
 
+# Good descriptive test names often don't fit PEP8, which is meant to cover
+# functions meant to be called by humans.
+# pylint: disable=invalid-name
+
 
 def _mock_lookup(query):
     """Look up the query from fixed list of names and email addresses."""

--- a/tests/utils/argparse_test.py
+++ b/tests/utils/argparse_test.py
@@ -29,6 +29,14 @@ import mock
 
 from alot.utils import argparse as cargparse
 
+# Good descriptive test names often don't fit PEP8, which is meant to cover
+# functions meant to be called by humans.
+# pylint: disable=invalid-name
+
+# When using mock asserts its possible that many methods will not use self,
+# that's fine
+# pylint: disable=no-self-use
+
 
 class TestValidatedStore(unittest.TestCase):
     """Tests for the ValidatedStore action class."""
@@ -56,7 +64,7 @@ class TestValidatedStore(unittest.TestCase):
 
 
 @contextlib.contextmanager
-def temporary_directory(suffix='', prefix='', dir=None):
+def temporary_directory(suffix='', prefix='', dir=None):  # pylint: disable=redefined-builtin
     """Python3 interface implementation.
 
     Python3 provides a class that can be used as a context manager, which

--- a/tests/utils/configobj_test.py
+++ b/tests/utils/configobj_test.py
@@ -5,6 +5,10 @@ import unittest
 
 from alot.utils import configobj as checks
 
+# Good descriptive test names often don't fit PEP8, which is meant to cover
+# functions meant to be called by humans.
+# pylint: disable=invalid-name
+
 
 class TestForceList(unittest.TestCase):
 

--- a/tests/widgets/globals_test.py
+++ b/tests/widgets/globals_test.py
@@ -29,6 +29,8 @@ class TestTagWidget(unittest.TestCase):
 
     def test_sort(self):
         """Test sorting."""
+        # There's an upstream bug about this
+        # pylint: disable=bad-continuation
         with mock.patch(
                 'alot.widgets.globals.settings.get_tagstring_representation',
                 lambda t, _, __: {'translated': t, 'normal': None,


### PR DESCRIPTION
There are a number of things pylint warns on that absolutely make sense
to fix in production code, but for unittests they either don't matter
(like naming variables "foo"), can't be fixed (TestCase methods that
don't use self because they use a mock assert), or the descriptive names
violate PEP8. These are annoying and create noise, so tell pylint to
ignore them.