### PR TITLE
db/message: Use self._id instead of self.get_message_id()

### DIFF
--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -66,17 +66,17 @@ class Message(object):
 
     def __eq__(self, other):
         if isinstance(other, type(self)):
-            return self.get_message_id() == other.get_message_id()
+            return self._id == other.get_message_id()
         return NotImplemented
 
     def __ne__(self, other):
         if isinstance(other, type(self)):
-            return self.get_message_id() != other.get_message_id()
+            return self._id != other.get_message_id()
         return NotImplemented
 
     def __lt__(self, other):
         if isinstance(other, type(self)):
-            return self.get_message_id() < other.get_message_id()
+            return self._id < other.get_message_id()
         return NotImplemented
 
     def get_email(self):


### PR DESCRIPTION
The latter function returns self._id anyway, and this avoids a function
call when sorting.

I noticed this when I was looking at something else. It's a pretty minor cleanup, but it might be noticable in large threads.