### PR TITLE
Give better feedback on invalid user input.

### DIFF
--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -106,6 +106,8 @@ def main():
         settings.read_config()
         settings.read_notmuch_config()
     except (ConfigError, OSError, IOError) as e:
+        print('Error when parsing a config file. '
+              'See log for potential details.')
         sys.exit(e)
 
     # store options given by config swiches to the settingsManager:

--- a/alot/account.py
+++ b/alot/account.py
@@ -359,11 +359,11 @@ class SendmailAccount(Account):
         def errb(failure):
             """The callback used on error."""
             termobj = failure.value
-            errmsg = '%s failed with code %s:\n%s' % \
-                (self.cmd, termobj.exitCode, str(failure.value))
+            errmsg = '%s failed with code %s:\n%s\nProcess stderr:\n%s' % \
+                     (self.cmd, termobj.exitCode, str(failure.value),
+                      failure.value.stderr)
             logging.error(errmsg)
             logging.error(failure.getTraceback())
-            logging.error(failure.value.stderr)
             raise SendingMailFailed(errmsg)
 
         # make sure self.mail is a string

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -35,6 +35,7 @@ from ..widgets.utils import DialogBox
 from ..db.errors import DatabaseLockedError
 from ..db.envelope import Envelope
 from ..settings.const import settings
+from ..settings.errors import NoMatchingAccount
 from ..utils import argparse as cargparse
 
 MODE = 'global'
@@ -816,7 +817,14 @@ class ComposeCommand(Command):
         # find out the right account
         sender = self.envelope.get('From')
         name, addr = email.utils.parseaddr(sender)
-        account = settings.get_account_by_address(addr)
+        try:
+            account = settings.get_account_by_address(addr)
+        except NoMatchingAccount:
+            msg = 'Cannot compose mail - no account found for `%s`' % addr
+            logging.error(msg)
+            ui.notify(msg, priority='error')
+            raise CommandCanceled()
+
         if account is None:
             accounts = settings.get_accounts()
             if not accounts:

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -35,7 +35,7 @@ from ..widgets.utils import DialogBox
 from ..db.errors import DatabaseLockedError
 from ..db.envelope import Envelope
 from ..settings.const import settings
-from ..settings.errors import NoMatchingAccount
+from ..settings.errors import ConfigError, NoMatchingAccount
 from ..utils import argparse as cargparse
 
 MODE = 'global'
@@ -973,4 +973,8 @@ class ReloadCommand(Command):
     """Reload configuration."""
 
     def apply(self, ui):
-        settings.reload()
+        try:
+            settings.reload()
+        except ConfigError as e:
+            ui.notify('Error when reloading config files:\n {}'.format(e),
+                      priority='error')

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -116,22 +116,19 @@ class SettingsManager(object):
             # tl/dr; If the loop loads a theme it breaks. If it doesn't break,
             # then it raises a ConfigError.
             for dir_ in itertools.chain([themes_dir], data_dirs):
-                if not os.path.isdir(dir_):
-                    logging.warning(
-                        'cannot find theme %s: themes_dir %s is missing',
-                        themestring, dir_)
+                theme_path = os.path.join(dir_, themestring)
+                if not os.path.exists(os.path.expanduser(theme_path)):
+                    logging.warning('Theme `%s` does not exist.', theme_path)
                 else:
-                    theme_path = os.path.join(dir_, themestring)
                     try:
                         self._theme = Theme(theme_path)
                     except ConfigError as e:
-                        logging.warning(
-                            'Theme file %s failed validation: %s',
-                            themestring, e)
+                        raise ConfigError('Theme file `%s` failed '
+                                          'validation:\n%s' % (theme_path, e))
                     else:
                         break
             else:
-                raise ConfigError('Cannot load theme {}, see log for more '
+                raise ConfigError('Could not find theme {}, see log for more '
                                   'information'.format(themestring))
 
         # if still no theme is set, resort to default

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -79,7 +79,7 @@ class SettingsManager(object):
         """parse alot's config file from path"""
         spec = os.path.join(DEFAULTSPATH, 'alot.rc.spec')
         newconfig = read_config(
-            self.alot_rc_path, spec, checks={
+            self.alot_rc_path, spec, report_extra=True, checks={
                 'mail_container': checks.mail_container,
                 'force_list': checks.force_list,
                 'align': checks.align_mode,

--- a/alot/settings/theme.py
+++ b/alot/settings/theme.py
@@ -22,7 +22,7 @@ class Theme(object):
         :raises: :class:`~alot.settings.errors.ConfigError`
         """
         self._spec = os.path.join(DEFAULTSPATH, 'theme.spec')
-        self._config = read_config(path, self._spec,
+        self._config = read_config(path, self._spec, report_extra=True,
                                    checks={'align': checks.align_mode,
                                            'widthtuple': checks.width_tuple,
                                            'force_list': checks.force_list,

--- a/alot/settings/utils.py
+++ b/alot/settings/utils.py
@@ -3,6 +3,8 @@
 # For further details see the COPYING file
 from __future__ import absolute_import
 
+import logging
+
 from configobj import ConfigObj, ConfigObjError, flatten_errors
 from validate import Validator
 from urwid import AttrSpec
@@ -30,7 +32,9 @@ def read_config(configpath=None, specpath=None, checks=None):
         config = ConfigObj(infile=configpath, configspec=specpath,
                            file_error=True, encoding='UTF8')
     except ConfigObjError as e:
-        raise ConfigError(e)
+        msg = 'Error when parsing `%s`:\n%s' % (configpath, e)
+        logging.error(msg)
+        raise ConfigError(msg)
     except IOError:
         raise ConfigError('Could not read %s and/or %s'
                           % (configpath, specpath))

--- a/tests/commands/envelope_test.py
+++ b/tests/commands/envelope_test.py
@@ -309,7 +309,7 @@ class TestSignCommand(unittest.TestCase):
                 [[default]]
                     realname = foo
                     address = foo@example.com
-                    sendmail_commnd = /bin/true
+                    sendmail_command = /bin/true
             """)
 
         # Allow settings.reload to work by not deleting the file until the end

--- a/tests/settings/manager_test.py
+++ b/tests/settings/manager_test.py
@@ -117,7 +117,7 @@ class TestSettingsManagerGetAccountByAddress(utilities.TestCaseClassCleanup):
                 [[default]]
                     realname = That Guy
                     address = that_guy@example.com
-                    sendmail_commnd = /bin/true
+                    sendmail_command = /bin/true
 
                 [[other]]
                     realname = A Dude


### PR DESCRIPTION
As an inexperienced user, I do a lot of silly things that leave me wonder why something doesn't work. I'm really impressed at how detailed alot can log, but at the same time I find it sometimes annoying that I have to check the logs to find out why something didn't work - which means, worst case, I have to restart alot and redo the same operation, because per default alot doesn't log anything.

So, in this particular case, I used an email address for the `from:` field that wasn't defined in the config.

In general, there are more cases where I think more information would help:
 - [x] Sending an email. I use `msmtpd` and alot just prints `failed to send: msmtp --account=posteo -t failed with code 78:
A process has ended with a probable error condition: process ended with exit code 78.`, but alot has the exact message in the logs.
 - [x] don't just silently accept a syntactically correct config file that has unknown settings - this made me pull my hair out, when I misspelled `theme_dir` instead of `themes_dir` (which is an easy mistake, because it's `template_dir` and not `templates_dir`) (Edit: or maybe it was the other way around ...)
 - [x] check if the same should be done for theme files.
 - [x] say which config file couldn't be parsed, when there's an error (true for alot's config, notmuch config and abook's address book)

So, tl;dr: if you agree these things are worth fixing, I could take a look and either push to this PR, or open new PRs. 