### PR TITLE
docs: Fix sphinx warnings (and build) on sphinx > 1.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ install:
       printf '%s = None\n' NotmuchError NullPointerError > notmuch.py
       touch gpgme.py
       # install sphinx for building the html docs
-      pip install sphinx==1.5.1
+      pip install sphinx
     else
       pip install .[test]
     fi

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -23,7 +23,6 @@ First Steps
 .. toctree::
    :hidden:
 
-   commands
    first_steps
    synopsis
    crypto


### PR DESCRIPTION
It turns out that commands was included in the toctree twice, which
caused warnings which we treat as errors in CI.

Fixes #994