### PR TITLE
Some small changes that are py2 and py3 compatible

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -863,7 +863,7 @@ class ComposeCommand(Command):
                 self.envelope.sign_key = account.gpg_key
             else:
                 msg = 'Cannot find gpg key for account {}'.format(account.address)
-                logging.warn(msg)
+                logging.warning(msg)
                 ui.notify(msg, priority='error')
 
         # get missing To header

--- a/alot/completion.py
+++ b/alot/completion.py
@@ -437,10 +437,10 @@ class CommandCompleter(Completer):
                                                                    localpos)
 
                         # prepend 'set ' + header and correct position
-                        def f((completed, pos)):
+                        def f(completed, pos):
                             return ('%s %s' % (header, completed),
                                     pos + len(header) + 1)
-                        res = [f(r) for r in res]
+                        res = [f(c, p) for c, p in res]
                         logging.debug(res)
 
                 elif self.mode == 'envelope' and cmd == 'unset':

--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -274,7 +274,7 @@ class DBManager(object):
         """returns :class:`notmuch.database.Thread` with given id"""
         query = self.query('thread:' + tid)
         try:
-            return query.search_threads().next()
+            return next(query.search_threads())
         except StopIteration:
             errmsg = 'no thread with id %s exists!' % tid
             raise NonexistantObjectError(errmsg)

--- a/alot/db/thread.py
+++ b/alot/db/thread.py
@@ -231,7 +231,7 @@ class Thread(object):
         """
         if not self._messages:  # if not already cached
             query = self._dbman.query('thread:' + self._id)
-            thread = query.search_threads().next()
+            thread = next(query.search_threads())
 
             def accumulate(acc, msg):
                 M = Message(self._dbman, msg, thread=self)


### PR DESCRIPTION
This just replaces some code that only works with py2 with a variant that works both with py2 and py3.  It should not break anything but at the same time will help us on the way to py3 (also if we drop py2 later).  With these changes 79 tests can already be run with py3 and 42 pass (many still fail because of string and unicode stuff or can not even be run because of import errors).

Triggered by #1116.

If you like this PR I also have some commits which add compatible imports with a `try: import py2stuff; except ImportError: import py3stuff` pattern.  Should I add them here. (They are different in that they have to be touched again if we drop py2. These changes here don't have to be touched again.)