### PR TITLE
Load default settings even if a user config doesn't exist

### DIFF
--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -67,15 +67,11 @@ class SettingsManager(object):
 
     def read_notmuch_config(self):
         """parse notmuch's config file from path"""
-        if self.notmuch_rc_path is not None:
-            spec = os.path.join(DEFAULTSPATH, 'notmuch.rc.spec')
-            self._notmuchconfig = read_config(self.notmuch_rc_path, spec)
+        spec = os.path.join(DEFAULTSPATH, 'notmuch.rc.spec')
+        self._notmuchconfig = read_config(self.notmuch_rc_path, spec)
 
     def read_config(self):
         """parse alot's config file from path"""
-        if self.alot_rc_path is None:
-            return
-
         spec = os.path.join(DEFAULTSPATH, 'alot.rc.spec')
         newconfig = read_config(
             self.alot_rc_path, spec, checks={

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -40,7 +40,6 @@ class SettingsManager(object):
         assert notmuch_rc is None or (isinstance(notmuch_rc, basestring) and os.path.exists(notmuch_rc))
         self.hooks = None
         self._mailcaps = mailcap.getcaps()
-        self._config = ConfigObj()
         self._notmuchconfig = None
         self._theme = None
         self._accounts = None

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,8 @@ MOCK_MODULES = ['twisted', 'twisted.internet',
                 'gpg',
                 'configobj',
                 'validate',
-                'argparse']
+                'argparse',
+                'alot.settings.const']
 MOCK_DIRTY = ['notmuch']
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = MockModule()

--- a/tests/settings/manager_test.py
+++ b/tests/settings/manager_test.py
@@ -63,7 +63,6 @@ class TestSettingsManager(unittest.TestCase):
         actual = manager.get_notmuch_setting('maildir', 'synchronize_flags')
         self.assertTrue(actual)
 
-    @unittest.expectedFailure
     def test_read_config_doesnt_exist(self):
         """If there is not an alot config things don't break.
 
@@ -81,7 +80,6 @@ class TestSettingsManager(unittest.TestCase):
 
         manager.get_theming_attribute('global', 'body')
 
-    @unittest.expectedFailure
     def test_read_notmuch_config_doesnt_exist(self):
         with tempfile.NamedTemporaryFile(delete=False) as f:
             f.write(textwrap.dedent("""\


### PR DESCRIPTION
There is a regression introduced by 86186a242c11fcbc501e7afc791a50187e0dd574 that causes default configurations to not be loaded if there is no notmuch config (for notmuch defaults) or not alot config (for alot defaults). This is because in the original patch the configs were not loaded in the constructor, but then were loaded outside the constructor. In the patch the logic that caused the constructor not to load the config was moved out of the constructor and prevented the calls in main from initializing to defaults.