### PR TITLE
Submit/fix no from header

### DIFF
--- a/alot/account.py
+++ b/alot/account.py
@@ -122,9 +122,15 @@ class Address(object):
             The intention is to use functions from the operator module.
         """
         if isinstance(other, unicode):
-            ouser, odomain = other.split(u'@')
+            try:
+                ouser, odomain = other.split(u'@')
+            except ValueError:
+                ouser, odomain = u'', u''
         elif isinstance(other, str):
-            ouser, odomain = other.decode('utf-8').split(u'@')
+            try:
+                ouser, odomain = other.decode('utf-8').split(u'@')
+            except ValueError:
+                ouser, odomain = '', ''
         else:
             ouser = other.username
             odomain = other.domainname

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -45,13 +45,21 @@ class Message(object):
         except ValueError:
             self._datetime = None
         self._filename = msg.get_filename()
-        try:
-            self._from = decode_header(msg.get_header('From'))
-        except NullPointerError:
-            self._from = ''
         self._email = None  # will be read upon first use
         self._attachments = None  # will be read upon first use
         self._tags = set(msg.get_tags())
+
+        try:
+            sender = decode_header(msg.get_header('From'))
+        except NullPointerError:
+            sender = None
+        if sender:
+            self._from = sender
+        elif 'draft' in self._tags:
+            acc = settings.get_accounts()[0]
+            self._from = '"{}" <{}>'.format(acc.realname, unicode(acc.address))
+        else:
+            self._from = '"Unknown" <>'
 
     def __str__(self):
         """prettyprint the message"""

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -51,6 +51,8 @@ class Message(object):
 
         try:
             sender = decode_header(msg.get_header('From'))
+            if not sender:
+                sender = decode_header(msg.get_header('Sender'))
         except NullPointerError:
             sender = None
         if sender:

--- a/tests/account_test.py
+++ b/tests/account_test.py
@@ -164,7 +164,6 @@ class TestAddress(unittest.TestCase):
         addr = account.Address(u'user', u'éxample.com', case_sensitive=True)
         self.assertEqual(addr, u'user@Éxample.com')
 
-    @unittest.expectedFailure
     def test_cmp_empty(self):
         addr = account.Address(u'user', u'éxample.com')
         self.assertNotEqual(addr, u'')

--- a/tests/account_test.py
+++ b/tests/account_test.py
@@ -163,3 +163,8 @@ class TestAddress(unittest.TestCase):
     def test_domain_name_eq_unicode_sensitive(self):
         addr = account.Address(u'user', u'éxample.com', case_sensitive=True)
         self.assertEqual(addr, u'user@Éxample.com')
+
+    @unittest.expectedFailure
+    def test_cmp_empty(self):
+        addr = account.Address(u'user', u'éxample.com')
+        self.assertNotEqual(addr, u'')

--- a/tests/db/message_test.py
+++ b/tests/db/message_test.py
@@ -78,7 +78,6 @@ class TestMessage(unittest.TestCase):
             MockNotmuchMessage({'From': '"User Name" <user@example.com>'}))
         self.assertEqual(msg.get_author(), ('User Name', 'user@example.com'))
 
-    @unittest.expectedFailure
     def test_get_author_sender(self):
         """Message._from is populated using the 'Sender' header when no 'From'
         header is present.

--- a/tests/db/message_test.py
+++ b/tests/db/message_test.py
@@ -88,7 +88,6 @@ class TestMessage(unittest.TestCase):
             MockNotmuchMessage({'Sender': '"User Name" <user@example.com>'}))
         self.assertEqual(msg.get_author(), ('User Name', 'user@example.com'))
 
-    @unittest.expectedFailure
     def test_get_author_no_name_draft(self):
         """Message._from is populated from the default account if the draft tag
         is present.
@@ -102,7 +101,6 @@ class TestMessage(unittest.TestCase):
                 mock.Mock(), MockNotmuchMessage(tags=['draft']))
         self.assertEqual(msg.get_author(), ('User Name', 'user@example.com'))
 
-    @unittest.expectedFailure
     def test_get_author_no_name(self):
         """Message._from is set to 'Unkown' if there is no relavent header and
         the message is not a draft.

--- a/tests/db/message_test.py
+++ b/tests/db/message_test.py
@@ -1,0 +1,116 @@
+# encoding=utf-8
+# Copyright © 2017 Dylan Baker
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+import unittest
+
+import mock
+
+from notmuch import NullPointerError
+
+from alot import account
+from alot.db import message
+
+
+class MockNotmuchMessage(object):
+    """An object that looks very much like a notmuch message.
+
+    All public instance variables that are not part of the notmuch Message
+    class are prefaced with mock.
+    """
+
+    def __init__(self, headers=None, tags=None):
+        self.mock_headers = headers or {}
+        self.mock_message_id = 'message id'
+        self.mock_thread_id = 'thread id'
+        self.mock_date = 0
+        self.mock_filename = 'filename'
+        self.mock_tags = tags or []
+
+    def get_header(self, field):
+        return self.mock_headers.get(field, '')
+
+    def get_message_id(self):
+        return self.mock_message_id
+
+    def get_thread_id(self):
+        return self.mock_thread_id
+
+    def get_date(self):
+        return self.mock_date
+
+    def get_filename(self):
+        return self.mock_filename
+
+    def get_tags(self):
+        return self.mock_tags
+
+
+class TestMessage(unittest.TestCase):
+
+    def test_get_author_email_only(self):
+        """Message._from is populated using the 'From' header when only an
+        email address is provided.
+        """
+        msg = message.Message(mock.Mock(),
+                              MockNotmuchMessage({'From': 'user@example.com'}))
+        self.assertEqual(msg.get_author(), ('', 'user@example.com'))
+
+    def test_get_author_name_and_email(self):
+        """Message._from is populated using the 'From' header when an email and
+        name are provided.
+        """
+        msg = message.Message(
+            mock.Mock(),
+            MockNotmuchMessage({'From': '"User Name" <user@example.com>'}))
+        self.assertEqual(msg.get_author(), ('User Name', 'user@example.com'))
+
+    @unittest.expectedFailure
+    def test_get_author_sender(self):
+        """Message._from is populated using the 'Sender' header when no 'From'
+        header is present.
+        """
+        msg = message.Message(
+            mock.Mock(),
+            MockNotmuchMessage({'Sender': '"User Name" <user@example.com>'}))
+        self.assertEqual(msg.get_author(), ('User Name', 'user@example.com'))
+
+    @unittest.expectedFailure
+    def test_get_author_no_name_draft(self):
+        """Message._from is populated from the default account if the draft tag
+        is present.
+        """
+        acc = mock.Mock()
+        acc.address = account.Address(u'user', u'example.com')
+        acc.realname = u'User Name'
+        with mock.patch('alot.db.message.settings.get_accounts',
+                        mock.Mock(return_value=[acc])):
+            msg = message.Message(
+                mock.Mock(), MockNotmuchMessage(tags=['draft']))
+        self.assertEqual(msg.get_author(), ('User Name', 'user@example.com'))
+
+    @unittest.expectedFailure
+    def test_get_author_no_name(self):
+        """Message._from is set to 'Unkown' if there is no relavent header and
+        the message is not a draft.
+        """
+        acc = mock.Mock()
+        acc.address = account.Address(u'user', u'example.com')
+        acc.realname = u'User Name'
+        with mock.patch('alot.db.message.settings.get_accounts',
+                        mock.Mock(return_value=[acc])):
+            msg = message.Message(mock.Mock(), MockNotmuchMessage())
+        self.assertEqual(msg.get_author(), ('Unknown', ''))


### PR DESCRIPTION
I noticed today that I have a draft email which lacks a 'from' header. This is obviously pretty rare, since it's unlikely that you would receive an email without a 'from' header. For drafts we set the 'Sender' header, which can be used to the same effect.

This covers using the 'Sender' as a fallback for 'From', and failing that uses the default account as the from.