### PR TITLE
Submit/external command tests

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -247,7 +247,7 @@ class ExternalCommand(Command):
         # set standard input for subcommand
         stdin = None
         if self.stdin is not None:
-            # wrap strings in StrinIO so that they behaves like a file
+            # wrap strings in StringIO so that they behave like files
             if isinstance(self.stdin, unicode):
                 stdin = StringIO(self.stdin)
             else:

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -255,7 +255,7 @@ class ExternalCommand(Command):
 
         def afterwards(data):
             if data == 'success':
-                if callable(self.on_success):
+                if self.on_success is not None:
                     self.on_success()
             else:
                 ui.notify(data, priority='error')

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -267,23 +267,16 @@ class ExternalCommand(Command):
 
         def thread_code(*_):
             try:
-                if stdin is None:
-                    proc = subprocess.Popen(self.cmdlist, shell=self.shell,
-                                            stderr=subprocess.PIPE)
-                    ret = proc.wait()
-                    err = proc.stderr.read()
-                else:
-                    proc = subprocess.Popen(self.cmdlist, shell=self.shell,
-                                            stdin=subprocess.PIPE,
-                                            stderr=subprocess.PIPE)
-                    _, err = proc.communicate(stdin.read())
-                    ret = proc.wait()
-                if ret == 0:
-                    return 'success'
-                else:
-                    return err.strip()
+                proc = subprocess.Popen(self.cmdlist, shell=self.shell,
+                                        stdin=subprocess.PIPE,
+                                        stderr=subprocess.PIPE)
             except OSError as e:
                 return str(e)
+
+            _, err = proc.communicate(stdin.read() if stdin else None)
+            if proc.returncode == 0:
+                return 'success'
+            return err.strip()
 
         if self.in_thread:
             d = threads.deferToThread(thread_code)

--- a/tests/commands/global_test.py
+++ b/tests/commands/global_test.py
@@ -116,3 +116,34 @@ class TestComposeCommand(unittest.TestCase):
 
         self.assertFalse(envelope.sign)
         self.assertIs(envelope.sign_key, None)
+
+
+class TestExternalCommand(unittest.TestCase):
+
+    class Success(Exception):
+        pass
+
+    def on_success(self):
+        raise self.Success
+
+    def test_no_spawn_no_stdin_success(self):
+        cmd = g_commands.ExternalCommand(
+            u'true',
+            refocus=False, on_success=self.on_success)
+        with self.assertRaises(self.Success):
+            cmd.apply(mock.Mock())
+
+    def test_no_spawn_stdin_success(self):
+        cmd = g_commands.ExternalCommand(
+            u"awk '{ exit $0 }'",
+            stdin=u'0', refocus=False, on_success=self.on_success)
+        with self.assertRaises(self.Success):
+            cmd.apply(mock.Mock())
+
+    def test_no_spawn_failure(self):
+        ui = mock.Mock()
+        cmd = g_commands.ExternalCommand(
+            u'false',
+            refocus=False, on_success=self.on_success)
+        cmd.apply(ui)
+        ui.notify.assert_called_once_with('', priority='error')

--- a/tests/commands/global_test.py
+++ b/tests/commands/global_test.py
@@ -17,6 +17,7 @@
 """Tests for global commands."""
 
 from __future__ import absolute_import
+import os
 
 from twisted.trial import unittest
 from twisted.internet.defer import inlineCallbacks
@@ -145,5 +146,31 @@ class TestExternalCommand(unittest.TestCase):
         cmd = g_commands.ExternalCommand(
             u'false',
             refocus=False, on_success=self.on_success)
+        cmd.apply(ui)
+        ui.notify.assert_called_once_with('', priority='error')
+
+    @mock.patch('alot.commands.globals.settings.get', mock.Mock(return_value=''))
+    @mock.patch.dict(os.environ, {'DISPLAY': ':0'})
+    def test_spawn_no_stdin_success(self):
+        ui = mock.Mock()
+        cmd = g_commands.ExternalCommand(u'true', refocus=False, spawn=True)
+        cmd.apply(ui)
+        ui.notify.assert_not_called()
+
+    @mock.patch('alot.commands.globals.settings.get', mock.Mock(return_value=''))
+    @mock.patch.dict(os.environ, {'DISPLAY': ':0'})
+    def test_spawn_stdin_success(self):
+        ui = mock.Mock()
+        cmd = g_commands.ExternalCommand(
+            u"awk '{ exit $0 }'",
+            stdin=u'0', refocus=False, spawn=True)
+        cmd.apply(ui)
+        ui.notify.assert_not_called()
+
+    @mock.patch('alot.commands.globals.settings.get', mock.Mock(return_value=''))
+    @mock.patch.dict(os.environ, {'DISPLAY': ':0'})
+    def test_spawn_failure(self):
+        ui = mock.Mock()
+        cmd = g_commands.ExternalCommand(u'false', refocus=False, spawn=True)
         cmd.apply(ui)
         ui.notify.assert_called_once_with('', priority='error')


### PR DESCRIPTION
Here's some tests for the ExternalCommand class. These don't hit everything, but they hit a lot of the class. These were on a branch that I had trying to using call_cmd and call_cmd_async for handling the calling that I never got working, but the tests themselves should be useful now that I've updated them to apply to master.

There's also a cleanup for a comment in here, and a patch to simplify some if branching, but it's not that complicated and the tests cover that change.