### PR TITLE
Add some tests

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -68,7 +68,7 @@ def determine_sender(mail, action='reply'):
     # account X is the one selected and not account Y.
     candidate_headers = settings.get("reply_account_header_priority")
     for candidate_header in candidate_headers:
-        if realname is not None:
+        if matching_account is not None:
             break
         candidate_addresses = getaddresses(mail.get_all(candidate_header, []))
 
@@ -80,7 +80,7 @@ def determine_sender(mail, action='reply'):
             if account.alias_regexp is not None:
                 acc_addresses.append(account.alias_regexp)
             for alias in acc_addresses:
-                if realname is not None:
+                if matching_account is not None:
                     break
                 regex = re.compile('^' + alias + '$', flags=re.IGNORECASE)
                 for seen_name, seen_address in candidate_addresses:
@@ -97,7 +97,7 @@ def determine_sender(mail, action='reply'):
                         matching_account = account
 
     # revert to default account if nothing found
-    if realname is None:
+    if matching_account is None:
         matching_account = my_accounts[0]
         realname = matching_account.realname
         address = matching_account.address

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -54,6 +54,7 @@ def determine_sender(mail, action='reply'):
     assert action in ['reply', 'forward', 'bounce']
     realname = None
     address = None
+    matching_account = None
 
     # get accounts
     my_accounts = settings.get_accounts()
@@ -93,17 +94,18 @@ def determine_sender(mail, action='reply'):
                             address = account.address
                         else:
                             address = seen_address
+                        matching_account = account
 
     # revert to default account if nothing found
     if realname is None:
-        account = my_accounts[0]
-        realname = account.realname
-        address = account.address
+        matching_account = my_accounts[0]
+        realname = matching_account.realname
+        address = matching_account.address
     logging.debug('using realname: "%s"', realname)
     logging.debug('using address: %s', address)
 
     from_value = formataddr((realname, address))
-    return from_value, account
+    return from_value, matching_account
 
 
 @registerCommand(MODE, 'reply', arguments=[

--- a/alot/crypto.py
+++ b/alot/crypto.py
@@ -291,6 +291,7 @@ def check_uid_validity(key, email):
     """
     for key_uid in key.uids:
         if email == key_uid.email and not key_uid.revoked and \
-                not key_uid.invalid and key_uid.validity >= 4:
+                not key_uid.invalid and \
+                key_uid.validity >= gpgme.VALIDITY_FULL:
             return True
     return False

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -104,6 +104,14 @@ def string_sanitize(string, tab_width=8):
 def string_decode(string, enc='ascii'):
     """
     safely decodes string to unicode bytestring, respecting `enc` as a hint.
+
+    :param string: the string to decode
+    :type string: str or unicode
+    :param enc: a hint what encoding is used in string ('ascii', 'utf-8', ...)
+    :type enc: str
+    :returns: the unicode decoded input string
+    :rtype: unicode
+
     """
 
     if enc is None:

--- a/tests/addressbook/init_test.py
+++ b/tests/addressbook/init_test.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2017  Lucas Hoffmann
+# This file is released under the GNU GPL, version 3 or a later revision.
+# For further details see the COPYING file
+from __future__ import absolute_import
+
+import unittest
+
+from alot import addressbook
+
+
+class _AddressBook(addressbook.AddressBook):
+
+    """Implements stubs for ABC methods.  The return value for get_contacts can
+    be set on instance creation."""
+
+    def __init__(self, contacts, **kwargs):
+        self._contacts = contacts
+        super(_AddressBook, self).__init__(**kwargs)
+
+    def get_contacts(self):
+        return self._contacts
+
+
+class TestAddressBook(unittest.TestCase):
+
+    def test_lookup_will_match_names(self):
+        contacts = [('foo', 'x@example.com'), ('bar', 'y@example.com'),
+                    ('baz', 'z@example.com')]
+        abook = _AddressBook(contacts)
+        actual = abook.lookup('bar')
+        expected = [contacts[1]]
+        self.assertListEqual(actual, expected)
+
+    def test_lookup_will_match_emails(self):
+        contacts = [('foo', 'x@example.com'), ('bar', 'y@example.com'),
+                    ('baz', 'z@example.com')]
+        abook = _AddressBook(contacts)
+        actual = abook.lookup('y@example.com')
+        expected = [contacts[1]]
+        self.assertListEqual(actual, expected)
+
+    def test_lookup_ignores_case_by_default(self):
+        contacts = [('name', 'email@example.com'),
+                    ('Name', 'other@example.com'),
+                    ('someone', 'someone@example.com')]
+        abook = _AddressBook(contacts)
+        actual = abook.lookup('name')
+        expected = [contacts[0], contacts[1]]
+        self.assertListEqual(actual, expected)
+
+    def test_lookup_can_match_case(self):
+        contacts = [('name', 'email@example.com'),
+                    ('Name', 'other@example.com'),
+                    ('someone', 'someone@example.com')]
+        abook = _AddressBook(contacts, ignorecase=False)
+        actual = abook.lookup('name')
+        expected = [contacts[0]]
+        self.assertListEqual(actual, expected)
+
+    def test_lookup_will_match_partial_in_the_middle(self):
+        contacts = [('name', 'email@example.com'),
+                    ('My Own Name', 'other@example.com'),
+                    ('someone', 'someone@example.com')]
+        abook = _AddressBook(contacts)
+        actual = abook.lookup('Own')
+        expected = [contacts[1]]
+        self.assertListEqual(actual, expected)

--- a/tests/commands/thread_test.py
+++ b/tests/commands/thread_test.py
@@ -155,3 +155,11 @@ class TestDetermineSender(unittest.TestCase):
         account2 = _AccountTestClass(address='bar@example.com')
         expected = ('foo@example.com', account1)
         self._test(accounts=[account1, account2], expected=expected)
+
+    @unittest.expectedFailure
+    def test_matching_address_and_account_are_returned(self):
+        account1 = _AccountTestClass(address='foo@example.com')
+        account2 = _AccountTestClass(address='to@example.com')
+        account3 = _AccountTestClass(address='bar@example.com')
+        expected = ('to@example.com', account2)
+        self._test(accounts=[account1, account2, account3], expected=expected)

--- a/tests/commands/thread_test.py
+++ b/tests/commands/thread_test.py
@@ -6,9 +6,13 @@
 """Test suite for alot.commands.thread module."""
 from __future__ import absolute_import
 
+import email
 import unittest
 
+import mock
+
 from alot.commands import thread
+from alot.account import Account
 
 # Good descriptive test names often don't fit PEP8, which is meant to cover
 # functions meant to be called by humans.
@@ -59,8 +63,8 @@ class TestClearMyAddress(unittest.TestCase):
 
     def test_only_my_emails_result_in_empty_list(self):
         expected = []
-        actual = thread.ReplyCommand.clear_my_address(self.mine,
-                                                      self.mine+[self.me_named])
+        actual = thread.ReplyCommand.clear_my_address(
+            self.mine, self.mine+[self.me_named])
         self.assertListEqual(actual, expected)
 
     def test_other_emails_are_untouched(self):
@@ -87,3 +91,67 @@ class TestClearMyAddress(unittest.TestCase):
         mine = 'alot team'
         actual = thread.ReplyCommand.clear_my_address(mine, expected)
         self.assertListEqual(actual, expected)
+
+
+class _AccountTestClass(Account):
+    """Implements stubs for ABC methods."""
+
+    def send_mail(self, mail):
+        pass
+
+
+class TestDetermineSender(unittest.TestCase):
+
+    header_priority = ["From", "To", "Cc", "Envelope-To", "X-Envelope-To",
+                       "Delivered-To"]
+    mailstring = '\n'.join([
+        "From: from@example.com",
+        "To: to@example.com",
+        "Cc: cc@example.com",
+        "Envelope-To: envelope-to@example.com",
+        "X-Envelope-To: x-envelope-to@example.com",
+        "Delivered-To: delivered-to@example.com",
+        "Subject: Alot test",
+        "\n",
+        "Some content",
+        ])
+    mail = email.message_from_string(mailstring)
+
+    def _test(self, accounts=(), expected=(), mail=None, header_priority=None,
+              force_realname=False, force_address=False):
+        """This method collects most of the steps that need to be done for most
+        tests.  Especially a closure to mock settings.get and a mock for
+        settings.get_accounts are set up."""
+        mail = self.mail if mail is None else mail
+        header_priority = self.header_priority if header_priority is None \
+            else header_priority
+
+        def settings_get(arg):
+            """Mock function for setting.get()"""
+            if arg == "reply_account_header_priority":
+                return header_priority
+            elif arg.endswith('_force_realname'):
+                return force_realname
+            elif arg.endswith('_force_address'):
+                return force_address
+
+        with mock.patch('alot.commands.thread.settings.get_accounts',
+                        mock.Mock(return_value=accounts)):
+            with mock.patch('alot.commands.thread.settings.get', settings_get):
+                actual = thread.determine_sender(mail)
+        self.assertTupleEqual(actual, expected)
+
+    def test_assert_that_some_accounts_are_defined(self):
+        with mock.patch('alot.commands.thread.settings.get_accounts',
+                        mock.Mock(return_value=[])) as cm1:
+            with self.assertRaises(AssertionError) as cm2:
+                thread.determine_sender(None)
+        expected = ('no accounts set!',)
+        cm1.assert_called_once_with()
+        self.assertTupleEqual(cm2.exception.args, expected)
+
+    def test_default_account_is_used_if_no_match_is_found(self):
+        account1 = _AccountTestClass(address='foo@example.com')
+        account2 = _AccountTestClass(address='bar@example.com')
+        expected = ('foo@example.com', account1)
+        self._test(accounts=[account1, account2], expected=expected)

--- a/tests/commands/thread_test.py
+++ b/tests/commands/thread_test.py
@@ -171,7 +171,6 @@ class TestDetermineSender(unittest.TestCase):
         self._test(accounts=[account1, account2, account3], expected=expected,
                    force_realname=True)
 
-    @unittest.expectedFailure
     def test_doesnt_fail_with_force_realname_if_real_name_not_defined(self):
         account1 = _AccountTestClass(address='foo@example.com')
         account2 = _AccountTestClass(address='to@example.com')

--- a/tests/commands/thread_test.py
+++ b/tests/commands/thread_test.py
@@ -178,3 +178,50 @@ class TestDetermineSender(unittest.TestCase):
         expected = ('to@example.com', account2)
         self._test(accounts=[account1, account2, account3], expected=expected,
                    force_realname=True)
+
+    def test_with_force_address_main_address_is_used_regardless_of_matching_address(self):
+        # In python 3.4 this and the next test could be written as subtests.
+        account1 = _AccountTestClass(address='foo@example.com')
+        account2 = _AccountTestClass(address='bar@example.com',
+                                     aliases=['to@example.com'])
+        account3 = _AccountTestClass(address='bar@example.com')
+        expected = ('bar@example.com', account2)
+        self._test(accounts=[account1, account2, account3], expected=expected,
+                   force_address=True)
+
+    def test_without_force_address_matching_address_is_used(self):
+        # In python 3.4 this and the previous test could be written as
+        # subtests.
+        account1 = _AccountTestClass(address='foo@example.com')
+        account2 = _AccountTestClass(address='bar@example.com',
+                                     aliases=['to@example.com'])
+        account3 = _AccountTestClass(address='baz@example.com')
+        expected = ('to@example.com', account2)
+        self._test(accounts=[account1, account2, account3], expected=expected,
+                   force_address=False)
+
+    def test_uses_to_header_if_present(self):
+        account1 = _AccountTestClass(address='foo@example.com')
+        account2 = _AccountTestClass(address='to@example.com')
+        account3 = _AccountTestClass(address='bar@example.com')
+        expected = ('to@example.com', account2)
+        self._test(accounts=[account1, account2, account3], expected=expected)
+
+    def test_header_order_is_more_important_than_accounts_order(self):
+        account1 = _AccountTestClass(address='cc@example.com')
+        account2 = _AccountTestClass(address='to@example.com')
+        account3 = _AccountTestClass(address='bcc@example.com')
+        expected = ('to@example.com', account2)
+        self._test(accounts=[account1, account2, account3], expected=expected)
+
+    def test_accounts_can_be_found_by_alias_regex_setting(self):
+        account1 = _AccountTestClass(address='foo@example.com')
+        account2 = _AccountTestClass(address='to@example.com',
+                                     alias_regexp=r'to\+.*@example.com')
+        account3 = _AccountTestClass(address='bar@example.com')
+        mailstring = self.mailstring.replace('to@example.com',
+                                             'to+some_tag@example.com')
+        mail = email.message_from_string(mailstring)
+        expected = ('to+some_tag@example.com', account2)
+        self._test(accounts=[account1, account2, account3], expected=expected,
+                   mail=mail)

--- a/tests/commands/thread_test.py
+++ b/tests/commands/thread_test.py
@@ -162,3 +162,20 @@ class TestDetermineSender(unittest.TestCase):
         account3 = _AccountTestClass(address='bar@example.com')
         expected = ('to@example.com', account2)
         self._test(accounts=[account1, account2, account3], expected=expected)
+
+    def test_force_realname_includes_real_name_in_returned_address_if_defined(self):
+        account1 = _AccountTestClass(address='foo@example.com')
+        account2 = _AccountTestClass(address='to@example.com', realname='Bar')
+        account3 = _AccountTestClass(address='baz@example.com')
+        expected = ('Bar <to@example.com>', account2)
+        self._test(accounts=[account1, account2, account3], expected=expected,
+                   force_realname=True)
+
+    @unittest.expectedFailure
+    def test_doesnt_fail_with_force_realname_if_real_name_not_defined(self):
+        account1 = _AccountTestClass(address='foo@example.com')
+        account2 = _AccountTestClass(address='to@example.com')
+        account3 = _AccountTestClass(address='bar@example.com')
+        expected = ('to@example.com', account2)
+        self._test(accounts=[account1, account2, account3], expected=expected,
+                   force_realname=True)

--- a/tests/commands/thread_test.py
+++ b/tests/commands/thread_test.py
@@ -156,7 +156,6 @@ class TestDetermineSender(unittest.TestCase):
         expected = ('foo@example.com', account1)
         self._test(accounts=[account1, account2], expected=expected)
 
-    @unittest.expectedFailure
     def test_matching_address_and_account_are_returned(self):
         account1 = _AccountTestClass(address='foo@example.com')
         account2 = _AccountTestClass(address='to@example.com')

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2017 Lucas Hoffmann
+# This file is released under the GNU GPL, version 3 or a later revision.
+# For further details see the COPYING file
+from __future__ import absolute_import
+
+import unittest
+
+import gpgme
+
+from alot import crypto
+from alot.errors import GPGProblem
+
+
+class TestHashAlgorithmHelper(unittest.TestCase):
+
+    """Test cases for the helper function RFC3156_canonicalize."""
+
+    def test_returned_string_starts_with_pgp(self):
+        result = crypto.RFC3156_micalg_from_algo(gpgme.MD_MD5)
+        self.assertTrue(result.startswith('pgp-'))
+
+    def test_returned_string_is_lower_case(self):
+        result = crypto.RFC3156_micalg_from_algo(gpgme.MD_MD5)
+        self.assertTrue(result.islower())
+
+    def test_raises_for_unknown_hash_name(self):
+        with self.assertRaises(GPGProblem):
+            crypto.RFC3156_micalg_from_algo(gpgme.MD_NONE)

--- a/tests/db/utils_test.py
+++ b/tests/db/utils_test.py
@@ -164,6 +164,26 @@ class TestEncodeHeader(unittest.TestCase):
         expected = email.header.Header('=?utf-8?b?dsOkbMO8ZQ==?=')
         self.assertEqual(actual, expected)
 
+    def test_plain_email_addresses_are_accepted(self):
+        address = 'user@example.com'
+        actual = utils.encode_header('from', address)
+        expected = email.header.Header(address)
+        self.assertEqual(actual, expected)
+
+    def test_email_addresses_with_realnames_are_accepted(self):
+        address = 'someone <user@example.com>'
+        actual = utils.encode_header('from', address)
+        expected = email.header.Header(address)
+        self.assertEqual(actual, expected)
+
+    @unittest.expectedFailure
+    def test_email_addresses_with_empty_realnames_are_treated_like_plain(self):
+        address = 'user@example.com'
+        empty_realname = '<'+address+'>'
+        actual = utils.encode_header('from', empty_realname)
+        expected = email.header.Header(address)
+        self.assertEqual(str(actual), str(expected))
+
     def test_space_around_email_address_is_striped(self):
         address = '  someone <user@example.com>  '
         actual = utils.encode_header('from', address)
@@ -190,6 +210,13 @@ class TestEncodeHeader(unittest.TestCase):
         actual = utils.encode_header('from', addresses)
         expected = email.header.Header(addresses)
         self.assertEqual(str(actual), str(expected))
+
+    def test_utf_8_chars_in_realnames_are_accepted(self):
+        address = u'Ümlaut <uemlaut@example.com>'
+        actual = utils.encode_header('from', address)
+        expected = email.header.Header(
+            '=?utf-8?q?=C3=9Cmlaut?= <uemlaut@example.com>')
+        self.assertEqual(actual, expected)
 
 
 class TestDecodeHeader(unittest.TestCase):

--- a/tests/db/utils_test.py
+++ b/tests/db/utils_test.py
@@ -176,7 +176,6 @@ class TestEncodeHeader(unittest.TestCase):
         expected = email.header.Header(address)
         self.assertEqual(actual, expected)
 
-    @unittest.expectedFailure
     def test_email_addresses_with_empty_realnames_are_treated_like_plain(self):
         address = 'user@example.com'
         empty_realname = '<'+address+'>'
@@ -203,7 +202,6 @@ class TestEncodeHeader(unittest.TestCase):
         expected = email.header.Header(addresses)
         self.assertEqual(actual, expected)
 
-    @unittest.expectedFailure
     def test_comma_in_names_are_allowed(self):
         addresses = '"last, first" <guy@example.com>, ' \
             '"name, other" <guy@example.com>'

--- a/tests/db/utils_test.py
+++ b/tests/db/utils_test.py
@@ -1,0 +1,59 @@
+# encoding: utf-8
+# Copyright (C) 2017 Lucas Hoffmann
+# This file is released under the GNU GPL, version 3 or a later revision.
+# For further details see the COPYING file
+from __future__ import absolute_import
+
+import email
+import unittest
+
+from alot.db import utils
+
+
+class TestGetParams(unittest.TestCase):
+
+    mailstring = '\n'.join([
+        'From: me',
+        'To: you',
+        'Subject: header field capitalisation',
+        'Content-type: text/plain; charset=utf-8',
+        'X-Header: param=one; and=two; or=three',
+        "X-Quoted: param=utf-8''%C3%9Cmlaut; second=plain%C3%9C",
+        'X-UPPERCASE: PARAM1=ONE; PARAM2=TWO'
+        '\n',
+        'content'
+        ])
+    mail = email.message_from_string(mailstring)
+
+    def test_returns_content_type_parameters_by_default(self):
+        actual = utils.get_params(self.mail)
+        expected = {'text/plain': '', 'charset': 'utf-8'}
+        self.assertDictEqual(actual, expected)
+
+    def test_can_return_params_of_any_header_field(self):
+        actual = utils.get_params(self.mail, header='x-header')
+        expected = {'param': 'one', 'and': 'two', 'or': 'three'}
+        self.assertDictEqual(actual, expected)
+
+    @unittest.expectedFailure
+    def test_parameters_are_decoded(self):
+        actual = utils.get_params(self.mail, header='x-quoted')
+        expected = {'param': 'Ümlaut', 'second': 'plain%C3%9C'}
+        self.assertDictEqual(actual, expected)
+
+    def test_parameters_names_are_converted_to_lowercase(self):
+        actual = utils.get_params(self.mail, header='x-uppercase')
+        expected = {'param1': 'ONE', 'param2': 'TWO'}
+        self.assertDictEqual(actual, expected)
+
+    def test_returns_empty_dict_if_header_not_present(self):
+        actual = utils.get_params(self.mail, header='x-header-not-present')
+        self.assertDictEqual(actual, dict())
+
+    def test_returns_failobj_if_header_not_present(self):
+        failobj = [('my special failobj for the test', 'needs to be a pair!')]
+        actual = utils.get_params(self.mail, header='x-header-not-present',
+                                  failobj=failobj)
+        expected = dict(failobj)
+        self.assertEqual(actual, expected)
+

--- a/tests/db/utils_test.py
+++ b/tests/db/utils_test.py
@@ -5,6 +5,8 @@
 from __future__ import absolute_import
 
 import email
+import os
+import os.path
 import unittest
 
 from alot.db import utils
@@ -57,3 +59,35 @@ class TestGetParams(unittest.TestCase):
         expected = dict(failobj)
         self.assertEqual(actual, expected)
 
+
+class TestIsSubdirOf(unittest.TestCase):
+
+    def test_both_paths_absolute_matching(self):
+        superpath = '/a/b'
+        subpath = '/a/b/c/d.rst'
+        result = utils.is_subdir_of(subpath, superpath)
+        self.assertTrue(result)
+
+    def test_both_paths_absolute_not_matching(self):
+        superpath = '/a/z'
+        subpath = '/a/b/c/d.rst'
+        result = utils.is_subdir_of(subpath, superpath)
+        self.assertFalse(result)
+
+    def test_both_paths_relative_matching(self):
+        superpath = 'a/b'
+        subpath = 'a/b/c/d.rst'
+        result = utils.is_subdir_of(subpath, superpath)
+        self.assertTrue(result)
+
+    def test_both_paths_relative_not_matching(self):
+        superpath = 'a/z'
+        subpath = 'a/b/c/d.rst'
+        result = utils.is_subdir_of(subpath, superpath)
+        self.assertFalse(result)
+
+    def test_relative_path_and_absolute_path_matching(self):
+        superpath = 'a/b'
+        subpath = os.path.join(os.getcwd(), 'a/b/c/d.rst')
+        result = utils.is_subdir_of(subpath, superpath)
+        self.assertTrue(result)


### PR DESCRIPTION
I generated a coverage report with
```sh
coverage2 run setup.py test
coverage2 html --include=alot/'*'
xdg-open htmlcov/index.html
```
and picked some easy things that where not yet covered.

Now I have a question about the last test in the last commit.  It fails for me but I don't think that is consistent so I assume it is a bug.  What do you think about it?  And what is the intended behaviour for alot.commands.thread.determine_sender anyway?