### PR TITLE
helper: Do not add a newline to the end of a signed section

### DIFF
--- a/alot/helper.py
+++ b/alot/helper.py
@@ -585,8 +585,7 @@ def RFC3156_canonicalize(text):
     This function works as follows (in that order):
 
     1. Convert all line endings to \\\\r\\\\n (DOS line endings).
-    2. Ensure the text ends with a newline (\\\\r\\\\n).
-    3. Encode all occurences of "From " at the beginning of a line
+    2. Encode all occurences of "From " at the beginning of a line
        to "From=20" in order to prevent other mail programs to replace
        this with "> From" (to avoid MBox conflicts) and thus invalidate
        the signature.
@@ -595,8 +594,6 @@ def RFC3156_canonicalize(text):
     :rtype: str
     """
     text = re.sub("\r?\n", "\r\n", text)
-    if not text.endswith("\r\n"):
-        text += "\r\n"
     text = re.sub("^From ", "From=20", text, flags=re.MULTILINE)
     return text
 


### PR DESCRIPTION
The spec is very clear here:

    (2)  An appropriate Content-Transfer-Encoding is then applied; see
         section 3.  In particular, line endings in the encoded data
         MUST use the canonical <CR><LF> sequence where appropriate
         (note that the canonical line ending may or may not be present
         on the last line of encoded data and MUST NOT be included in
         the signature if absent).

That very last MUST NOT is what's important here, we shouldn't be adding
newlines if they weren't there to begin with. Because we do it causes
signed blobs that have newlines to be invalid since we've changed the
substance of the signed code.