### PR TITLE
commands/envelope: Fall back to account for signing key

### DIFF
--- a/alot/commands/utils.py
+++ b/alot/commands/utils.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import re
 import logging
+
 from twisted.internet.defer import inlineCallbacks, returnValue
 
 from ..errors import GPGProblem, GPGCode

--- a/alot/settings/errors.py
+++ b/alot/settings/errors.py
@@ -6,3 +6,8 @@
 class ConfigError(Exception):
     """could not parse user config"""
     pass
+
+
+class NoMatchingAccount(ConfigError):
+    """No account matching requirements found."""
+    pass

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -16,7 +16,7 @@ from ..addressbook.external import ExternalAddressbook
 from ..helper import pretty_datetime, string_decode
 from ..utils import configobj as checks
 
-from .errors import ConfigError
+from .errors import ConfigError, NoMatchingAccount
 from .utils import read_config
 from .utils import resolve_att
 from .theme import Theme
@@ -414,19 +414,27 @@ class SettingsManager(object):
         """
         return self._accounts
 
-    def get_account_by_address(self, address):
-        """
-        returns :class:`Account` for a given email address (str)
+    def get_account_by_address(self, address, return_default=False):
+        """returns :class:`Account` for a given email address (str)
 
-        :param address: address to look up
-        :type address: string
-        :rtype:  :class:`Account` or None
+        :param str address: address to look up
+        :param bool return_default: If True and no address can be found, then
+            the default account wil be returned
+        :rtype: :class:`Account`
+        :raises ~alot.settings.errors.NoMatchingAccount: If no account can be
+            found. Thsi includes if return_default is True and there are no
+            accounts defined.
         """
-
         for myad in self.get_addresses():
             if myad == address:
                 return self._accountmap[myad]
-        return None
+        if return_default:
+            try:
+                return self.get_accounts()[0]
+            except IndexError:
+                # Fall through
+                pass
+        raise NoMatchingAccount
 
     def get_main_addresses(self):
         """returns addresses of known accounts without its aliases"""

--- a/tests/settings/manager_test.py
+++ b/tests/settings/manager_test.py
@@ -12,7 +12,9 @@ import textwrap
 import unittest
 
 from alot.settings.manager import SettingsManager
-from alot.settings.errors import ConfigError
+from alot.settings.errors import ConfigError, NoMatchingAccount
+
+from .. import utilities
 
 
 class TestSettingsManager(unittest.TestCase):
@@ -60,3 +62,52 @@ class TestSettingsManager(unittest.TestCase):
         manager.reload()
         actual = manager.get_notmuch_setting('maildir', 'synchronize_flags')
         self.assertTrue(actual)
+
+
+class TestSettingsManagerGetAccountByAddress(utilities.TestCaseClassCleanup):
+    """Test the get_account_by_address helper."""
+
+    @classmethod
+    def setUpClass(cls):
+        config = textwrap.dedent("""\
+            [accounts]
+                [[default]]
+                    realname = That Guy
+                    address = that_guy@example.com
+                    sendmail_commnd = /bin/true
+
+                [[other]]
+                    realname = A Dude
+                    address = a_dude@example.com
+                    sendmail_command = /bin/true
+            """)
+
+        # Allow settings.reload to work by not deleting the file until the end
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(config)
+        cls.addClassCleanup(os.unlink, f.name)
+
+        # Replace the actual settings object with our own using mock, but
+        # ensure it's put back afterwards
+        cls.manager = SettingsManager(alot_rc=f.name)
+
+    def test_exists_addr(self):
+        acc = self.manager.get_account_by_address('that_guy@example.com')
+        self.assertEqual(acc.realname, 'That Guy')
+
+    def test_doesnt_exist_return_default(self):
+        acc = self.manager.get_account_by_address('doesntexist@example.com',
+                                                  return_default=True)
+        self.assertEqual(acc.realname, 'That Guy')
+
+    def test_doesnt_exist_raise(self):
+        with self.assertRaises(NoMatchingAccount):
+            self.manager.get_account_by_address('doesntexist@example.com')
+
+    def test_doesnt_exist_no_default(self):
+        with tempfile.NamedTemporaryFile() as f:
+            f.write('')
+            settings = SettingsManager(alot_rc=f.name)
+        with self.assertRaises(NoMatchingAccount):
+            settings.get_account_by_address('that_guy@example.com',
+                                            return_default=True)


### PR DESCRIPTION
If there isn't a key provided as an argument to sign or togglesign, fall
back to using the account of the sending address to determine the key,
otherwise the message will be marked as "to sign", but won't actually be
signed. This is the same type of logic used for sign_by_default.