### PR TITLE
additional tests for the helper module

### DIFF
--- a/alot/helper.py
+++ b/alot/helper.py
@@ -333,7 +333,7 @@ def call_cmd_async(cmdlist, stdin=None, env=None):
                 self.deferred.errback(terminated_obj)
 
     d = Deferred()
-    environment = os.environ
+    environment = os.environ.copy()
     if env is not None:
         environment.update(env)
     logging.debug('ENV = %s', environment)

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -129,7 +129,7 @@ def string_decode(string, enc='ascii'):
 def shorten(string, maxlen):
     """shortens string if longer than maxlen, appending ellipsis"""
     if 1 < maxlen < len(string):
-        string = string[:maxlen - 1] + u'\u2026'
+        string = string[:maxlen - 1] + u'…'
     return string[:maxlen]
 
 

--- a/tests/helper_test.py
+++ b/tests/helper_test.py
@@ -402,3 +402,21 @@ class TestEmailAsString(unittest.TestCase):
         actual = helper.email_as_string(message)
         expected = 'X-Unicode-Header: dummy value\r\n\r\n'
         self.assertEqual(actual, expected)
+
+
+class TestShorten(unittest.TestCase):
+
+    def test_lt_maxlen(self):
+        expected = u'a string'
+        actual = helper.shorten(expected, 25)
+        self.assertEqual(expected, actual)
+
+    def test_eq_maxlen(self):
+        expected = 'a string'
+        actual = helper.shorten(expected, len(expected))
+        self.assertEqual(expected, actual)
+
+    def test_gt_maxlen(self):
+        expected = u'a long string…'
+        actual = helper.shorten('a long string that is full of text', 14)
+        self.assertEqual(expected, actual)

--- a/tests/helper_test.py
+++ b/tests/helper_test.py
@@ -451,7 +451,6 @@ class TestCallCmdAsync(unittest.TestCase):
                 env={'foo': 'bar'})
         self.assertEqual(ret, 'bar')
 
-    @utilities.expected_failure
     @inlineCallbacks
     def test_env_doesnt_pollute(self):
         with mock.patch.dict(os.environ, {}, clear=True):

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -171,3 +171,13 @@ def make_key(revoked=False, expired=False, invalid=False, can_encrypt=True,
     mock_key.can_sign = can_sign
 
     return mock_key
+
+
+def expected_failure(func):
+    """For marking expected failures for twisted.trial based unit tests.
+
+    The builtin unittest.expectedFailure does not work with twisted.trail,
+    there is an outstanding bug for this, but no one has ever fixed it.
+    """
+    func.todo = 'expected failure'
+    return func


### PR DESCRIPTION
Mostly this is just more tests and a little bit of test framework (the addition of an expected_failure decorator for `twisted.trial.unittest based tests`). There is one small bug fix that stops `call_cmd_async` from polluting the global environment when called.