### PR TITLE
docs: mention 'content' part in threadline theming

### DIFF
--- a/alot/defaults/theme.spec
+++ b/alot/defaults/theme.spec
@@ -26,8 +26,9 @@
     [[threadline]]
         normal = attrtriple
         focus = attrtriple
-        # order subwidgets are displayed. subset of {date,mailcount,tags,authors,subject,count}
-        # every element listed must have its own subsection below
+        # list of subwidgets to display. Every element listed must have its
+        # own subsection below. Valid elements are authors, content, date,
+        # mailcount, tags, and subject.
         parts = string_list(default=None)
         [[[__many__]]]
             normal = attrtriple

--- a/docs/source/configuration/theming.rst
+++ b/docs/source/configuration/theming.rst
@@ -65,11 +65,12 @@ determines how to present a thread: here, :ref:`attributes <config.theming.attri
 'focus' provide fallback/spacer themes and 'parts' is a (string) list of displayed subwidgets.
 Possible part strings are:
 
+* authors
+* content
 * date
 * mailcount
-* tags
-* authors
 * subject
+* tags
 
 For every listed part there must be a subsection with the same name, defining
 
@@ -82,7 +83,7 @@ For every listed part there must be a subsection with the same name, defining
 :alignment: how to place the content string if the widget space is larger.
             This must be one of 'right', 'left' or 'center'.
 
-To "highlight" some thread lines (use different attributes than the defaults found in the
+To highlight some thread lines (use different attributes than the defaults found in the
 '[[threadline]]' section), one can define sections with prefix 'threadline'.
 Each one of those can redefine any part of the structure outlined above, the rest defaults to
 values defined in '[[threadline]]'.


### PR DESCRIPTION
... which displays a prefix of the msg contents. I forgot to list this
feature in the docs.

closes #1068