### PR TITLE
db/utils: Support unicode in signatures

### DIFF
--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -39,25 +39,28 @@ def add_signature_headers(mail, sigs, error_msg):
     :param error_msg: `str` containing an error message, the empty
                       string indicating no error
     '''
-    sig_from = ''
+    sig_from = u''
+
+    if isinstance(error_msg, str):
+        error_msg = error_msg.decode('utf-8')
 
     if len(sigs) == 0:
-        error_msg = error_msg or 'no signature found'
+        error_msg = error_msg or u'no signature found'
     else:
         try:
             key = crypto.get_key(sigs[0].fpr)
             for uid in key.uids:
                 if crypto.check_uid_validity(key, uid.email):
-                    sig_from = uid.uid
+                    sig_from = uid.uid.decode('utf-8')
                     uid_trusted = True
                     break
             else:
                 # No trusted uid found, we did not break but drop from the
                 # for loop.
                 uid_trusted = False
-                sig_from = key.uids[0].uid
+                sig_from = key.uids[0].uid.decode('utf-8')
         except:
-            sig_from = sigs[0].fpr
+            sig_from = sigs[0].fpr.decode('utf-8')
             uid_trusted = False
 
     mail.add_header(

--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -44,9 +44,9 @@ def add_signature_headers(mail, sigs, error_msg):
     if isinstance(error_msg, str):
         error_msg = error_msg.decode('utf-8')
 
-    if len(sigs) == 0:
+    if not sigs:
         error_msg = error_msg or u'no signature found'
-    else:
+    elif not error_msg:
         try:
             key = crypto.get_key(sigs[0].fpr)
             for uid in key.uids:

--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -63,18 +63,15 @@ def add_signature_headers(mail, sigs, error_msg):
             sig_from = sigs[0].fpr.decode('utf-8')
             uid_trusted = False
 
-    mail.add_header(
-        X_SIGNATURE_VALID_HEADER,
-        'False' if error_msg else 'True',
-    )
-    mail.add_header(
-        X_SIGNATURE_MESSAGE_HEADER,
-        u'Invalid: {0}'.format(error_msg)
-        if error_msg else
-        u'Valid: {0}'.format(sig_from)
-        if uid_trusted else
-        u'Untrusted: {0}'.format(sig_from)
-    )
+    if error_msg:
+        msg = u'Invalid: {}'.format(error_msg)
+    elif uid_trusted:
+        msg = u'Valid: {}'.format(sig_from)
+    else:
+        msg = u'Untrusted: {}'.format(sig_from)
+
+    mail.add_header(X_SIGNATURE_VALID_HEADER, 'False' if error_msg else 'True')
+    mail.add_header(X_SIGNATURE_MESSAGE_HEADER, msg)
 
 
 def get_params(mail, failobj=None, header='content-type', unquote=True):

--- a/tests/db/utils_test.py
+++ b/tests/db/utils_test.py
@@ -369,3 +369,15 @@ class TestAddSignatureHeaders(unittest.TestCase):
         self.assertIn((utils.X_SIGNATURE_VALID_HEADER, u'True'), mail.headers)
         self.assertIn(
             (utils.X_SIGNATURE_MESSAGE_HEADER, u'Untrusted: mocked'), mail.headers)
+
+    @unittest.expectedFailure
+    def test_unicode_as_bytes(self):
+        mail = self.FakeMail()
+        key = make_key()
+        key.uids = [make_uid('andreá@example.com',
+                             uid=u'Andreá'.encode('utf-8'))]
+        mail = self.check(key, True)
+
+        self.assertIn((utils.X_SIGNATURE_VALID_HEADER, u'True'), mail.headers)
+        self.assertIn(
+            (utils.X_SIGNATURE_MESSAGE_HEADER, u'Valid: Andreá'), mail.headers)

--- a/tests/db/utils_test.py
+++ b/tests/db/utils_test.py
@@ -342,7 +342,7 @@ class TestAddSignatureHeaders(unittest.TestCase):
                         mock.Mock(return_value=key)), \
                 mock.patch('alot.db.utils.crypto.check_uid_validity',
                            mock.Mock(return_value=valid)):
-            utils.add_signature_headers(mail, [mock.Mock(fpr=None)], u'')
+            utils.add_signature_headers(mail, [mock.Mock(fpr='')], u'')
 
         return mail
 
@@ -370,7 +370,6 @@ class TestAddSignatureHeaders(unittest.TestCase):
         self.assertIn(
             (utils.X_SIGNATURE_MESSAGE_HEADER, u'Untrusted: mocked'), mail.headers)
 
-    @unittest.expectedFailure
     def test_unicode_as_bytes(self):
         mail = self.FakeMail()
         key = make_key()

--- a/tests/db/utils_test.py
+++ b/tests/db/utils_test.py
@@ -14,7 +14,7 @@ import unittest
 import mock
 
 from alot.db import utils
-from ..crypto_test import make_key
+from ..utilities import make_key
 
 
 class TestGetParams(unittest.TestCase):

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -148,10 +148,21 @@ class ModuleCleanup(object):
         return wrapper
 
 
+def make_uid(email, revoked=False, invalid=False, validity=gpgme.VALIDITY_FULL):
+    uid = mock.Mock()
+    uid.email = email
+    uid.uid = u'mocked'
+    uid.revoked = revoked
+    uid.invalid = invalid
+    uid.validity = validity
+
+    return uid
+
+
 def make_key(revoked=False, expired=False, invalid=False, can_encrypt=True,
              can_sign=True):
     mock_key = mock.create_autospec(gpgme.Key)
-    mock_key.uids = [mock.Mock(uid=u'mocked')]
+    mock_key.uids = [make_uid(u'foo@example.com')]
     mock_key.revoked = revoked
     mock_key.expired = expired
     mock_key.invalid = invalid
@@ -159,13 +170,3 @@ def make_key(revoked=False, expired=False, invalid=False, can_encrypt=True,
     mock_key.can_sign = can_sign
 
     return mock_key
-
-
-def make_uid(email, revoked=False, invalid=False, validity=gpgme.VALIDITY_FULL):
-    uid = mock.Mock()
-    uid.email = email
-    uid.revoked = revoked
-    uid.invalid = invalid
-    uid.validity = validity
-
-    return uid

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -148,15 +148,16 @@ class ModuleCleanup(object):
         return wrapper
 
 
-def make_uid(email, revoked=False, invalid=False, validity=gpgme.VALIDITY_FULL):
-    uid = mock.Mock()
-    uid.email = email
-    uid.uid = u'mocked'
-    uid.revoked = revoked
-    uid.invalid = invalid
-    uid.validity = validity
+def make_uid(email, uid=u'mocked', revoked=False, invalid=False,
+             validity=gpgme.VALIDITY_FULL):
+    uid_ = mock.Mock()
+    uid_.email = email
+    uid_.uid = uid
+    uid_.revoked = revoked
+    uid_.invalid = invalid
+    uid_.validity = validity
 
-    return uid
+    return uid_
 
 
 def make_key(revoked=False, expired=False, invalid=False, can_encrypt=True,

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -21,6 +21,9 @@ from __future__ import absolute_import
 import functools
 import unittest
 
+import gpgme
+import mock
+
 
 def _tear_down_class_wrapper(original, cls):
     """Ensure that doClassCleanups is called after tearDownClass."""
@@ -143,3 +146,26 @@ class ModuleCleanup(object):
                 raise
 
         return wrapper
+
+
+def make_key(revoked=False, expired=False, invalid=False, can_encrypt=True,
+             can_sign=True):
+    mock_key = mock.create_autospec(gpgme.Key)
+    mock_key.uids = [mock.Mock(uid=u'mocked')]
+    mock_key.revoked = revoked
+    mock_key.expired = expired
+    mock_key.invalid = invalid
+    mock_key.can_encrypt = can_encrypt
+    mock_key.can_sign = can_sign
+
+    return mock_key
+
+
+def make_uid(email, revoked=False, invalid=False, validity=gpgme.VALIDITY_FULL):
+    uid = mock.Mock()
+    uid.email = email
+    uid.revoked = revoked
+    uid.invalid = invalid
+    uid.validity = validity
+
+    return uid


### PR DESCRIPTION
Currently if a signature name has a non-ascii unicode character in it,
the thread will fail to load because a UnicodeEncodeError. This patch
fixes that by converting the str into unicode.