### PR TITLE
fix example hook

### DIFF
--- a/docs/source/configuration/hooks.rst
+++ b/docs/source/configuration/hooks.rst
@@ -28,7 +28,7 @@ Consider this pre-hook for the exit command, that logs a personalized goodbye
 message::
 
     import logging
-    from alot.settings import settings
+    from alot.settings.const import settings
     def pre_global_exit(**kwargs):
         accounts = settings.get_accounts()
         if accounts:


### PR DESCRIPTION
This fixes the example "goodbye"-hook in order to make it work again
with v0.6 and newer branches: the initializes SettingsManager
object is now accessible as 'alot.settings.const.settings'.