### PR TITLE
docs: Remove spurious reference _account in config_options

### DIFF
--- a/docs/source/configuration/config_options.rst
+++ b/docs/source/configuration/config_options.rst
@@ -9,5 +9,3 @@ if the type says "boolean" you may only provide "True" or "False" as values in y
 otherwise alot will complain on startup. Strings *may* be quoted but do not need to be.
 
 .. include:: alotrc_table
-
-.. _account:


### PR DESCRIPTION
This reference doesn't seem to actually be referenced anywhere, not even in the commit that added it.