### PR TITLE
fix #1036

### DIFF
--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -376,6 +376,9 @@ class ThreadBuffer(Buffer):
         self.message_count = self.thread.get_total_messages()
 
     def render(self, size, focus=False):
+        if self.message_count == 0:
+            return self.body.render(size, focus)
+
         if settings.get('auto_remove_unread'):
             logging.debug('Tbuffer: auto remove unread tag from msg?')
             msg = self.get_selected_message()


### PR DESCRIPTION
This prevents the threadbuffer to look up a nonexistent focussed message
if the thread is empty (e.g. after removal of the last msg).