### PR TITLE
crypto: Handle message that is encrypted, but the signature is invalid

### DIFF
--- a/alot/crypto.py
+++ b/alot/crypto.py
@@ -202,12 +202,15 @@ def decrypt_verify(encrypted):
     """
     ctx = gpg.core.Context()
     try:
-        (plaintext, _, verify_result) = ctx.decrypt(encrypted, verify=True)
+        plaintext, _, verify_result = ctx.decrypt(encrypted, verify=True)
+        sigs = verify_result.signatures
     except gpg.errors.GPGMEError as e:
         raise GPGProblem(str(e), code=e.getcode())
-    # what if the signature is bad?
+    except gpg.errors.BadSignatures as e:
+        plaintext, _, _ = ctx.decrypt(encrypted, verify=False)
+        sigs = e.result.signatures
 
-    return verify_result.signatures, plaintext
+    return sigs, plaintext
 
 
 def validate_key(key, sign=False, encrypt=False):


### PR DESCRIPTION
One case of this would be not having the public key of the signer. If
the verification of the signatures fails, then use the signatures from
the error, and try to redecrypt without verification.

I have no tests yet, and this probably deserves tests.

Fixes #1157