### PR TITLE
Bug fixes regarding XDG_* variable expansion + adds general env expansion

### DIFF
--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -11,7 +11,7 @@ import sys
 import alot
 from alot.settings.const import settings
 from alot.settings.errors import ConfigError
-from alot.helper import get_env
+from alot.helper import get_xdg_env
 from alot.db.manager import DBManager
 from alot.ui import UI
 from alot.commands import *
@@ -93,7 +93,8 @@ def main():
 
     # locate alot config files
     if options.config is None:
-        xdg_dir = get_env('XDG_CONFIG_HOME', os.path.expanduser('~/.config'))
+        xdg_dir = get_xdg_env('XDG_CONFIG_HOME',
+                              os.path.expanduser('~/.config'))
         alotconfig = os.path.join(xdg_dir, 'alot', 'config')
         if os.path.exists(alotconfig):
             settings.alot_rc_path = alotconfig

--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -11,6 +11,7 @@ import sys
 import alot
 from alot.settings.const import settings
 from alot.settings.errors import ConfigError
+from alot.helper import get_env
 from alot.db.manager import DBManager
 from alot.ui import UI
 from alot.commands import *
@@ -92,9 +93,8 @@ def main():
 
     # locate alot config files
     if options.config is None:
-        alotconfig = os.path.join(
-            os.environ.get('XDG_CONFIG_HOME', os.path.expanduser('~/.config')),
-            'alot', 'config')
+        xdg_dir = get_env('XDG_CONFIG_HOME', os.path.expanduser('~/.config'))
+        alotconfig = os.path.join(xdg_dir, 'alot', 'config')
         if os.path.exists(alotconfig):
             settings.alot_rc_path = alotconfig
     else:

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -756,8 +756,9 @@ class ComposeCommand(Command):
         if self.template is not None:
             # get location of tempsdir, containing msg templates
             tempdir = settings.get('template_dir')
-            tempdir = os.path.expanduser(tempdir)
-            if not tempdir:
+            if tempdir:
+                tempdir = os.path.expanduser(tempdir)
+            else:
                 xdgdir = os.environ.get('XDG_CONFIG_HOME',
                                         os.path.expanduser('~/.config'))
                 tempdir = os.path.join(xdgdir, 'alot', 'templates')

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -756,12 +756,6 @@ class ComposeCommand(Command):
         if self.template is not None:
             # get location of tempsdir, containing msg templates
             tempdir = settings.get('template_dir')
-            if tempdir:
-                tempdir = os.path.expanduser(tempdir)
-            else:
-                xdgdir = os.environ.get('XDG_CONFIG_HOME',
-                                        os.path.expanduser('~/.config'))
-                tempdir = os.path.join(xdgdir, 'alot', 'templates')
 
             path = os.path.expanduser(self.template)
             if not os.path.dirname(path):  # use tempsdir

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -31,12 +31,10 @@ tabwidth = integer(default=8)
 
 # templates directory that contains your message templates.
 # It will be used if you give `compose --template` a filename without a path prefix.
-# The default path is `$XDG_CONFIG_HOME/alot/temmplates`.
-template_dir = string(default=None)
+template_dir = string(default='$XDG_CONFIG_HOME/alot/templates')
 
 # directory containing theme files.
-# The default path is `$XDG_CONFIG_HOME/alot/themes`.
-themes_dir = string(default=None)
+themes_dir = string(default='$XDG_CONFIG_HOME/alot/themes')
 
 # name of the theme to use
 theme = string(default=None)

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -31,9 +31,11 @@ tabwidth = integer(default=8)
 
 # templates directory that contains your message templates.
 # It will be used if you give `compose --template` a filename without a path prefix.
+# The default path is `$XDG_CONFIG_HOME/alot/temmplates`.
 template_dir = string(default=None)
 
-# directory containing theme files
+# directory containing theme files.
+# The default path is `$XDG_CONFIG_HOME/alot/themes`.
 themes_dir = string(default=None)
 
 # name of the theme to use

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -31,7 +31,7 @@ tabwidth = integer(default=8)
 
 # templates directory that contains your message templates.
 # It will be used if you give `compose --template` a filename without a path prefix.
-template_dir = string(default='$XDG_CONFIG_HOME/alot/templates')
+template_dir = string(default=None)
 
 # directory containing theme files
 themes_dir = string(default=None)

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -625,3 +625,9 @@ def email_as_string(mail):
                            as_string, flags=re.MULTILINE)
 
     return as_string
+
+
+def get_env(env_name, fallback):
+    """ Gets environment variable and returns fallback if unset or empty """
+    env = os.environ.get(env_name)
+    return env if env else fallback

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -627,7 +627,7 @@ def email_as_string(mail):
     return as_string
 
 
-def get_env(env_name, fallback):
-    """ Gets environment variable and returns fallback if unset or empty """
+def get_xdg_env(env_name, fallback):
+    """ Used for XDG_* env variables to return fallback if unset *or* empty """
     env = os.environ.get(env_name)
     return env if env else fallback

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -98,12 +98,12 @@ class SettingsManager(object):
                 self._bindings.merge(newbindings)
 
         tempdir = self._process_xdg_default('template_dir', 'alot/templates')
-        logging.debug(tempdir)
+        logging.debug('template directory: `{}`'.format(tempdir))
 
         # themes
         themestring = newconfig['theme']
         themes_dir = self._process_xdg_default('themes_dir', 'alot/themes')
-        logging.debug(themes_dir)
+        logging.debug('themes directory: `{}`'.format(themes_dir))
 
         # if config contains theme string use that
         data_dirs = [os.path.join(d, 'alot/themes') for d in DATA_DIRS]

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -96,6 +96,15 @@ class SettingsManager(object):
             newbindings = newconfig['bindings']
             if isinstance(newbindings, Section):
                 self._bindings.merge(newbindings)
+
+        tempdir = self._config.get('template_dir')
+        if tempdir:
+            tempdir = os.path.expanduser(tempdir)
+        else:
+            xdgdir = os.environ.get('XDG_CONFIG_HOME',
+                                    os.path.expanduser('~/.config'))
+            tempdir = os.path.join(xdgdir, 'alot', 'templates')
+
         # themes
         themestring = newconfig['theme']
         themes_dir = self._config.get('themes_dir')

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -15,7 +15,7 @@ from configobj import ConfigObj, Section
 from ..account import SendmailAccount
 from ..addressbook.abook import AbookAddressBook
 from ..addressbook.external import ExternalAddressbook
-from ..helper import pretty_datetime, string_decode
+from ..helper import pretty_datetime, string_decode, get_env
 from ..utils import configobj as checks
 
 from .errors import ConfigError, NoMatchingAccount
@@ -25,8 +25,8 @@ from .theme import Theme
 
 
 DEFAULTSPATH = os.path.join(os.path.dirname(__file__), '..', 'defaults')
-DATA_DIRS = os.environ.get('XDG_DATA_DIRS',
-                           '/usr/local/share:/usr/share').split(':')
+DATA_DIRS = get_env('XDG_DATA_DIRS',
+                    '/usr/local/share:/usr/share').split(':')
 
 
 class SettingsManager(object):
@@ -157,8 +157,8 @@ class SettingsManager(object):
         if path:
             path = os.path.expanduser(path)
         else:
-            xdgdir = os.environ.get('XDG_CONFIG_HOME',
-                                    os.path.expanduser('~/.config'))
+            xdgdir = get_env('XDG_CONFIG_HOME',
+                             os.path.expanduser('~/.config'))
             path = os.path.join(xdgdir, fallback)
 
         self._config[setting_name] = path

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -15,7 +15,7 @@ from configobj import ConfigObj, Section
 from ..account import SendmailAccount
 from ..addressbook.abook import AbookAddressBook
 from ..addressbook.external import ExternalAddressbook
-from ..helper import pretty_datetime, string_decode, get_env
+from ..helper import pretty_datetime, string_decode, get_xdg_env
 from ..utils import configobj as checks
 
 from .errors import ConfigError, NoMatchingAccount
@@ -25,8 +25,8 @@ from .theme import Theme
 
 
 DEFAULTSPATH = os.path.join(os.path.dirname(__file__), '..', 'defaults')
-DATA_DIRS = get_env('XDG_DATA_DIRS',
-                    '/usr/local/share:/usr/share').split(':')
+DATA_DIRS = get_xdg_env('XDG_DATA_DIRS',
+                        '/usr/local/share:/usr/share').split(':')
 
 
 class SettingsManager(object):

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -138,7 +138,6 @@ class SettingsManager(object):
         self._accounts = self._parse_accounts(self._config)
         self._accountmap = self._account_table(self._accounts)
 
-
     @staticmethod
     def _expand_config_values(section, key):
         """
@@ -149,15 +148,11 @@ class SettingsManager(object):
 
         :param section: as passed by ConfigObj.walk
         :param key: as passed by ConfigObj.walk
-        :param expansion_fct: function to expand a configuration string
-        :type expansion_fct: function
         """
 
         def expand_environment_and_home(value):
             """
             Expands environment variables and the home directory (~).
-
-            Only acts on string input values.
 
             $FOO and ${FOO}-style environment variables are expanded, if they
             exist. If they do not exist, they are left unchanged.

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -97,12 +97,12 @@ class SettingsManager(object):
             if isinstance(newbindings, Section):
                 self._bindings.merge(newbindings)
 
-        tempdir = self._process_xdg_default('template_dir', 'alot/templates')
+        tempdir = self._process_xdg_default('template_dir')
         logging.debug('template directory: `{}`'.format(tempdir))
 
         # themes
         themestring = newconfig['theme']
-        themes_dir = self._process_xdg_default('themes_dir', 'alot/themes')
+        themes_dir = self._process_xdg_default('themes_dir')
         logging.debug('themes directory: `{}`'.format(themes_dir))
 
         # if config contains theme string use that
@@ -137,7 +137,7 @@ class SettingsManager(object):
         self._accounts = self._parse_accounts(self._config)
         self._accountmap = self._account_table(self._accounts)
 
-    def _process_xdg_default(self, setting_name, fallback):
+    def _process_xdg_default(self, setting_name):
         """
         Processes setting that uses $XDG_CONFIG_HOME in the default value.
 
@@ -147,20 +147,18 @@ class SettingsManager(object):
 
         :param setting_name: name of setting to be processed
         :type setting_name: str
-        :param fallback: fallback path relative to ~/.config if the setting
-        is not set by the user.
-        :type fallback: str
         :returns: path
         :rvalue: str
         """
         path = self._config.get(setting_name)
-        if path:
-            path = os.path.expanduser(path)
-        else:
-            xdgdir = get_env('XDG_CONFIG_HOME',
-                             os.path.expanduser('~/.config'))
-            path = os.path.join(xdgdir, fallback)
+        if path.startswith('$XDG_CONFIG_HOME'):
+            if os.environ.get('XDG_CONFIG_HOME', False):
+                xdg_expanded = os.environ['XDG_CONFIG_HOME']
+            else:
+                xdg_expanded = '~/.config'
+            path = path.replace('$XDG_CONFIG_HOME', xdg_expanded)
 
+        path = os.path.expanduser(path)
         self._config[setting_name] = path
         return path
 

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -18,7 +18,7 @@ from .commands import CommandCanceled
 from .commands import CommandParseError
 from .helper import split_commandline
 from .helper import string_decode
-from .helper import get_env
+from .helper import get_xdg_env
 from .widgets.globals import CompleteEdit
 from .widgets.globals import ChoiceWidget
 
@@ -84,7 +84,7 @@ class UI(object):
 
         # load histories
         self._cache = os.path.join(
-            get_env('XDG_CACHE_HOME', os.path.expanduser('~/.cache')),
+            get_xdg_env('XDG_CACHE_HOME', os.path.expanduser('~/.cache')),
             'alot', 'history')
         self._cmd_hist_file = os.path.join(self._cache, 'commands')
         self._sender_hist_file = os.path.join(self._cache, 'senders')

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -18,6 +18,7 @@ from .commands import CommandCanceled
 from .commands import CommandParseError
 from .helper import split_commandline
 from .helper import string_decode
+from .helper import get_env
 from .widgets.globals import CompleteEdit
 from .widgets.globals import ChoiceWidget
 
@@ -83,7 +84,7 @@ class UI(object):
 
         # load histories
         self._cache = os.path.join(
-            os.environ.get('XDG_CACHE_HOME', os.path.expanduser('~/.cache')),
+            get_env('XDG_CACHE_HOME', os.path.expanduser('~/.cache')),
             'alot', 'history')
         self._cmd_hist_file = os.path.join(self._cache, 'commands')
         self._sender_hist_file = os.path.join(self._cache, 'senders')

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -576,6 +576,7 @@
 
      templates directory that contains your message templates.
      It will be used if you give `compose --template` a filename without a path prefix.
+     The default path is `$XDG_CONFIG_HOME/alot/temmplates`.
 
     :type: string
     :default: None
@@ -605,7 +606,8 @@
 
 .. describe:: themes_dir
 
-     directory containing theme files
+     directory containing theme files.
+     The default path is `$XDG_CONFIG_HOME/alot/themes`.
 
     :type: string
     :default: None

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -578,7 +578,7 @@
      It will be used if you give `compose --template` a filename without a path prefix.
 
     :type: string
-    :default: "$XDG_CONFIG_HOME/alot/templates"
+    :default: None
 
 
 .. _terminal-cmd:

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -576,10 +576,9 @@
 
      templates directory that contains your message templates.
      It will be used if you give `compose --template` a filename without a path prefix.
-     The default path is `$XDG_CONFIG_HOME/alot/temmplates`.
 
     :type: string
-    :default: None
+    :default: "$XDG_CONFIG_HOME/alot/templates"
 
 
 .. _terminal-cmd:
@@ -607,10 +606,9 @@
 .. describe:: themes_dir
 
      directory containing theme files.
-     The default path is `$XDG_CONFIG_HOME/alot/themes`.
 
     :type: string
-    :default: None
+    :default: "$XDG_CONFIG_HOME/alot/themes"
 
 
 .. _thread-authors-me:

--- a/docs/source/configuration/theming.rst
+++ b/docs/source/configuration/theming.rst
@@ -11,7 +11,8 @@ To make it easier to switch between or share different such themes, they are def
 files (see below for the exact format).
 To specify the theme to use, set the :ref:`theme <theme>` config option to the name of a theme-file.
 A file by that name will be looked up in the path given by the :ref:`themes_dir <themes-dir>` config setting
-which defaults to :file:`~/.config/alot/themes/`. If the themes_dir is not
+which defaults to $XDG_CONFIG_HOME/alot/themes, and :file:`~/.config/alot/themes/`,
+if XDG_CONFIG_HOME is empty or not set. If the themes_dir is not
 present then the contents of $XDG_DATA_DIRS/alot/themes will be tried in order.
 This defaults to :file:`/usr/local/share/alot/themes` and :file:`/usr/share/alot/themes`, in that order.
 These locations are meant to be used by distro packages to put themes in.

--- a/tests/helper_test.py
+++ b/tests/helper_test.py
@@ -478,15 +478,13 @@ class TestGetEnv(unittest.TestCase):
                              self.default)
 
     def test_env_empty(self):
-        with mock.patch.dict('os.environ'):
-            os.environ[self.env_name] = ''
+        with mock.patch.dict('os.environ', {self.env_name: ''}):
             self.assertEqual(helper.get_xdg_env(self.env_name, self.default),
                              self.default)
 
     def test_env_not_empty(self):
         custom_path = '/my/personal/config/home'
 
-        with mock.patch.dict('os.environ'):
-            os.environ[self.env_name] = custom_path
+        with mock.patch.dict('os.environ', {self.env_name: custom_path}):
             self.assertEqual(helper.get_xdg_env(self.env_name, self.default),
                              custom_path)

--- a/tests/helper_test.py
+++ b/tests/helper_test.py
@@ -474,13 +474,13 @@ class TestGetEnv(unittest.TestCase):
         with mock.patch.dict('os.environ'):
             if self.env_name in os.environ:
                 del os.environ[self.env_name]
-            self.assertEqual(helper.get_env(self.env_name, self.default),
+            self.assertEqual(helper.get_xdg_env(self.env_name, self.default),
                              self.default)
 
     def test_env_empty(self):
         with mock.patch.dict('os.environ'):
             os.environ[self.env_name] = ''
-            self.assertEqual(helper.get_env(self.env_name, self.default),
+            self.assertEqual(helper.get_xdg_env(self.env_name, self.default),
                              self.default)
 
     def test_env_not_empty(self):
@@ -488,5 +488,5 @@ class TestGetEnv(unittest.TestCase):
 
         with mock.patch.dict('os.environ'):
             os.environ[self.env_name] = custom_path
-            self.assertEqual(helper.get_env(self.env_name, self.default),
+            self.assertEqual(helper.get_xdg_env(self.env_name, self.default),
                              custom_path)

--- a/tests/helper_test.py
+++ b/tests/helper_test.py
@@ -464,3 +464,29 @@ class TestCallCmdAsync(unittest.TestCase):
             yield helper.call_cmd_async(['_____better_not_exist'])
         self.assertEqual(cm.exception.exitCode, 1)
         self.assertTrue(cm.exception.stderr)
+
+
+class TestGetEnv(unittest.TestCase):
+    env_name = 'XDG_CONFIG_HOME'
+    default = '~/.config'
+
+    def test_env_not_set(self):
+        with mock.patch.dict('os.environ'):
+            if self.env_name in os.environ:
+                del os.environ[self.env_name]
+            self.assertEqual(helper.get_env(self.env_name, self.default),
+                             self.default)
+
+    def test_env_empty(self):
+        with mock.patch.dict('os.environ'):
+            os.environ[self.env_name] = ''
+            self.assertEqual(helper.get_env(self.env_name, self.default),
+                             self.default)
+
+    def test_env_not_empty(self):
+        custom_path = '/my/personal/config/home'
+
+        with mock.patch.dict('os.environ'):
+            os.environ[self.env_name] = custom_path
+            self.assertEqual(helper.get_env(self.env_name, self.default),
+                             custom_path)

--- a/tests/settings/manager_test.py
+++ b/tests/settings/manager_test.py
@@ -139,8 +139,7 @@ class TestSettingsManager(unittest.TestCase):
 class TestSettingsManagerProcessXDG(unittest.TestCase):
     """ Tests SettingsManager._process_xdg_default """
     setting_name = 'template_dir'
-    def_relative = 'alot/templates'
-    default = os.path.join('$XDG_CONFIG_HOME', def_relative)
+    default = '$XDG_CONFIG_HOME/alot/templates'
     xdg_fallback = '~/.config'
     xdg_config_home = '/foo/bar/.config'
     default_expanded = default.replace('$XDG_CONFIG_HOME', xdg_fallback)
@@ -150,7 +149,7 @@ class TestSettingsManagerProcessXDG(unittest.TestCase):
             if 'XDG_CONFIG_HOME' in os.environ:
                 del os.environ['XDG_CONFIG_HOME']
             manager = SettingsManager()
-            manager._process_xdg_default(self.setting_name, self.def_relative)
+            manager._process_xdg_default(self.setting_name)
             self.assertEqual(manager._config.get(self.setting_name),
                              os.path.expanduser(self.default_expanded))
 
@@ -158,7 +157,7 @@ class TestSettingsManagerProcessXDG(unittest.TestCase):
         with mock.patch.dict('os.environ'):
             os.environ['XDG_CONFIG_HOME'] = ''
             manager = SettingsManager()
-            manager._process_xdg_default(self.setting_name, self.def_relative)
+            manager._process_xdg_default(self.setting_name)
             self.assertEqual(manager._config.get(self.setting_name),
                              os.path.expanduser(self.default_expanded))
 
@@ -166,7 +165,7 @@ class TestSettingsManagerProcessXDG(unittest.TestCase):
         with mock.patch.dict('os.environ'):
             os.environ['XDG_CONFIG_HOME'] = self.xdg_config_home
             manager = SettingsManager()
-            manager._process_xdg_default(self.setting_name, self.def_relative)
+            manager._process_xdg_default(self.setting_name)
             actual = manager._config.get(self.setting_name)
             expected = self.default.replace('$XDG_CONFIG_HOME',
                                             self.xdg_config_home)
@@ -182,7 +181,7 @@ class TestSettingsManagerProcessXDG(unittest.TestCase):
             self.addCleanup(os.unlink, f.name)
 
             manager = SettingsManager(alot_rc=f.name)
-            manager._process_xdg_default(self.setting_name, self.def_relative)
+            manager._process_xdg_default(self.setting_name)
             self.assertEqual(manager._config.get(self.setting_name),
                              os.path.expanduser(user_setting))
 


### PR DESCRIPTION
~~Matches the [code](https://github.com/pazz/alot/blob/054d2a932e7cb8d18dae258750ed26fb86e650b9/alot/settings/manager.py#L104).~~

- [x] Fixes `:compose --template=foo` if default template_dir is used
- [x] Fixes `XDG_CONFIG_HOME='' alot` (does not find configuration files etc.)
- Expands environment variables:
 - [x] expand any environment variable
 - [x] write tests and check how it interacts with ConfigObj's string interpolation