### PR TITLE
Call _get_body() only once.

### DIFF
--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -207,7 +207,7 @@ class MessageTree(CollapsibleTree):
 
             bodytree = self._get_body()
             if bodytree is not None:
-                mainstruct.append((self._get_body(), None))
+                mainstruct.append((bodytree, None))
 
         structure = [
             (self._get_summary(), mainstruct)


### PR DESCRIPTION
Unless I missed something, the second call to _get_body() is not needed.