### PR TITLE
allow selection of contenttype

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -1154,3 +1154,31 @@ class TagCommand(Command):
         # flush index
         if self.flush:
             await ui.apply_command(FlushCommand())
+
+
+@registerCommand(MODE, 'nextpart', help='display the next multipart part')
+class NextPartCommand(Command):
+
+    """display the next multipart part"""
+    repeatable = True
+
+    def apply(self, ui):
+        tbuffer = ui.current_buffer
+        message_tree = tbuffer.get_selected_messagetree()
+        message_tree.next_part()
+        message_tree.reassemble()
+        tbuffer.refresh()
+
+
+@registerCommand(MODE, 'prevpart', help='display the previous multipart part')
+class PrevPartCommand(Command):
+
+    """display the next multipart part"""
+    repeatable = True
+
+    def apply(self, ui):
+        tbuffer = ui.current_buffer
+        message_tree = tbuffer.get_selected_messagetree()
+        message_tree.prev_part()
+        message_tree.reassemble()
+        tbuffer.refresh()

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from notmuch import NullPointerError
 
 from . import utils
-from .utils import extract_body
+from .utils import extract_body, extract_bodies
 from .utils import decode_header
 from .attachment import Attachment
 from .. import helper
@@ -278,6 +278,12 @@ class Message:
            'text/html' in (part.get_content_type() for part in eml.walk())):
             return MISSING_HTML_MSG
         return bodytext
+
+    def get_body_parts(self):
+        """
+        returns bodystring for each part in this mail
+        """
+        return extract_bodies(self.get_email())
 
     def get_text_content(self):
         return extract_body(self.get_email(), types=['text/plain'])

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -280,16 +280,22 @@ class MessageTree(CollapsibleTree):
             self._current_part += offset
             self._current_part %= len(mps)
 
+    def get_current_text(self):
+        return self._get_current(1)
+
     def _get_current_part(self):
+        return self._get_current(2)
+
+    def _get_current(self, index):
         mps = self._get_multiparts()
         if mps:
-            return mps[self._current_part][1]
+            return mps[self._current_part][index]
 
     def _get_multipart_selector(self):
         mps = self._get_multiparts()
         if mps:
             return MultipartWidget(
-                [ctype for ctype, _ in self._get_multiparts()],
+                [ctype for ctype, _, _ in self._get_multiparts()],
                 self._current_part)
 
     def _get_multiparts(self):
@@ -300,6 +306,7 @@ class MessageTree(CollapsibleTree):
 
             self._multiparts = [
                 (ctype,
+                 text,
                  TextlinesList(text, att, att_focus))
                 for ctype, text
                 in self._message.get_body_parts()]

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -304,7 +304,11 @@ class MessageTree(CollapsibleTree):
                 for ctype, text
                 in self._message.get_body_parts()]
 
-            self._current_part = 0
+            preferred = 'text/plain' if settings.get(
+                'prefer_plaintext') else 'text/html'
+            prefs = [i for i, e in enumerate(self._multiparts)
+                     if e[0] == preferred]
+            self._current_part = prefs[0] if prefs else 0
 
         return self._multiparts
 

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -182,7 +182,7 @@ class MessageTree(CollapsibleTree):
         self._default_headers_tree = None
         self.display_attachments = True
         self._attachments = None
-        self._current_part = 0
+        self._current_part = None
         self._multiparts = None
         self._maintree = SimpleTree(self._assemble_structure(True))
         CollapsibleTree.__init__(self, self._maintree)
@@ -275,19 +275,22 @@ class MessageTree(CollapsibleTree):
         self._other_part(-1)
 
     def _other_part(self, offset):
-        self._current_part += offset
-        self._current_part %= len(self._get_multiparts())
+        mps = self._get_multiparts()
+        if mps:
+            self._current_part += offset
+            self._current_part %= len(mps)
 
     def _get_current_part(self):
-        if self._current_part < len(self._get_multiparts()):
-            return self._multiparts[self._current_part][1]
-        else:
-            return None
+        mps = self._get_multiparts()
+        if mps:
+            return mps[self._current_part][1]
 
     def _get_multipart_selector(self):
-        return MultipartWidget(
-            [ctype for ctype, _ in self._get_multiparts()],
-            self._current_part)
+        mps = self._get_multiparts()
+        if mps:
+            return MultipartWidget(
+                [ctype for ctype, _ in self._get_multiparts()],
+                self._current_part)
 
     def _get_multiparts(self):
         if self._multiparts is None:
@@ -300,6 +303,8 @@ class MessageTree(CollapsibleTree):
                  TextlinesList(text, att, att_focus))
                 for ctype, text
                 in self._message.get_body_parts()]
+
+            self._current_part = 0
 
         return self._multiparts
 

--- a/docs/source/usage/modes/thread.rst
+++ b/docs/source/usage/modes/thread.rst
@@ -5,6 +5,20 @@ Commands in `thread` mode
 -------------------------
 The following commands are available in thread mode:
 
+.. _cmd.thread.nextpart:
+
+.. describe:: nextpart
+
+    display the next multipart part
+
+
+.. _cmd.thread.prevpart:
+
+.. describe:: prevpart
+
+    display the previous multipart part
+
+
 .. _cmd.thread.bounce:
 
 .. describe:: bounce


### PR DESCRIPTION
Fixes #405.
  
- [ ] Tests
- [x] Rename `:nextctype` to `:nextpart` and reflect this in the code
- [x] Add a "previous" to the "next"
- [x] Fix "prefer_plaintext"
- [x] Quote the selected part on reply/forward
- [x] Make it pretty
- [x] rebase and cleanup

Issues:
- [ ] Alot crashes when I swap to a content tab with less content, because we try to select the same line in every content tab (the same line might not exist).
- [x] A message with multipart/mixed, but only a single part (the attachment), fails to open (example for self: thread:0000000000006739)
- [x] Body of neither text nor html is shown (example for self: thread:0000000000007fc1)