### PR TITLE
Handle servers that treat the user segment of an address as case insensitive

### DIFF
--- a/alot/account.py
+++ b/alot/account.py
@@ -201,7 +201,7 @@ class Account(object):
                  signature_filename=None, signature_as_attachment=False,
                  sent_box=None, sent_tags=None, draft_box=None,
                  draft_tags=None, abook=None, sign_by_default=False,
-                 encrypt_by_default=u"none",
+                 encrypt_by_default=u"none", case_sensitive_username=False,
                  **_):
         sent_tags = sent_tags or []
         if 'sent' not in sent_tags:
@@ -210,8 +210,9 @@ class Account(object):
         if 'draft' not in draft_tags:
             draft_tags.append('draft')
 
-        self.address = address
-        self.aliases = aliases or []
+        self.address = Address.from_string(address, case_sensitive=case_sensitive_username)
+        self.aliases = [Address.from_string(a, case_sensitive=case_sensitive_username)
+                        for a in (aliases or [])]
         self.alias_regexp = alias_regexp
         self.realname = realname
         self.gpg_key = gpg_key

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -71,11 +71,13 @@ def determine_sender(mail, action='reply'):
         # pick the most important account that has an address in candidates
         # and use that accounts realname and the address found here
         for account in my_accounts:
-            acc_addresses = [re.escape(a) for a in account.get_addresses()]
+            acc_addresses = [re.escape(unicode(a)) for a in account.get_addresses()]
             if account.alias_regexp is not None:
                 acc_addresses.append(account.alias_regexp)
             for alias in acc_addresses:
-                regex = re.compile('^' + alias + '$', flags=re.IGNORECASE)
+                regex = re.compile(
+                    u'^' + unicode(alias) + u'$',
+                    flags=re.IGNORECASE if not account.address.case_sensitive else 0)
                 for seen_name, seen_address in candidate_addresses:
                     if regex.match(seen_address):
                         logging.debug("match!: '%s' '%s'", seen_address, alias)

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -355,6 +355,14 @@ thread_focus_linewise = boolean(default=True)
         # use your default key.
         gpg_key = gpg_key_hint(default=None)
 
+        # Whether the server treats the address as case-senstive or
+        # case-insensitve (True for the former, False for the latter)
+        #
+        # .. note:: The vast majority (if not all) SMTP servers in modern use
+        #           treat usernames as case insenstive, you should only set
+        #           this if you know that you need it.
+        case_sensitive_username = boolean(default=False)
+
         # address book for this account
         [[[abook]]]
             # type identifier for address book

--- a/docs/source/api/settings.rst
+++ b/docs/source/api/settings.rst
@@ -54,6 +54,8 @@ Accounts
 
 .. module:: alot.account
 
+.. autoclass:: Address
+    :members:
 .. autoclass:: Account
     :members:
 .. autoclass:: SendmailAccount

--- a/docs/source/configuration/accounts_table
+++ b/docs/source/configuration/accounts_table
@@ -169,3 +169,18 @@
     :type: string
     :default: None
 
+
+.. _case-sensitive-username:
+
+.. describe:: case_sensitive_username
+
+     Whether the server treats the address as case-senstive or
+     case-insensitve (True for the former, False for the latter)
+
+     .. note:: The vast majority (if not all) SMTP servers in modern use
+               treat usernames as case insenstive, you should only set
+               this if you know that you need it.
+
+    :type: boolean
+    :default: False
+

--- a/tests/account_test.py
+++ b/tests/account_test.py
@@ -52,3 +52,114 @@ class TestAccount(unittest.TestCase):
             acct = _AccountTestClass(address=u'foo@example.com',
                                      encrypt_by_default=each)
             self.assertEqual(acct.encrypt_by_default, u'none')
+
+
+class TestAddress(unittest.TestCase):
+
+    """Tests for the Address class."""
+
+    def test_constructor_bytes(self):
+        with self.assertRaises(AssertionError):
+            account.Address(b'username', b'domainname')
+
+    def test_from_string_bytes(self):
+        with self.assertRaises(AssertionError):
+            account.Address.from_string(b'user@example.com')
+
+    def test_from_string(self):
+        addr = account.Address.from_string(u'user@example.com')
+        self.assertEqual(addr.username, u'user')
+        self.assertEqual(addr.domainname, u'example.com')
+
+    def test_unicode(self):
+        addr = account.Address(u'ušer', u'example.com')
+        self.assertEqual(unicode(addr), u'ušer@example.com')
+
+    def test_str(self):
+        addr = account.Address(u'ušer', u'example.com')
+        self.assertEqual(str(addr), u'ušer@example.com'.encode('utf-8'))
+
+    def test_eq_unicode(self):
+        addr = account.Address(u'ušer', u'example.com')
+        self.assertEqual(addr, u'ušer@example.com')
+
+    def test_eq_address(self):
+        addr = account.Address(u'ušer', u'example.com')
+        addr2 = account.Address(u'ušer', u'example.com')
+        self.assertEqual(addr, addr2)
+
+    def test_ne_unicode(self):
+        addr = account.Address(u'ušer', u'example.com')
+        self.assertNotEqual(addr, u'user@example.com')
+
+    def test_ne_address(self):
+        addr = account.Address(u'ušer', u'example.com')
+        addr2 = account.Address(u'user', u'example.com')
+        self.assertNotEqual(addr, addr2)
+
+    def test_eq_unicode_case(self):
+        addr = account.Address(u'UŠer', u'example.com')
+        self.assertEqual(addr, u'ušer@example.com')
+
+    def test_ne_unicode_case(self):
+        addr = account.Address(u'ušer', u'example.com')
+        self.assertEqual(addr, u'uŠer@example.com')
+
+    def test_ne_address_case(self):
+        addr = account.Address(u'ušer', u'example.com')
+        addr2 = account.Address(u'uŠer', u'example.com')
+        self.assertEqual(addr, addr2)
+
+    def test_eq_address_case(self):
+        addr = account.Address(u'UŠer', u'example.com')
+        addr2 = account.Address(u'ušer', u'example.com')
+        self.assertEqual(addr, addr2)
+
+    def test_eq_unicode_case_sensitive(self):
+        addr = account.Address(u'UŠer', u'example.com', case_sensitive=True)
+        self.assertNotEqual(addr, u'ušer@example.com')
+
+    def test_eq_address_case_sensitive(self):
+        addr = account.Address(u'UŠer', u'example.com', case_sensitive=True)
+        addr2 = account.Address(u'ušer', u'example.com')
+        self.assertNotEqual(addr, addr2)
+
+    def test_eq_str(self):
+        addr = account.Address(u'user', u'example.com', case_sensitive=True)
+        with self.assertRaises(TypeError):
+            addr == 1  # pylint: disable=pointless-statement
+
+    def test_ne_str(self):
+        addr = account.Address(u'user', u'example.com', case_sensitive=True)
+        with self.assertRaises(TypeError):
+            addr != 1  # pylint: disable=pointless-statement
+
+    def test_repr(self):
+        addr = account.Address(u'user', u'example.com', case_sensitive=True)
+        self.assertEqual(
+            repr(addr),
+            "Address(u'user', u'example.com', case_sensitive=True)")
+
+    def test_domain_name_ne(self):
+        addr = account.Address(u'user', u'example.com')
+        self.assertNotEqual(addr, u'user@example.org')
+
+    def test_domain_name_eq_case(self):
+        addr = account.Address(u'user', u'example.com')
+        self.assertEqual(addr, u'user@Example.com')
+
+    def test_domain_name_ne_unicode(self):
+        addr = account.Address(u'user', u'éxample.com')
+        self.assertNotEqual(addr, u'user@example.com')
+
+    def test_domain_name_eq_unicode(self):
+        addr = account.Address(u'user', u'éxample.com')
+        self.assertEqual(addr, u'user@Éxample.com')
+
+    def test_domain_name_eq_case_sensitive(self):
+        addr = account.Address(u'user', u'example.com', case_sensitive=True)
+        self.assertEqual(addr, u'user@Example.com')
+
+    def test_domain_name_eq_unicode_sensitive(self):
+        addr = account.Address(u'user', u'éxample.com', case_sensitive=True)
+        self.assertEqual(addr, u'user@Éxample.com')

--- a/tests/commands/thread_test.py
+++ b/tests/commands/thread_test.py
@@ -151,77 +151,77 @@ class TestDetermineSender(unittest.TestCase):
         self.assertTupleEqual(cm2.exception.args, expected)
 
     def test_default_account_is_used_if_no_match_is_found(self):
-        account1 = _AccountTestClass(address='foo@example.com')
-        account2 = _AccountTestClass(address='bar@example.com')
-        expected = ('foo@example.com', account1)
+        account1 = _AccountTestClass(address=u'foo@example.com')
+        account2 = _AccountTestClass(address=u'bar@example.com')
+        expected = (u'foo@example.com', account1)
         self._test(accounts=[account1, account2], expected=expected)
 
     def test_matching_address_and_account_are_returned(self):
-        account1 = _AccountTestClass(address='foo@example.com')
-        account2 = _AccountTestClass(address='to@example.com')
-        account3 = _AccountTestClass(address='bar@example.com')
-        expected = ('to@example.com', account2)
+        account1 = _AccountTestClass(address=u'foo@example.com')
+        account2 = _AccountTestClass(address=u'to@example.com')
+        account3 = _AccountTestClass(address=u'bar@example.com')
+        expected = (u'to@example.com', account2)
         self._test(accounts=[account1, account2, account3], expected=expected)
 
     def test_force_realname_includes_real_name_in_returned_address_if_defined(self):
-        account1 = _AccountTestClass(address='foo@example.com')
-        account2 = _AccountTestClass(address='to@example.com', realname='Bar')
-        account3 = _AccountTestClass(address='baz@example.com')
-        expected = ('Bar <to@example.com>', account2)
+        account1 = _AccountTestClass(address=u'foo@example.com')
+        account2 = _AccountTestClass(address=u'to@example.com', realname='Bar')
+        account3 = _AccountTestClass(address=u'baz@example.com')
+        expected = (u'Bar <to@example.com>', account2)
         self._test(accounts=[account1, account2, account3], expected=expected,
                    force_realname=True)
 
     def test_doesnt_fail_with_force_realname_if_real_name_not_defined(self):
-        account1 = _AccountTestClass(address='foo@example.com')
-        account2 = _AccountTestClass(address='to@example.com')
-        account3 = _AccountTestClass(address='bar@example.com')
-        expected = ('to@example.com', account2)
+        account1 = _AccountTestClass(address=u'foo@example.com')
+        account2 = _AccountTestClass(address=u'to@example.com')
+        account3 = _AccountTestClass(address=u'bar@example.com')
+        expected = (u'to@example.com', account2)
         self._test(accounts=[account1, account2, account3], expected=expected,
                    force_realname=True)
 
     def test_with_force_address_main_address_is_used_regardless_of_matching_address(self):
         # In python 3.4 this and the next test could be written as subtests.
-        account1 = _AccountTestClass(address='foo@example.com')
-        account2 = _AccountTestClass(address='bar@example.com',
-                                     aliases=['to@example.com'])
-        account3 = _AccountTestClass(address='bar@example.com')
-        expected = ('bar@example.com', account2)
+        account1 = _AccountTestClass(address=u'foo@example.com')
+        account2 = _AccountTestClass(address=u'bar@example.com',
+                                     aliases=[u'to@example.com'])
+        account3 = _AccountTestClass(address=u'bar@example.com')
+        expected = (u'bar@example.com', account2)
         self._test(accounts=[account1, account2, account3], expected=expected,
                    force_address=True)
 
     def test_without_force_address_matching_address_is_used(self):
         # In python 3.4 this and the previous test could be written as
         # subtests.
-        account1 = _AccountTestClass(address='foo@example.com')
-        account2 = _AccountTestClass(address='bar@example.com',
-                                     aliases=['to@example.com'])
-        account3 = _AccountTestClass(address='baz@example.com')
-        expected = ('to@example.com', account2)
+        account1 = _AccountTestClass(address=u'foo@example.com')
+        account2 = _AccountTestClass(address=u'bar@example.com',
+                                     aliases=[u'to@example.com'])
+        account3 = _AccountTestClass(address=u'baz@example.com')
+        expected = (u'to@example.com', account2)
         self._test(accounts=[account1, account2, account3], expected=expected,
                    force_address=False)
 
     def test_uses_to_header_if_present(self):
-        account1 = _AccountTestClass(address='foo@example.com')
-        account2 = _AccountTestClass(address='to@example.com')
-        account3 = _AccountTestClass(address='bar@example.com')
-        expected = ('to@example.com', account2)
+        account1 = _AccountTestClass(address=u'foo@example.com')
+        account2 = _AccountTestClass(address=u'to@example.com')
+        account3 = _AccountTestClass(address=u'bar@example.com')
+        expected = (u'to@example.com', account2)
         self._test(accounts=[account1, account2, account3], expected=expected)
 
     def test_header_order_is_more_important_than_accounts_order(self):
-        account1 = _AccountTestClass(address='cc@example.com')
-        account2 = _AccountTestClass(address='to@example.com')
-        account3 = _AccountTestClass(address='bcc@example.com')
-        expected = ('to@example.com', account2)
+        account1 = _AccountTestClass(address=u'cc@example.com')
+        account2 = _AccountTestClass(address=u'to@example.com')
+        account3 = _AccountTestClass(address=u'bcc@example.com')
+        expected = (u'to@example.com', account2)
         self._test(accounts=[account1, account2, account3], expected=expected)
 
     def test_accounts_can_be_found_by_alias_regex_setting(self):
-        account1 = _AccountTestClass(address='foo@example.com')
-        account2 = _AccountTestClass(address='to@example.com',
+        account1 = _AccountTestClass(address=u'foo@example.com')
+        account2 = _AccountTestClass(address=u'to@example.com',
                                      alias_regexp=r'to\+.*@example.com')
-        account3 = _AccountTestClass(address='bar@example.com')
-        mailstring = self.mailstring.replace('to@example.com',
-                                             'to+some_tag@example.com')
+        account3 = _AccountTestClass(address=u'bar@example.com')
+        mailstring = self.mailstring.replace(u'to@example.com',
+                                             u'to+some_tag@example.com')
         mail = email.message_from_string(mailstring)
-        expected = ('to+some_tag@example.com', account2)
+        expected = (u'to+some_tag@example.com', account2)
         self._test(accounts=[account1, account2, account3], expected=expected,
                    mail=mail)

--- a/tests/settings/manager_test.py
+++ b/tests/settings/manager_test.py
@@ -123,17 +123,17 @@ class TestSettingsManagerGetAccountByAddress(utilities.TestCaseClassCleanup):
         cls.manager = SettingsManager(alot_rc=f.name)
 
     def test_exists_addr(self):
-        acc = self.manager.get_account_by_address('that_guy@example.com')
+        acc = self.manager.get_account_by_address(u'that_guy@example.com')
         self.assertEqual(acc.realname, 'That Guy')
 
     def test_doesnt_exist_return_default(self):
-        acc = self.manager.get_account_by_address('doesntexist@example.com',
+        acc = self.manager.get_account_by_address(u'doesntexist@example.com',
                                                   return_default=True)
         self.assertEqual(acc.realname, 'That Guy')
 
     def test_doesnt_exist_raise(self):
         with self.assertRaises(NoMatchingAccount):
-            self.manager.get_account_by_address('doesntexist@example.com')
+            self.manager.get_account_by_address(u'doesntexist@example.com')
 
     def test_doesnt_exist_no_default(self):
         with tempfile.NamedTemporaryFile() as f:
@@ -148,7 +148,6 @@ class TestSettingsManagerGetAccountByAddress(utilities.TestCaseClassCleanup):
             'That Guy <a_dude@example.com>')
         self.assertEqual(acc.realname, 'A Dude')
 
-    @unittest.expectedFailure
     def test_address_case(self):
         """Some servers do not differentiate addresses by case.
 

--- a/tests/settings/manager_test.py
+++ b/tests/settings/manager_test.py
@@ -147,3 +147,15 @@ class TestSettingsManagerGetAccountByAddress(utilities.TestCaseClassCleanup):
         acc = self.manager.get_account_by_address(
             'That Guy <a_dude@example.com>')
         self.assertEqual(acc.realname, 'A Dude')
+
+    @unittest.expectedFailure
+    def test_address_case(self):
+        """Some servers do not differentiate addresses by case.
+
+        So, for example, "foo@example.com" and "Foo@example.com" would be
+        considered the same. Among servers that do this gmail, yahoo, fastmail,
+        anything running Exchange (i.e., most large corporations), and others.
+        """
+        acc1 = self.manager.get_account_by_address('That_guy@example.com')
+        acc2 = self.manager.get_account_by_address('that_guy@example.com')
+        self.assertIs(acc1, acc2)


### PR DESCRIPTION
Alot (like other email clients that aren't tightly coupled to one mail server) are in a difficult position, RFC 5321 section 2.3.11 (which is in the docstring of the "account: Add an Address class" patch), says that only the server for the receiving domain (for example, gmail.com) is allowed to alter or interpret the user name segment (everything before the @) in any way.

Why is this a problem for alot? Well, we need to apply the same semantics. If the server for "example.com" treats "foo@example.com" and "Foo@example.com" as equivalent (which it may), alot needs to do the same. If example.com treats them as different accounts, then alot does too.

There are simply too many servers out there to try to maintain a list of who does what (and it's a dangerous game to play, because some servers apply additional semantics, like gmail and fastmail that ignore anything after a "+" sign, so "foo@example.com" and "foo+spam@example.com" are the same to these services) and we don't want to manage that.

Instead this series takes the approach of adding a new class that acts like a `unicode` or `str` instance, including being comparable with rich comparison operators (at least == and !=, although the other's could easily be added) which can be flagged as either case sensitive or not, and adds a new option to the account section of the configuration to control this flag.