### PR TITLE
relay "exclude_tags" in queries

### DIFF
--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -403,7 +403,11 @@ class DBManager(object):
         """
         mode = Database.MODE.READ_ONLY
         db = Database(path=self.path, mode=mode)
-        return db.create_query(querystring)
+        q = db.create_query(querystring)
+        # add configured exclude tags
+        for tag in settings.get('exclude_tags'):
+            q.exclude_tag(tag)
+        return q
 
     def add_message(self, path, tags=None, afterwards=None):
         """

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -13,6 +13,10 @@ attachment_prefix = string(default='~')
 # timeout in (floating point) seconds until partial input is cleared
 input_timeout = float(default=1.0)
 
+# A list of tags that will be excluded from search results by default. Using an excluded tag in a query will override that exclusion.
+# .. note:: this config setting is equivalent to, but independent of, the 'search.exclude_tags' in the notmuch config.
+exclude_tags = force_list(default=list())
+
 # confirm exit
 bug_on_exit = boolean(default=False)
 

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -234,6 +234,17 @@
     :default: [{buffer_no}: envelope], {input_queue} total messages: {total_messages}
 
 
+.. _exclude-tags:
+
+.. describe:: exclude_tags
+
+     A list of tags that will be excluded from search results by default. Using an excluded tag in a query will override that exclusion.
+     .. note:: this config setting is equivalent to, but independent of, the 'search.exclude_tags' in the notmuch config.
+
+    :type: string list
+    :default: ,
+
+
 .. _flush-retry-timeout:
 
 .. describe:: flush_retry_timeout


### PR DESCRIPTION
This allows to define special tags that render messages invisible.
The functionality is copied from notmuch (see man notmuch-config)
and was requested before for alot (#732).