### PR TITLE
optional linewise focussing in thread mode

### DIFF
--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -256,6 +256,12 @@ history_size = integer(default=50)
 # The number of seconds to wait between calls to the loop_hook
 periodic_hook_frequency = integer(default=300)
 
+# Split message body linewise and allows to (move) the focus to each individual
+# line. Setting this to False will result in one potentially big text widget
+# for the whole message body.
+thread_focus_linewise = boolean(default=True)
+
+
 # Key bindings
 [bindings]
     __many__ = string(default=None)

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -94,8 +94,14 @@ class TextlinesList(SimpleTree):
         for each line in content.
         """
         structure = []
-        for line in content.splitlines():
-            structure.append((FocusableText(line, attr, attr_focus), None))
+
+        # depending on this config setting, we either add individual lines
+        # or the complete context as focusable objects.
+        if settings.get('thread_focus_linewise'):
+            for line in content.splitlines():
+                structure.append((FocusableText(line, attr, attr_focus), None))
+        else:
+            structure.append((FocusableText(content, attr, attr_focus), None))
         SimpleTree.__init__(self, structure)
 
 

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -633,6 +633,18 @@
     :default: True
 
 
+.. _thread-focus-linewise:
+
+.. describe:: thread_focus_linewise
+
+     Split message body linewise and allows to (move) the focus to each individual
+     line. Setting this to False will result in one potentially big text widget
+     for the whole message body.
+
+    :type: boolean
+    :default: True
+
+
 .. _thread-statusbar:
 
 .. describe:: thread_statusbar


### PR DESCRIPTION
This introduces a new config option 'thread_focus_linewise',
(defaults to True), which determines if the message texts are
split into individually focussable lines in thread mode.

fixes #645