### PR TITLE
commands/globals: Only set stdin to a pipe if there is data

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -268,7 +268,7 @@ class ExternalCommand(Command):
         def thread_code(*_):
             try:
                 proc = subprocess.Popen(self.cmdlist, shell=self.shell,
-                                        stdin=subprocess.PIPE,
+                                        stdin=subprocess.PIPE if stdin else None,
                                         stderr=subprocess.PIPE)
             except OSError as e:
                 return str(e)

--- a/tests/commands/global_test.py
+++ b/tests/commands/global_test.py
@@ -121,31 +121,22 @@ class TestComposeCommand(unittest.TestCase):
 
 class TestExternalCommand(unittest.TestCase):
 
-    class Success(Exception):
-        pass
-
-    def on_success(self):
-        raise self.Success
-
     def test_no_spawn_no_stdin_success(self):
-        cmd = g_commands.ExternalCommand(
-            u'true',
-            refocus=False, on_success=self.on_success)
-        with self.assertRaises(self.Success):
-            cmd.apply(mock.Mock())
+        ui = mock.Mock()
+        cmd = g_commands.ExternalCommand(u'true', refocus=False)
+        cmd.apply(ui)
+        ui.notify.assert_not_called()
 
     def test_no_spawn_stdin_success(self):
-        cmd = g_commands.ExternalCommand(
-            u"awk '{ exit $0 }'",
-            stdin=u'0', refocus=False, on_success=self.on_success)
-        with self.assertRaises(self.Success):
-            cmd.apply(mock.Mock())
+        ui = mock.Mock()
+        cmd = g_commands.ExternalCommand(u"awk '{ exit $0 }'", stdin=u'0',
+                                         refocus=False)
+        cmd.apply(ui)
+        ui.notify.assert_not_called()
 
     def test_no_spawn_failure(self):
         ui = mock.Mock()
-        cmd = g_commands.ExternalCommand(
-            u'false',
-            refocus=False, on_success=self.on_success)
+        cmd = g_commands.ExternalCommand(u'false', refocus=False)
         cmd.apply(ui)
         ui.notify.assert_called_once_with('', priority='error')
 

--- a/tests/commands/global_test.py
+++ b/tests/commands/global_test.py
@@ -25,8 +25,6 @@ import mock
 
 from alot.commands import globals as g_commands
 
-from .. import utilities
-
 
 class Stop(Exception):
     """exception for stopping testing of giant unmanagable functions."""
@@ -136,7 +134,6 @@ class TestExternalCommand(unittest.TestCase):
         cmd.apply(ui)
         ui.notify.assert_not_called()
 
-    @utilities.expected_failure
     def test_no_spawn_no_stdin_attached(self):
         ui = mock.Mock()
         cmd = g_commands.ExternalCommand(u'test -t 0', refocus=False)

--- a/tests/commands/global_test.py
+++ b/tests/commands/global_test.py
@@ -25,6 +25,8 @@ import mock
 
 from alot.commands import globals as g_commands
 
+from .. import utilities
+
 
 class Stop(Exception):
     """exception for stopping testing of giant unmanagable functions."""
@@ -133,6 +135,19 @@ class TestExternalCommand(unittest.TestCase):
                                          refocus=False)
         cmd.apply(ui)
         ui.notify.assert_not_called()
+
+    @utilities.expected_failure
+    def test_no_spawn_no_stdin_attached(self):
+        ui = mock.Mock()
+        cmd = g_commands.ExternalCommand(u'test -t 0', refocus=False)
+        cmd.apply(ui)
+        ui.notify.assert_not_called()
+
+    def test_no_spawn_stdin_attached(self):
+        ui = mock.Mock()
+        cmd = g_commands.ExternalCommand(u"test -t 0", stdin=u'0', refocus=False)
+        cmd.apply(ui)
+        ui.notify.assert_called_once_with('', priority='error')
 
     def test_no_spawn_failure(self):
         ui = mock.Mock()


### PR DESCRIPTION
Otherwise the editor will crash.

I can't figure out for the life of me to test this. I thought that I
would be able to do something like detect if stdin is a tty or something
else, but that doesn't seem to work.

Fixes #1137