### PR TITLE
mark old options for encrypt_by_default as deprecated

### DIFF
--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -332,23 +332,23 @@ thread_focus_linewise = boolean(default=True)
         # Outgoing messages will be GPG signed by default if this is set to True.
         sign_by_default = boolean(default=False)
 
-	# Alot will try to GPG encrypt outgoing messages by default when this
-	# is set to `all` or `trusted`.  If set to `all` the message will be
-	# encrypted for all recipients for who a key is available in the key
-	# ring.  If set to `trusted` it will be encrypted to all
-	# recipients if a trusted key is available for all recipients (one
-	# where the user id for the key is signed with a trusted signature).
-	#
-	# .. note:: If the message will not be encrypted by default you can
-	#           still use the :ref:`toggleencrypt
-	#           <cmd.envelope.toggleencrypt>`, :ref:`encrypt
-	#           <cmd.envelope.encrypt>` and :ref:`unencrypt
-	#           <cmd.envelope.unencrypt>` commands to encrypt it.
-	# .. note:: The values `True` and `False` are interpreted as `all` and
-	#           `none` respectively.  They are kept for backwards
-	#           compatibility to give users a change to migrate to the new
-	#           option type.  They might become deprecated in future
-	#           versions.
+        # Alot will try to GPG encrypt outgoing messages by default when this
+        # is set to `all` or `trusted`.  If set to `all` the message will be
+        # encrypted for all recipients for who a key is available in the key
+        # ring.  If set to `trusted` it will be encrypted to all
+        # recipients if a trusted key is available for all recipients (one
+        # where the user id for the key is signed with a trusted signature).
+        #
+        # .. note:: If the message will not be encrypted by default you can
+        #           still use the :ref:`toggleencrypt
+        #           <cmd.envelope.toggleencrypt>`, :ref:`encrypt
+        #           <cmd.envelope.encrypt>` and :ref:`unencrypt
+        #           <cmd.envelope.unencrypt>` commands to encrypt it.
+        # .. deprecated:: 0.4
+        #           The values `True` and `False` are interpreted as `all` and
+        #           `none` respectively. `0`, `1`, `true`, `True`, `false`,
+        #           `False`, `yes`, `Yes`, `no`, `No`, will be removed before
+        #           1.0, please move to `all`, `none`, or `trusted`.
         encrypt_by_default = option('all', 'none', 'trusted', 'True', 'False', 'true', 'false', 'Yes', 'No', 'yes', 'no', '1', '0', default='none')
 
         # The GPG key ID you want to use with this account. If unset, alot will

--- a/docs/source/configuration/accounts_table
+++ b/docs/source/configuration/accounts_table
@@ -149,11 +149,11 @@
                <cmd.envelope.toggleencrypt>`, :ref:`encrypt
                <cmd.envelope.encrypt>` and :ref:`unencrypt
                <cmd.envelope.unencrypt>` commands to encrypt it.
-     .. note:: The values `True` and `False` are interpreted as `all` and
-               `none` respectively.  They are kept for backwards
-               compatibility to give users a change to migrate to the new
-               option type.  They might become deprecated in future
-               versions.
+     .. deprecated:: 0.4
+               The values `True` and `False` are interpreted as `all` and
+               `none` respectively. `0`, `1`, `true`, `True`, `false`,
+               `False`, `yes`, `Yes`, `no`, `No`, will be removed before
+               1.0, please move to `all`, `none`, or `trusted`.
 
     :type: option, one of ['all', 'none', 'trusted', 'True', 'False', 'true', 'false', 'Yes', 'No', 'yes', 'no', '1', '0']
     :default: none


### PR DESCRIPTION
Mark all values for [account]encrypt_by_default as deprecated