### PR TITLE
mention unrendered HTML parts directly in message body text.

### DIFF
--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -18,6 +18,11 @@ from ..settings.const import settings
 
 charset.add_charset('utf-8', charset.QP, charset.QP, 'utf-8')
 
+MISSING_HTML_MSG = ("This message contains a text/html part that was not "
+                    "rendered due to a missing mailcap entry. "
+                    "Please refer to item 5 in our FAQ: "
+                    "http://alot.rtfd.io/en/latest/faq.html")
+
 
 @functools.total_ordering
 class Message(object):
@@ -256,7 +261,14 @@ class Message(object):
         returns bodystring extracted from this mail
         """
         # TODO: allow toggle commands to decide which part is considered body
-        return extract_body(self.get_email())
+        eml = self.get_email()
+        bodytext = extract_body(eml)
+
+        # check if extracted body is empty but msg contains html parts
+        if (not bodytext and
+           'text/html' in (part.get_content_type() for part in eml.walk())):
+            return MISSING_HTML_MSG
+        return bodytext
 
     def get_text_content(self):
         return extract_body(self.get_email(), types=['text/plain'])

--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -325,6 +325,10 @@ def extract_body(mail, types=None, field_key='copiousoutput'):
 
     body_parts = []
     for part in mail.walk():
+        # skip non-leaf nodes in the mail tree
+        if part.is_multipart():
+            continue
+
         ctype = part.get_content_type()
 
         if types is not None:

--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -346,10 +346,11 @@ def extract_body(mail, types=None, field_key='copiousoutput'):
         else:
             # get mime handler
             _, entry = settings.mailcap_find_match(ctype, key=field_key)
-            tempfile_name = None
-            stdin = None
-
-            if entry:
+            if entry is None:
+                part.add_header('Content-Disposition', 'attachment; ' + cd)
+            else:
+                tempfile_name = None
+                stdin = None
                 handler_raw_commandstring = entry['view']
                 # in case the mailcap defined command contains no '%s',
                 # we pipe the files content to the handling command via stdin

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -14,7 +14,6 @@ from .globals import TagWidget
 from .globals import AttachmentWidget
 from ..settings.const import settings
 from ..db.utils import decode_header, X_SIGNATURE_MESSAGE_HEADER
-from ..db.utils import extract_body
 
 
 class MessageSummaryWidget(urwid.WidgetWrap):
@@ -238,7 +237,7 @@ class MessageTree(CollapsibleTree):
 
     def _get_body(self):
         if self._bodytree is None:
-            bodytxt = extract_body(self._message.get_email())
+            bodytxt = self._message.accumulate_body()
             if bodytxt:
                 att = settings.get_theming_attribute('thread', 'body')
                 att_focus = settings.get_theming_attribute(


### PR DESCRIPTION
This fixes issue #987 and is intended as a replacement for #1163.