### PR TITLE
Fix the packaging of tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include COPYING
 include NEWS
 include extra/completion/alot-completion.zsh
 include extra/alot.desktop
-recursive-exclude tests *
+include tests
+recursive-exclude *

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='alot',
       author_email=alot.__author_email__,
       url=alot.__url__,
       license=alot.__copyright__,
-      packages=find_packages(),
+      packages=find_packages(exclude=['tests*']),
       package_data={'alot': [
                              'defaults/alot.rc.spec',
                              'defaults/notmuch.rc.spec',


### PR DESCRIPTION
* Include the tests in the sdist
* Don't install the test packages if present when running setup.py install.

This way installing correctly omits the tests/ subdirectory when installing from a git checkout -- previously this would install a package called "tests" as well. Furthermore, the tests are now included in the sdist, as they should be.

I was notified of the git checkout issue because I'm still using github's tarballs for the AUR package, and one of them was getting file conflicts (presumably with some other package making the same mistake, but I haven't heard back from them).