### PR TITLE
Tag completion: escape RE characters in search pattern.

### DIFF
--- a/alot/addressbook/__init__.py
+++ b/alot/addressbook/__init__.py
@@ -34,7 +34,7 @@ class AddressBook(object):
     def lookup(self, query=''):
         """looks up all contacts where name or address match query"""
         res = []
-        query = re.compile('.*%s.*' % query, self.reflags)
+        query = re.compile('.*%s.*' % re.escape(query), self.reflags)
         for name, email in self.get_contacts():
             if query.match(name) or query.match(email):
                 res.append((name, email))

--- a/alot/completion.py
+++ b/alot/completion.py
@@ -75,7 +75,7 @@ class StringlistCompleter(Completer):
         re_prefix = '.*' if self.match_anywhere else ''
 
         def match(s, m):
-            r = re_prefix + m + '.*'
+            r = '{}{}.*'.format(re_prefix, re.escape(m))
             return re.match(r, s, flags=self.flags) is not None
 
         return [(a, len(a)) for a in self.resultlist if match(a, pref)]

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -320,7 +320,7 @@ class SettingsManager(object):
         fallback_focus = resolve_att(onebelow_focus, default_focus)
 
         for sec in cfg['tags'].sections:
-            if re.match('^' + sec + '$', tag):
+            if re.match('^{}$'.format(re.escape(sec)), tag):
                 normal = resolve_att(colourpick(cfg['tags'][sec]['normal']),
                                      fallback_normal)
                 focus = resolve_att(colourpick(cfg['tags'][sec]['focus']),

--- a/tests/addressbook/init_test.py
+++ b/tests/addressbook/init_test.py
@@ -65,3 +65,12 @@ class TestAddressBook(unittest.TestCase):
         actual = abook.lookup('Own')
         expected = [contacts[1]]
         self.assertListEqual(actual, expected)
+
+    def test_lookup_can_handle_special_regex_chars(self):
+        contacts = [('name [work]', 'email@example.com'),
+                    ('My Own Name', 'other@example.com'),
+                    ('someone', 'someone@example.com')]
+        abook = _AddressBook(contacts)
+        actual = abook.lookup('[wor')
+        expected = [contacts[0]]
+        self.assertListEqual(actual, expected)

--- a/tests/completion_test.py
+++ b/tests/completion_test.py
@@ -87,3 +87,12 @@ class AbooksCompleterTest(unittest.TestCase):
         expected = [(r""""all 'fanzy' \"stuff\" at, once" <all@example.com>""",
                      50)]
         self._assert_only_one_list_entry(actual, expected)
+
+
+class StringlistCompleterTest(unittest.TestCase):
+    def test_dont_choke_on_special_regex_characters(self):
+        tags = ['[match]', 'nomatch']
+        completer = completion.StringlistCompleter(tags)
+        actual = completer.complete('[', 1)
+        expected = [(tags[0], len(tags[0]))]
+        self.assertListEqual(actual, expected)

--- a/tests/settings/manager_test.py
+++ b/tests/settings/manager_test.py
@@ -94,6 +94,18 @@ class TestSettingsManager(unittest.TestCase):
         setting = manager.get_notmuch_setting('foo', 'bar')
         self.assertIsNone(setting)
 
+    def test_dont_choke_on_regex_special_chars_in_tagstring(self):
+        tag = 'to**do'
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(textwrap.dedent("""\
+                [tags]
+                    [[{tag}]]
+                        normal = '','', 'white','light red', 'white','#d66'
+                """.format(tag=tag)))
+        self.addCleanup(os.unlink, f.name)
+        manager = SettingsManager(alot_rc=f.name)
+        manager.get_tagstring_representation(tag)
+
 
 class TestSettingsManagerGetAccountByAddress(utilities.TestCaseClassCleanup):
     """Test the get_account_by_address helper."""


### PR DESCRIPTION
Fixes the following crash if you have a tag that starts with `[`:
`:search tag:[<tab>`

```
Traceback (most recent call last):
  File "/usr/bin/alot", line 11, in <module>
    load_entry_point('alot==0.7.0.dev0', 'console_scripts', 'alot')()
  File "/usr/lib/python2.7/site-packages/alot/__main__.py", line 130, in main
    UI(dbman, cmdstring)
  File "/usr/lib/python2.7/site-packages/alot/ui.py", line 124, in __init__
    self.mainloop.run()
  File "/usr/lib/python2.7/site-packages/urwid/main_loop.py", line 278, in run
    self._run()
  File "/usr/lib/python2.7/site-packages/urwid/main_loop.py", line 376, in _run
    self.event_loop.run()
  File "/usr/lib/python2.7/site-packages/urwid/main_loop.py", line 1200, in wrapper
    rval = f(*args,**kargs)
  File "/usr/lib/python2.7/site-packages/urwid/raw_display.py", line 393, in <lambda>
    event_loop, callback, self.get_available_raw_input())
  File "/usr/lib/python2.7/site-packages/urwid/raw_display.py", line 493, in parse_input
    callback(processed, processed_codes)
  File "/usr/lib/python2.7/site-packages/urwid/main_loop.py", line 403, in _update
    self.process_input(keys)
  File "/usr/lib/python2.7/site-packages/urwid/main_loop.py", line 503, in process_input
    k = self._topmost_widget.keypress(self.screen_size, k)
  File "/usr/lib/python2.7/site-packages/urwid/container.py", line 592, in keypress
    *self.calculate_padding_filler(size, True)), key)
  File "/usr/lib/python2.7/site-packages/urwid/container.py", line 2269, in keypress
    key = w.keypress((mc,) + size[1:], key)
  File "/usr/lib/python2.7/site-packages/alot/widgets/globals.py", line 144, in keypress
    self.edit_pos)
  File "/usr/lib/python2.7/site-packages/alot/completion.py", line 546, in complete
    for ccmd, ccpos in self._commandcompleter.complete(cmdstring, cpos):
  File "/usr/lib/python2.7/site-packages/alot/completion.py", line 408, in complete
    res = self._querycompleter.complete(params, localpos)
  File "/usr/lib/python2.7/site-packages/alot/completion.py", line 154, in complete
    mypos - cmdlen)
  File "/usr/lib/python2.7/site-packages/alot/completion.py", line 81, in complete
    return [(a, len(a)) for a in self.resultlist if match(a, pref)]
  File "/usr/lib/python2.7/site-packages/alot/completion.py", line 79, in match
    return re.match(r, s, flags=self.flags) is not None
  File "/usr/lib/python2.7/re.py", line 141, in match
    return _compile(pattern, flags).match(string)
  File "/usr/lib/python2.7/re.py", line 251, in _compile
    raise error, v # invalid expression
sre_constants.error: unexpected end of regular expression
```
`[` may be a stupid character as part of a tag, but it can happen (in my case, with gmails default folder names). I think escaping regular expression characters is the right behavior for tag completion, but I'm not sure if this is wanted for all cases where `StringlistCompleter` is used.