### PR TITLE
conservative lookup of sub-completers

### DIFF
--- a/alot/completion.py
+++ b/alot/completion.py
@@ -19,6 +19,7 @@ from .utils import argparse as cargparse
 from .helper import split_commandline
 from .addressbook import AddressbookError
 from .errors import CompletionError
+from .utils.cached_property import cached_property
 
 
 class Completer(object):
@@ -320,14 +321,35 @@ class CommandCompleter(Completer):
         self.mode = mode
         self.currentbuffer = currentbuffer
         self._commandnamecompleter = CommandNameCompleter(mode)
-        self._querycompleter = QueryCompleter(dbman)
-        self._tagcompleter = TagCompleter(dbman)
+
+    @cached_property
+    def _querycompleter(self):
+        return QueryCompleter(self.dbman)
+
+    @cached_property
+    def _tagcompleter(self):
+        return TagCompleter(self.dbman)
+
+    @cached_property
+    def _contactscompleter(self):
         abooks = settings.get_addressbooks()
-        self._contactscompleter = ContactsCompleter(abooks)
-        self._pathcompleter = PathCompleter()
-        self._accountscompleter = AccountCompleter()
-        self._secretkeyscompleter = CryptoKeyCompleter(private=True)
-        self._publickeyscompleter = CryptoKeyCompleter(private=False)
+        return ContactsCompleter(abooks)
+
+    @cached_property
+    def _pathcompleter(self):
+        return PathCompleter()
+
+    @cached_property
+    def _accountscompleter(self):
+        return AccountCompleter()
+
+    @cached_property
+    def _secretkeyscompleter(self):
+        return CryptoKeyCompleter(private=True)
+
+    @cached_property
+    def _publickeyscompleter(self):
+        return CryptoKeyCompleter(private=False)
 
     def complete(self, line, pos):
         # remember how many preceding space characters we see until the command

--- a/alot/utils/cached_property.py
+++ b/alot/utils/cached_property.py
@@ -1,6 +1,38 @@
-# werkzeug.utils.cached_property
+# verbatim from werkzeug.utils.cached_property
+#
+#Copyright (c) 2014 by the Werkzeug Team, see AUTHORS for more details.
+#
+#Redistribution and use in source and binary forms, with or without
+#modification, are permitted provided that the following conditions are
+#met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above
+#      copyright notice, this list of conditions and the following
+#      disclaimer in the documentation and/or other materials provided
+#      with the distribution.
+#
+#    * The names of the contributors may not be used to endorse or
+#      promote products derived from this software without specific
+#      prior written permission.
+#
+#THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 
 _missing = object()
+
 
 class cached_property(object):
     """A decorator that converts a function into a lazy property.  The

--- a/alot/utils/cached_property.py
+++ b/alot/utils/cached_property.py
@@ -1,0 +1,43 @@
+# werkzeug.utils.cached_property
+
+_missing = object()
+
+class cached_property(object):
+    """A decorator that converts a function into a lazy property.  The
+    function wrapped is called the first time to retrieve the result
+    and then that calculated result is used the next time you access
+    the value::
+
+        class Foo(object):
+
+            @cached_property
+            def foo(self):
+                # calculate something important here
+                return 42
+
+    The class has to have a `__dict__` in order for this property to
+    work.
+    """
+
+    # implementation detail: this property is implemented as non-data
+    # descriptor.  non-data descriptors are only invoked if there is
+    # no entry with the same name in the instance's __dict__.
+    # this allows us to completely get rid of the access function call
+    # overhead.  If one choses to invoke __get__ by hand the property
+    # will still work as expected because the lookup logic is replicated
+    # in __get__ for manual invocation.
+
+    def __init__(self, func, name=None, doc=None):
+        self.__name__ = name or func.__name__
+        self.__module__ = func.__module__
+        self.__doc__ = doc or func.__doc__
+        self.func = func
+
+    def __get__(self, obj, type=None):
+        if obj is None:
+            return self
+        value = obj.__dict__.get(self.__name__, _missing)
+        if value is _missing:
+            value = self.func(obj)
+            obj.__dict__[self.__name__] = value
+        return value


### PR DESCRIPTION
via cached properties.

This should help with #1064 and is generally a good idea because most of the time, only specific sub-completer will be in use and so there is no need to instantiate all of them upfront.

The decorator used comes from the [werkzeug](https://github.com/pallets/werkzeug/blob/10b4b8b6918a83712170fdaabd3ec61cf07f23ff/werkzeug/utils.py#L35) toolkit, which is avoided as a dependency here.