### PR TITLE
Fix issue with account selection

### DIFF
--- a/alot/account.py
+++ b/alot/account.py
@@ -193,7 +193,7 @@ class SendmailAccount(Account):
         """Pipe the given mail to the configured sendmail command.  Display a
         short message on success or a notification on error.
         :param mail: the mail to send out
-        :type mail: str
+        :type mail: :class:`email.message.Message` or string
         :returns: the deferred that calls the sendmail command
         :rtype: `twisted.internet.defer.Deferred`
         """
@@ -213,6 +213,9 @@ class SendmailAccount(Account):
             logging.error(failure.getTraceback())
             logging.error(failure.value.stderr)
             raise SendingMailFailed(errmsg)
+
+        # make sure self.mail is a string
+        mail = str(mail)
 
         d = call_cmd_async(cmdlist, stdin=mail)
         d.addCallback(cb)

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -236,11 +236,6 @@ class SendCommand(Command):
             return
         logging.debug("ACCOUNT: \"%s\"" % account.address)
 
-        # make sure self.mail is a string
-        logging.debug(self.mail.__class__)
-        if isinstance(self.mail, email.message.Message):
-            self.mail = str(self.mail)
-
         # define callback
         def afterwards(_):
             initial_tags = []

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -118,7 +118,7 @@ class SaveCommand(Command):
         # determine account to use
         try:
             account = settings.get_account_by_address(
-                envelope.get('From'), return_default=True)
+                envelope['From'], return_default=True)
         except NoMatchingAccount:
             ui.notify('no accounts set.', priority='error')
             return
@@ -226,12 +226,15 @@ class SendCommand(Command):
         msg = self.mail
         if not isinstance(msg, email.message.Message):
             msg = email.message_from_string(self.mail)
+        address = msg.get('From', '')
+        logging.debug("FROM: \"%s\"" % address)
         try:
-            account = settings.get_account_by_address(
-                msg.get('From', ''), return_default=True)
+            account = settings.get_account_by_address(address,
+                                                      return_default=True)
         except NoMatchingAccount:
             ui.notify('no accounts set', priority='error')
             return
+        logging.debug("ACCOUNT: \"%s\"" % account.address)
 
         # make sure self.mail is a string
         logging.debug(self.mail.__class__)
@@ -505,8 +508,7 @@ class SignCommand(Command):
                     return
             else:
                 try:
-                    _, addr = email.utils.parseaddr(envelope.headers['From'][0])
-                    acc = settings.get_account_by_address(addr)
+                    acc = settings.get_account_by_address(envelope['From'])
                 except NoMatchingAccount:
                     envelope.sign = False
                     ui.notify('Unable to find a matching account',

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -9,6 +9,7 @@ import logging
 import mailcap
 import os
 import re
+import email
 from configobj import ConfigObj, Section
 
 from ..account import SendmailAccount
@@ -112,7 +113,7 @@ class SettingsManager(object):
         if themestring:
             # This is a python for/else loop
             # https://docs.python.org/3/reference/compound_stmts.html#for
-            # 
+            #
             # tl/dr; If the loop loads a theme it breaks. If it doesn't break,
             # then it raises a ConfigError.
             for dir_ in itertools.chain([themes_dir], data_dirs):
@@ -433,7 +434,7 @@ class SettingsManager(object):
     def get_account_by_address(self, address, return_default=False):
         """returns :class:`Account` for a given email address (str)
 
-        :param str address: address to look up
+        :param str address: address to look up. A realname part will be ignored.
         :param bool return_default: If True and no address can be found, then
             the default account wil be returned
         :rtype: :class:`Account`
@@ -441,6 +442,7 @@ class SettingsManager(object):
             found. Thsi includes if return_default is True and there are no
             accounts defined.
         """
+        _, address = email.utils.parseaddr(address)
         for myad in self.get_addresses():
             if myad == address:
                 return self._accountmap[myad]

--- a/tests/commands/envelope_test.py
+++ b/tests/commands/envelope_test.py
@@ -170,10 +170,10 @@ class TestSignCommand(unittest.TestCase):
     @staticmethod
     def _make_ui_mock():
         """Create a mock for the ui and envelope and return them."""
-        envelope = mock.Mock()
+        envelope = Envelope()
+        envelope['From'] = 'foo <foo@example.com>'
         envelope.sign = mock.sentinel.default
         envelope.sign_key = mock.sentinel.default
-        envelope.headers = {'From': ['foo <foo@example.com>']}
         ui = mock.Mock(current_buffer=mock.Mock(envelope=envelope))
         return envelope, ui
 

--- a/tests/commands/envelope_test.py
+++ b/tests/commands/envelope_test.py
@@ -23,7 +23,9 @@ import os
 import shutil
 import tempfile
 import textwrap
-import unittest
+
+from twisted.trial import unittest
+from twisted.internet.defer import inlineCallbacks
 
 import mock
 
@@ -370,18 +372,20 @@ class TestSendCommand(unittest.TestCase):
         Foo Bar Baz
         """)
 
+    @inlineCallbacks
     def test_get_account_by_address_with_str(self):
         cmd = envelope.SendCommand(mail=self.mail)
         account = mock.Mock()
         with mock.patch(
                 'alot.commands.envelope.settings.get_account_by_address',
                 mock.Mock(return_value=account)) as get_account_by_address:
-            cmd.apply(mock.Mock())
+            yield cmd.apply(mock.Mock())
         get_account_by_address.assert_called_once_with('foo@example.com',
                                                        return_default=True)
         # check that the apply did run through till the end.
         account.send_mail.assert_called_once_with(self.mail)
 
+    @inlineCallbacks
     def test_get_account_by_address_with_email_message(self):
         mail = email.message_from_string(self.mail)
         cmd = envelope.SendCommand(mail=mail)
@@ -389,7 +393,7 @@ class TestSendCommand(unittest.TestCase):
         with mock.patch(
                 'alot.commands.envelope.settings.get_account_by_address',
                 mock.Mock(return_value=account)) as get_account_by_address:
-            cmd.apply(mock.Mock())
+            yield cmd.apply(mock.Mock())
         get_account_by_address.assert_called_once_with('foo@example.com',
                                                        return_default=True)
         # check that the apply did run through till the end.

--- a/tests/settings/manager_test.py
+++ b/tests/settings/manager_test.py
@@ -111,3 +111,8 @@ class TestSettingsManagerGetAccountByAddress(utilities.TestCaseClassCleanup):
         with self.assertRaises(NoMatchingAccount):
             settings.get_account_by_address('that_guy@example.com',
                                             return_default=True)
+
+    def test_real_name_will_be_stripped_before_matching(self):
+        acc = self.manager.get_account_by_address(
+            'That Guy <a_dude@example.com>')
+        self.assertEqual(acc.realname, 'A Dude')


### PR DESCRIPTION
The problem is that `commands.envelope.SendCommand` simply passes the content
of the From-header to `settings.get_account_by_address`, without removing the realname part.
The problem was introduced in 084e37c, which silently drops the parsing of structured address strings .

So if the From-header is of the form "real name <email@address.org>", this does not match the account with
address "email@address.org" and falls back to the default account, which could be different.
I noticed this only by chance because my default provider (gmail) actually processes (and changes the sender) when given mails with foreign From-header values.

The first patch here moves this call into `get_account_by_address` itself, the second patch simplifies all calls to this method.

This might also fix #1110