### PR TITLE
travis: generate coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,9 @@ before_install: |
     # Install the python bindings.
     cd bindings/python
     pip install .
+    # Install the coverage programs to generate a coverage report and upload
+    # it to codacy.com
+    pip install coverage codacy-coverage
     # Move out of the notmuch dir again.
     cd ../../..
   fi
@@ -109,7 +112,15 @@ script: |
     make -C docs html SPHINXBUILD='sphinx-build -W'
   else
     alot --config conf
-    python setup.py test
+    coverage run setup.py test
+  fi
+
+after_success: |
+  set -e
+  if [[ $JOB = tests ]]; then
+    coverage xml
+    export CODACY_PROJECT_TOKEN=df4443e7313e4ae599bcbbaf4835b00f
+    python-codacy-coverage -r coverage.xml
   fi
 
 notifications:


### PR DESCRIPTION
Generate a coverage report and upload it to codacy.com as discussed in #1087.

@pazz as said in https://github.com/pazz/alot/issues/1087#issuecomment-320333120 I will need your help to generate and encrypt an API token for codacy.  You could post the encrypted token as a comment in this PR, then I will amend my commit.  You could also try to run these commands on the command line first to see if it works:
```sh
pip2 install --user coverage codacy-coverage
coverage run setup.py test
coverage xml
export CODACY_PROJECT_TOKEN='the unencrypted token'
codacy-coverage -r coverage.xml
```