### PR TITLE
travis: Use github mirror of notmuch source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install: |
     export PATH=/usr/lib/ccache:$PATH
 
     # Clone the notmuch repository and move into it.
-    git clone git://notmuchmail.org/git/notmuch
+    git clone https://github.com/notmuch/notmuch.git
     cd notmuch
     # Make and install the library.  We install the library without sudo as we
     # might want to switch to the travis container later.


### PR DESCRIPTION
Since the git repo on notmuchmail.org seems to be down.