### PR TITLE
alot: replace email.Utils with email.utils

### DIFF
--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -132,7 +132,7 @@ class SaveCommand(Command):
         mail = envelope.construct_mail()
         # store mail locally
         # add Date header
-        mail['Date'] = email.Utils.formatdate(localtime=True)
+        mail['Date'] = email.utils.formatdate(localtime=True)
         path = account.store_draft_mail(email_as_string(mail))
 
         msg = 'draft saved successfully'
@@ -213,7 +213,7 @@ class SendCommand(Command):
 
             try:
                 self.mail = self.envelope.construct_mail()
-                self.mail['Date'] = email.Utils.formatdate(localtime=True)
+                self.mail['Date'] = email.utils.formatdate(localtime=True)
                 self.mail = email_as_string(self.mail)
             except GPGProblem as e:
                 ui.clear_notify([clearme])

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -821,7 +821,7 @@ class ComposeCommand(Command):
 
         # find out the right account
         sender = self.envelope.get('From')
-        name, addr = email.Utils.parseaddr(sender)
+        name, addr = email.utils.parseaddr(sender)
         account = settings.get_account_by_address(addr)
         if account is None:
             accounts = settings.get_accounts()

--- a/alot/db/envelope.py
+++ b/alot/db/envelope.py
@@ -261,7 +261,7 @@ class Envelope(object):
         headers = self.headers.copy()
         # add Message-ID
         if 'Message-ID' not in headers:
-            headers['Message-ID'] = [email.Utils.make_msgid()]
+            headers['Message-ID'] = [email.utils.make_msgid()]
 
         if 'User-Agent' in headers:
             uastring_format = headers['User-Agent'][0]

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -155,7 +155,7 @@ class Message(object):
 
         :rtype: (str,str)
         """
-        return email.Utils.parseaddr(self._from)
+        return email.utils.parseaddr(self._from)
 
     def add_tags(self, tags, afterwards=None, remove_rest=False):
         """


### PR DESCRIPTION
In python 3 email.Utils doesn't exist, in python 2.7 both do, but Utils
is deprecated.