### PR TITLE
[WIP] Fix writing/loading history, if a command contains non-ascii character(s)

### DIFF
--- a/alot/ui.py
+++ b/alot/ui.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 import logging
 import os
 import signal
+import codecs
 
 from twisted.internet import reactor, defer, task
 import urwid
@@ -729,7 +730,7 @@ class UI(object):
         if size == 0:
             return []
         if os.path.exists(path):
-            with open(path) as histfile:
+            with codecs.open(path, 'r', encoding='utf-8') as histfile:
                 lines = [line.rstrip('\n') for line in histfile]
             if size > 0:
                 lines = lines[-size:]
@@ -759,7 +760,7 @@ class UI(object):
         if not os.path.exists(directory):
             os.makedirs(directory)
         # Write linewise to avoid building a large string in menory.
-        with open(path, 'w') as histfile:
+        with codecs.open(path, 'w', encoding='utf-8') as histfile:
             for line in history:
                 histfile.write(line)
                 histfile.write('\n')


### PR DESCRIPTION
When poking around  #824 I found this bug:
- alot -l log -d debug
- :search ö<enter>
- quit alot

In the log file:

```
ERROR:ui:Traceback (most recent call last):
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/Twisted-17.9.0-py2.7-linux-x86_64.egg/twisted/internet/defer.py", line 653, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/alot-0.7.0.dev0-py2.7.egg/alot/ui.py", line 679, in call_apply
    return defer.maybeDeferred(cmd.apply, self)
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/Twisted-17.9.0-py2.7-linux-x86_64.egg/twisted/internet/defer.py", line 150, in maybeDeferred
    result = f(*args, **kw)
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/Twisted-17.9.0-py2.7-linux-x86_64.egg/twisted/internet/defer.py", line 1532, in unwindGenerator
    return _inlineCallbacks(None, gen, Deferred())
--- <exception caught here> ---
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/Twisted-17.9.0-py2.7-linux-x86_64.egg/twisted/internet/defer.py", line 1386, in _inlineCallbacks
    result = g.send(result)
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/alot-0.7.0.dev0-py2.7.egg/alot/commands/globals.py", line 77, in apply
    ui.cleanup()
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/alot-0.7.0.dev0-py2.7.egg/alot/ui.py", line 711, in cleanup
    self._cmd_hist_file, size=size)
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/alot-0.7.0.dev0-py2.7.egg/alot/ui.py", line 764, in _save_history_to_file
    histfile.write(line)
exceptions.UnicodeEncodeError: 'ascii' codec can't encode character u'\xf6' in position 7: ordinal not in range(128)
```
todo (just posting this PR now, so I won't forget):
- [ ] test
- [ ] check other instances of `open`

Specifying an encoding will also be necessary in Python 3 (where otherwise the preferred system encoding is used).
  
  