### PR TITLE
py3k small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/build
 docs/source/configuration/*table.rst
 tags
 .eggs
+__pycache__

--- a/alot/commands/__init__.py
+++ b/alot/commands/__init__.py
@@ -167,7 +167,7 @@ def commandfactory(cmdline, mode='global'):
     try:
         args = split_commandstring(cmdline)
     except ValueError as e:
-        raise CommandParseError(e.message)
+        raise CommandParseError(str(e))
     args = [string_decode(x, 'utf-8') for x in args]
     logging.debug('ARGS: %s', args)
     cmdname = args[0]

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -146,8 +146,8 @@ class SaveCommand(Command):
                 ui.apply_command(globals.FlushCommand())
                 ui.apply_command(commands.globals.BufferCloseCommand())
             except DatabaseError as e:
-                logging.error(e.message)
-                ui.notify('could not index message:\n%s' % e.message,
+                logging.error(e)
+                ui.notify('could not index message:\n%s' % e,
                           priority='error',
                           block=True)
         else:
@@ -217,7 +217,7 @@ class SendCommand(Command):
                 self.mail = email_as_string(self.mail)
             except GPGProblem as e:
                 ui.clear_notify([clearme])
-                ui.notify(e.message, priority='error')
+                ui.notify(str(e), priority='error')
                 return
 
             ui.clear_notify([clearme])
@@ -499,7 +499,7 @@ class SignCommand(Command):
                                                        sign=True)
                 except GPGProblem as e:
                     envelope.sign = False
-                    ui.notify(e.message, priority='error')
+                    ui.notify(str(e), priority='error')
                     return
             else:
                 try:
@@ -571,7 +571,7 @@ class EncryptCommand(Command):
                     tmp_key = crypto.get_key(keyid)
                     del envelope.encrypt_keys[tmp_key.fpr]
             except GPGProblem as e:
-                ui.notify(e.message, priority='error')
+                ui.notify(str(e), priority='error')
             if not envelope.encrypt_keys:
                 envelope.encrypt = False
             ui.current_buffer.rebuild()

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -12,7 +12,7 @@ import glob
 import logging
 import os
 import subprocess
-from StringIO import StringIO
+from io import StringIO
 
 import urwid
 from twisted.internet.defer import inlineCallbacks

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -14,7 +14,7 @@ from email.utils import getaddresses, parseaddr, formataddr
 from email.message import Message
 
 from twisted.internet.defer import inlineCallbacks
-from cStringIO import StringIO
+from io import BytesIO
 
 from . import Command, registerCommand
 from .globals import ExternalCommand
@@ -970,7 +970,7 @@ class OpenAttachmentCommand(Command):
                 def afterwards():
                     os.unlink(tempfile_name)
             else:
-                handler_stdin = StringIO()
+                handler_stdin = BytesIO()
                 self.attachment.write(handler_stdin)
 
             # create handler command list

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -186,7 +186,7 @@ class ReplyCommand(Command):
         try:
             from_header, _ = determine_sender(mail, 'reply')
         except AssertionError as e:
-            ui.notify(e.message, priority='error')
+            ui.notify(str(e), priority='error')
             return
         envelope.add('From', from_header)
 
@@ -394,7 +394,7 @@ class ForwardCommand(Command):
         try:
             from_header, _ = determine_sender(mail, 'reply')
         except AssertionError as e:
-            ui.notify(e.message, priority='error')
+            ui.notify(str(e), priority='error')
             return
         envelope.add('From', from_header)
 
@@ -441,7 +441,7 @@ class BounceMailCommand(Command):
         try:
             resent_from_header, account = determine_sender(mail, 'bounce')
         except AssertionError as e:
-            ui.notify(e.message, priority='error')
+            ui.notify(str(e), priority='error')
             return
         mail['Resent-From'] = resent_from_header
 

--- a/alot/commands/utils.py
+++ b/alot/commands/utils.py
@@ -86,7 +86,7 @@ def _get_keys(ui, encrypt_keyids, block_error=False, signed_only=False):
                     encrypt_keyids.append(keyid)
                 continue
             else:
-                ui.notify(e.message, priority='error', block=block_error)
+                ui.notify(str(e), priority='error', block=block_error)
                 continue
         keys[key.fpr] = key
     returnValue(keys)

--- a/alot/crypto.py
+++ b/alot/crypto.py
@@ -196,7 +196,7 @@ def verify_detached(message, signature):
     except gpg.errors.BadSignatures as e:
         raise GPGProblem(str(e), code=GPGCode.BAD_SIGNATURE)
     except gpg.errors.GPGMEError as e:
-        raise GPGProblem(e.message, code=e.getcode())
+        raise GPGProblem(str(e), code=e.getcode())
 
 
 def decrypt_verify(encrypted):
@@ -212,7 +212,7 @@ def decrypt_verify(encrypted):
     try:
         (plaintext, _, verify_result) = ctx.decrypt(encrypted, verify=True)
     except gpg.errors.GPGMEError as e:
-        raise GPGProblem(e.message, code=e.getcode())
+        raise GPGProblem(str(e), code=e.getcode())
     # what if the signature is bad?
 
     return verify_result.signatures, plaintext

--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -15,7 +15,7 @@ import tempfile
 import re
 import logging
 import mailcap
-from cStringIO import StringIO
+from io import BytesIO
 
 from .. import crypto
 from .. import helper
@@ -264,14 +264,14 @@ def message_from_file(handle):
 def message_from_string(s):
     '''Reads a mail from the given string. This is the equivalent of
     :func:`email.message_from_string` which does nothing but to wrap
-    the given string in a StringIO object and to call
+    the given string in a BytesIO object and to call
     :func:`email.message_from_file`.
 
     Please refer to the documentation of :func:`message_from_file` for
     details.
 
     '''
-    return message_from_file(StringIO(s))
+    return message_from_file(BytesIO(s))
 
 
 def extract_headers(mail, headers=None):

--- a/alot/errors.py
+++ b/alot/errors.py
@@ -19,6 +19,7 @@ class GPGCode(object):
 
 class GPGProblem(Exception):
     """GPG Error"""
+
     def __init__(self, message, code):
         self.code = code
         super(GPGProblem, self).__init__(message)

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -9,7 +9,7 @@ from __future__ import division
 from datetime import timedelta
 from datetime import datetime
 from collections import deque
-from cStringIO import StringIO
+from io import BytesIO
 import logging
 import mimetypes
 import os
@@ -315,8 +315,8 @@ def call_cmd_async(cmdlist, stdin=None, env=None):
     class _EverythingGetter(ProcessProtocol):
         def __init__(self, deferred):
             self.deferred = deferred
-            self.outBuf = StringIO()
-            self.errBuf = StringIO()
+            self.outBuf = BytesIO()
+            self.errBuf = BytesIO()
             self.outReceived = self.outBuf.write
             self.errReceived = self.errBuf.write
 
@@ -606,7 +606,7 @@ def email_as_string(mail):
     :param mail: email to convert to string
     :rtype: str
     """
-    fp = StringIO()
+    fp = BytesIO()
     g = Generator(fp, mangle_from_=False, maxheaderlen=78)
     g.flatten(mail)
     as_string = RFC3156_canonicalize(fp.getvalue())

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -123,7 +123,7 @@ class SettingsManager(object):
                     except ConfigError as e:
                         logging.warning(
                             'Theme file %s failed validation: %s',
-                            themestring, str(e.message))
+                            themestring, e)
                     else:
                         break
             else:

--- a/alot/settings/utils.py
+++ b/alot/settings/utils.py
@@ -44,7 +44,7 @@ def read_config(configpath=None, specpath=None, checks=None):
         try:
             results = config.validate(validator, preserve_errors=True)
         except ConfigObjError as e:
-            raise ConfigError(e.message)
+            raise ConfigError(str(e))
 
         if results is not True:
             error_msg = ''

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -174,7 +174,7 @@ class UI(object):
                     try:
                         self.apply_commandline(cmdline)
                     except CommandParseError as e:
-                        self.notify(e.message, priority='error')
+                        self.notify(str(e), priority='error')
                 # move keys are always passed
                 elif cmdline in ['move up', 'move down', 'move page up',
                                  'move page down']:

--- a/alot/utils/configobj.py
+++ b/alot/utils/configobj.py
@@ -47,7 +47,7 @@ def attr_triple(value):
         normal = AttrSpec(acc['16fg'], acc['16bg'], 16)
         high = AttrSpec(acc['256fg'], acc['256bg'], 256)
     except AttrSpecError as e:
-        raise ValidateError(e.message)
+        raise ValidateError(str(e))
     return mono, normal, high
 
 
@@ -141,4 +141,4 @@ def gpg_key(value):
     try:
         return crypto.get_key(value)
     except GPGProblem as e:
-        raise ValidateError(e.message)
+        raise ValidateError(str(e))

--- a/alot/widgets/globals.py
+++ b/alot/widgets/globals.py
@@ -7,7 +7,6 @@ This contains alot-specific :class:`urwid.Widget` used in more than one mode.
 """
 from __future__ import absolute_import
 
-import functools
 import re
 import operator
 import urwid
@@ -272,7 +271,6 @@ class HeadersList(urwid.WidgetWrap):
         return headerlines
 
 
-@functools.total_ordering
 class TagWidget(urwid.AttrMap):
     """
     text widget that renders a tagstring.
@@ -318,11 +316,8 @@ class TagWidget(urwid.AttrMap):
     def set_unfocussed(self):
         self.set_attr_map(self.attmaps['normal'])
 
-    def __lt__(self, other):
-        """Groups tags of 1 character first, then alphabetically.
-
-        This groups tags unicode characters at the begnining.
-        """
+    def __cmp(self, other, comparitor):
+        """Shared comparison method."""
         if not isinstance(other, TagWidget):
             return NotImplemented
 
@@ -330,8 +325,24 @@ class TagWidget(urwid.AttrMap):
         oth_len = len(other.translated)
 
         if (self_len == 1) is not (oth_len == 1):
-            return self_len < oth_len
-        return self.translated.lower() < other.translated.lower()
+            return comparitor(self_len, oth_len)
+        return comparitor(self.translated.lower(), other.translated.lower())
+
+    def __lt__(self, other):
+        """Groups tags of 1 character first, then alphabetically.
+
+        This groups tags unicode characters at the begnining.
+        """
+        return self.__cmp(other, operator.lt)
+
+    def __gt__(self, other):
+        return self.__cmp(other, operator.gt)
+
+    def __ge__(self, other):
+        return self.__cmp(other, operator.ge)
+
+    def __le__(self, other):
+        return self.__cmp(other, operator.le)
 
     def __eq__(self, other):
         if not isinstance(other, TagWidget):

--- a/alot/widgets/globals.py
+++ b/alot/widgets/globals.py
@@ -292,6 +292,7 @@ class TagWidget(urwid.AttrMap):
         self.translated = representation['translated']
         self.hidden = self.translated == ''
         self.txt = urwid.Text(self.translated, wrap='clip')
+        self.__hash = hash('{}_{}'.format(self.translated, self.txt))
         normal_att = representation['normal']
         focus_att = representation['focussed']
         self.attmaps = {'normal': normal_att, 'focus': focus_att}
@@ -343,3 +344,6 @@ class TagWidget(urwid.AttrMap):
         if not isinstance(other, TagWidget):
             return NotImplemented
         return self.translated.lower() != other.translated.lower()
+
+    def __hash__(self):
+        return self.__hash

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -274,7 +274,6 @@ class MessageTree(CollapsibleTree):
 
         if headers is None:
             # collect all header/value pairs in the order they appear
-            headers = mail.keys()
             for key, value in mail.items():
                 dvalue = decode_header(value, normalize=normalize)
                 lines.append((key, dvalue))


### PR DESCRIPTION
Here's some additional py3k readying patches that do some more user/performance transparent changes in addition to those that lucc sent. These are mostly just syntactic or moved/renamed interface changes. The only thing that is significant, is the addition of the `__hash__` protocol to `TagWidget`. When implementing the `__eq__` protocol in python 2.x `__hash__` isn't required, but it is in python 3. After implementing it I noticed that the search buffer was much slower than it was before, so the hash is cached and not calculated on each walk, which makes it as fast as it was before. It's possible that we either need to make do some of the calculation asynchronously or cache them to make the interface a little faster.