### PR TITLE
alot.rc.spec: Fix typo in documentation

### DIFF
--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -80,7 +80,7 @@ editor_cmd = string(default=None)
 # file encoding used by your editor
 editor_writes_encoding = string(default='UTF-8')
 
-# use terminal_command to spawn a new terminal for the editor?
+# use :ref:`terminal_cmd <terminal-cmd>` to spawn a new terminal for the editor?
 # equivalent to always providing the `--spawn=yes` parameter to compose/edit commands
 editor_spawn = boolean(default=False)
 

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -192,7 +192,7 @@
 
 .. describe:: editor_spawn
 
-     use terminal_command to spawn a new terminal for the editor?
+     use :ref:`terminal_cmd <terminal-cmd>` to spawn a new terminal for the editor?
      equivalent to always providing the `--spawn=yes` parameter to compose/edit commands
 
     :type: boolean


### PR DESCRIPTION
It currently lists "terminal_command" in relation to "editor_spawn" but
the config option is actually "terminal_cmd".