### PR TITLE
Remove Java style getters

### DIFF
--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -308,7 +308,7 @@ class SearchBuffer(Buffer):
             self.body.set_focus(0)
         elif self.result_count < 200 or self.sort_order not in self._REVERSE:
             self.consume_pipe()
-            num_lines = len(self.threadlist.get_lines())
+            num_lines = len(self.threadlist.lines)
             self.body.set_focus(num_lines - 1)
         else:
             self.rebuild(reverse=True)

--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -676,4 +676,4 @@ class TagListBuffer(Buffer):
         """returns selected tagstring"""
         cols, _ = self.taglist.get_focus()
         tagwidget = cols.original_widget.get_focus()
-        return tagwidget.get_tag()
+        return tagwidget.tag

--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -282,7 +282,7 @@ class SearchBuffer(Buffer):
         returns curently focussed :class:`alot.widgets.ThreadlineWidget`
         from the result list.
         """
-        threadlinewidget, _ = self.threadlist.get_focus()
+        threadlinewidget, _ = self.threadlist.focus
         return threadlinewidget
 
     def get_selected_thread(self):

--- a/alot/walker.py
+++ b/alot/walker.py
@@ -16,18 +16,20 @@ class PipeWalker(urwid.ListWalker):
         self.kwargs = kwargs
         self.containerclass = containerclass
         self.lines = []
-        self.focus = 0
+        self._focus = 0
         self.empty = False
         self.direction = -1 if reverse else 1
 
     def __contains__(self, name):
         return self.lines.__contains__(name)
 
-    def get_focus(self):
-        return self._get_at_pos(self.focus)
+    @property
+    def focus(self):
+        return self._get_at_pos(self._focus)
 
-    def set_focus(self, focus):
-        self.focus = focus
+    @focus.setter
+    def focus(self, value):
+        self._focus = value
         self._modified()
 
     def get_next(self, start_from):
@@ -37,9 +39,9 @@ class PipeWalker(urwid.ListWalker):
         return self._get_at_pos(start_from - self.direction)
 
     def remove(self, obj):
-        next_focus = self.focus % len(self.lines)
-        if self.focus == len(self.lines) - 1 and self.empty:
-            next_focus = self.focus - 1
+        next_focus = self._focus % len(self.lines)
+        if self._focus == len(self.lines) - 1 and self.empty:
+            next_focus = self._focus - 1
 
         self.lines.remove(obj)
         if self.lines:

--- a/alot/walker.py
+++ b/alot/walker.py
@@ -8,8 +8,12 @@ import urwid
 
 
 class PipeWalker(urwid.ListWalker):
-    """urwid.ListWalker that reads next items from a pipe and
-    wraps them in `containerclass` widgets for displaying
+    """urwid.ListWalker that reads next items from a pipe and wraps them in
+    `containerclass` widgets for displaying
+
+    Atributes that should be considered publicly readable:
+        :attr lines: the lines obtained from the pipe
+        :type lines: list(`containerclass`)
     """
     def __init__(self, pipe, containerclass, reverse=False, **kwargs):
         self.pipe = pipe

--- a/alot/walker.py
+++ b/alot/walker.py
@@ -79,6 +79,3 @@ class PipeWalker(urwid.ListWalker):
             next_widget = None
             self.empty = True
         return next_widget
-
-    def get_lines(self):
-        return self.lines

--- a/alot/widgets/globals.py
+++ b/alot/widgets/globals.py
@@ -307,9 +307,6 @@ class TagWidget(urwid.AttrMap):
     def keypress(self, size, key):
         return key
 
-    def get_tag(self):
-        return self.tag
-
     def set_focussed(self):
         self.set_attr_map(self.attmaps['focus'])
 

--- a/alot/widgets/globals.py
+++ b/alot/widgets/globals.py
@@ -279,6 +279,10 @@ class TagWidget(urwid.AttrMap):
 
     It looks up the string it displays in the `tags` section
     of the config as well as custom theme settings for its tag.
+
+    Atributes that should be considered publicly readable:
+        :attr tag: the notmuch tag
+        :type tag: str
     """
     def __init__(self, tag, fallback_normal=None, fallback_focus=None):
         self.tag = tag


### PR DESCRIPTION
There are some more in the code but I did not know which belong to some urwid interface that we implement and which could be removed.

If you agree I would say we should note which of our methods overwrite/implement some library interface in the docstring of the method. (Another job on the incremental TODO list.)