### PR TITLE
alot/db/utils: Revert use of iterkeys on Message

### DIFF
--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -251,7 +251,7 @@ def extract_headers(mail, headers=None):
     """
     headertext = u''
     if headers is None:
-        headers = mail.iterkeys()
+        headers = mail.keys()
     for key in headers:
         value = u''
         if key in mail:


### PR DESCRIPTION
Message doesn't have an iterkeys method, just a keys method.