### PR TITLE
github: add notmuch version to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -11,6 +11,8 @@ Software Versions
 
 Python version:
 
+Notmuch version:
+
 Alot version (either a number or sha for master):
 
 Observed behavior


### PR DESCRIPTION
A recent bug made me think that maybe the notmuch was out of date. It would be good to include that information in a bug report.