### PR TITLE
Call a text-to-html converter to build html alternative body parts

### DIFF
--- a/alot/buffers/envelope.py
+++ b/alot/buffers/envelope.py
@@ -89,7 +89,7 @@ class EnvelopeBuffer(Buffer):
             self.attachment_wgt = urwid.Pile(lines)
             displayed_widgets.append(self.attachment_wgt)
 
-        self.body_wgt = urwid.Text(string_sanitize(self.envelope.body))
+        self.body_wgt = urwid.Text(string_sanitize(self.envelope.body_txt))
         displayed_widgets.append(self.body_wgt)
         self.body = urwid.ListBox(displayed_widgets)
 

--- a/alot/buffers/envelope.py
+++ b/alot/buffers/envelope.py
@@ -94,7 +94,7 @@ class EnvelopeBuffer(Buffer):
             displayed_widgets.append(self.attachment_wgt)
 
         # message body
-        txt = self.envelope.body_txt
+        txt = self._find_body_text()
         self.body_wgt = urwid.Text(string_sanitize(txt))
         displayed_widgets.append(self.body_wgt)
         self.body = urwid.ListBox(displayed_widgets)
@@ -104,13 +104,7 @@ class EnvelopeBuffer(Buffer):
         self.all_headers = not self.all_headers
         self.rebuild()
 
-    def set_displaypart(self, part):
-        """Update the view to display body part (plaintext, html, src).
-
-        ..note:: This assumes that selv.envelope.body_html exists in case
-        the requested part is 'html' or 'src'!
-        """
-        self.displaypart = part
+    def _find_body_text(self):
         txt = "no such part!"
         if self.displaypart == "html":
             htmlpart = MIMEText(self.envelope.body_html, 'html', 'utf-8')
@@ -119,4 +113,14 @@ class EnvelopeBuffer(Buffer):
             txt = self.envelope.body_html
         elif self.displaypart == "plaintext":
             txt = self.envelope.body_txt
+        return txt
+
+    def set_displaypart(self, part):
+        """Update the view to display body part (plaintext, html, src).
+
+        ..note:: This assumes that selv.envelope.body_html exists in case
+        the requested part is 'html' or 'src'!
+        """
+        self.displaypart = part
+        txt = self._find_body_text()
         self.body_wgt.set_text(txt)

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -798,3 +798,18 @@ class ChangeDisplaymodeCommand(Command):
 
         ui.current_buffer.set_displaypart(self.part)
         ui.update()
+
+
+@registerCommand(
+    MODE, 'removehtml',
+    help='remove HTML alternative from the envelope',
+)
+class RemoveHtmlCommand(Command):
+    def apply(self, ui):
+        ebuffer = ui.current_buffer
+        envelope = ebuffer.envelope
+
+        envelope.body_html = None
+        ebuffer.displaypart = 'plaintext'
+        ebuffer.rebuild()
+        ui.update()

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -743,3 +743,30 @@ class BodyConvertCommand(Command):
                 envelope.body_txt = self.convert(cmdstring, envelope.body_html)
 
         ui.current_buffer.rebuild()
+
+
+@registerCommand(
+    MODE, 'display', help='change which body alternative to display',
+    arguments=[(['part'], {'help': 'part to show'})])
+class ChangeDisplaymodeCommand(Command):
+
+    """change wich body alternative is shown"""
+
+    def __init__(self, part=None, **kwargs):
+        """
+        :param part: which part to show
+        :type indent: 'plaintext', 'src', or 'html'
+        """
+        self.part = part
+        Command.__init__(self, **kwargs)
+
+    async def apply(self, ui):
+        ebuffer = ui.current_buffer
+        envelope = ebuffer.envelope
+
+        # make sure that envelope has html part if requested here
+        if self.part in ['html', 'src'] and not envelope.body_html:
+            await ui.apply_command(BodyConvertCommand(action='txt2html'))
+
+        ui.current_buffer.set_displaypart(self.part)
+        ui.update()

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -390,7 +390,7 @@ class EditCommand(Command):
                 headertext += '%s: %s\n' % (key, value)
 
         # determine editable content
-        bodytext = self.envelope.body
+        bodytext = self.envelope.body_txt
         if headertext:
             content = '%s\n%s' % (headertext, bodytext)
             self.edit_only_body = False

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -739,16 +739,15 @@ class TagCommand(Command):
 class BodyConvertCommand(Command):
     def __init__(self, action=None, cmd=None):
         self.action = action
-        self.cmd = cmd
+        self.cmd = cmd  # this comes as a space separated list
         Command.__init__(self)
 
-    def convert(self, cmdstring, inputstring):
-        logging.debug("converting using %s" % cmdstring)
-        cmdlist = split_commandstring(cmdstring)
+    def convert(self, cmdlist, inputstring):
+        logging.debug("converting using %s" % cmdlist)
         resultstring, errmsg, retval = call_cmd(cmdlist,
                                                 stdin=inputstring)
         if retval != 0:
-            msg = 'converter "%s" returned with ' % cmdstring
+            msg = 'converter "%s" returned with ' % cmdlist
             msg += 'return code %d' % retval
             if errmsg:
                 msg += ':\n%s' % errmsg
@@ -761,14 +760,16 @@ class BodyConvertCommand(Command):
         envelope = ebuffer.envelope
 
         if self.action is "txt2html":
-            cmdstring = self.cmd or settings.get('envelope_txt2html')
-            if cmdstring:
-                envelope.body_html = self.convert(cmdstring, envelope.body_txt)
+            fallbackcmd = settings.get('envelope_txt2html')
+            cmd = self.cmd or split_commandstring(fallbackcmd)
+            if cmd:
+                envelope.body_html = self.convert(cmd, envelope.body_txt)
 
         elif self.action is "html2txt":
-            cmdstring = self.cmd or settings.get('envelope_html2txt')
-            if cmdstring:
-                envelope.body_txt = self.convert(cmdstring, envelope.body_html)
+            fallbackcmd = settings.get('envelope_html2txt')
+            cmd = self.cmd or split_commandstring(fallbackcmd)
+            if cmd:
+                envelope.body_txt = self.convert(cmd, envelope.body_html)
 
         ui.current_buffer.rebuild()
 

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -317,23 +317,32 @@ class SendCommand(Command):
     (['--spawn'], {'action': cargparse.BooleanAction, 'default': None,
                    'help': 'spawn editor in new terminal'}),
     (['--refocus'], {'action': cargparse.BooleanAction, 'default': True,
-                     'help': 'refocus envelope after editing'})])
+                     'help': 'refocus envelope after editing'}),
+    (['--part'], {'help': 'which alternative to edit ("html" or "plaintext")',
+                  'choices': ['html', 'plaintext']}),
+])
 class EditCommand(Command):
     """edit mail"""
-    def __init__(self, envelope=None, spawn=None, refocus=True, **kwargs):
+    def __init__(self, envelope=None, spawn=None, refocus=True, part=None,
+                 **kwargs):
         """
         :param envelope: email to edit
         :type envelope: :class:`~alot.db.envelope.Envelope`
         :param spawn: force spawning of editor in a new terminal
         :type spawn: bool
         :param refocus: m
+        :param part: which alternative to edit
+        :type part: str
         """
         self.envelope = envelope
         self.openNew = (envelope is not None)
         self.force_spawn = spawn
         self.refocus = refocus
         self.edit_only_body = False
-        self.edit_part = None
+        self.edit_part = settings.get('envelope_edit_default_alternative')
+        if part in ['html', 'plaintext']:
+            self.edit_part = part
+        logging.debug('edit_part: %s ' % self.edit_part)
 
         Command.__init__(self, **kwargs)
 
@@ -396,7 +405,7 @@ class EditCommand(Command):
                 headertext += '%s: %s\n' % (key, value)
 
         # determine which part to edit
-        # TODO: add config option to enforce plaintext here
+        logging.debug('edit_part: %s ' % self.edit_part)
         if self.edit_part is None:
             # I can't access ebuffer in my constructor, hence the check here
             if isinstance(ebuffer, buffers.EnvelopeBuffer):

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -718,13 +718,13 @@ class TagCommand(Command):
 @registerCommand(
     MODE, 'html2txt', forced={'action': 'html2txt'},
     arguments=[(['cmd'], {'nargs': argparse.REMAINDER,
-                           'help': 'converter command to use'})],
+                          'help': 'converter command to use'})],
     help='convert html to plaintext alternative',
 )
 @registerCommand(
     MODE, 'txt2html', forced={'action': 'txt2html'},
     arguments=[(['cmd'], {'nargs': argparse.REMAINDER,
-                           'help': 'converter command to use'})],
+                          'help': 'converter command to use'})],
     help='convert plaintext to html alternative',
 )
 class BodyConvertCommand(Command):

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -334,7 +334,7 @@ class ForwardCommand(Command):
                 for line in self.message.get_body_text().splitlines():
                     mailcontent += quote_prefix + line + '\n'
 
-            envelope.body = mailcontent
+            envelope.body_txt = mailcontent
 
             for a in self.message.get_attachments():
                 envelope.attach(a)

--- a/alot/db/envelope.py
+++ b/alot/db/envelope.py
@@ -305,8 +305,9 @@ class Envelope:
 
         return outer_msg
 
-    def parse_template(self, raw, reset=False, only_body=False):
-        """parses a template or user edited string to fills this envelope.
+    def parse_template(self, raw, reset=False, only_body=False,
+                       target_body='plaintext'):
+        """Parse a template or user edited string to fills this envelope.
 
         :param raw: the string to parse.
         :type raw: str
@@ -314,6 +315,9 @@ class Envelope:
         :type reset: bool
         :param only_body: do not parse headers
         :type only_body: bool
+        :param target_body: body text alternative this should be stored in;
+            can be 'plaintext' or 'html'
+        :type reset: str
         """
         logging.debug('GoT: """\n%s\n"""', raw)
 
@@ -354,4 +358,8 @@ class Envelope:
                     self.attach(path)
                 del self['Attach']
 
-        self.body = raw[headerEndPos:].strip()
+        body = raw[headerEndPos:].strip()
+        if target_body == 'html':
+            self.body_html = body
+        else:
+            self.body_txt = body

--- a/alot/db/envelope.py
+++ b/alot/db/envelope.py
@@ -38,8 +38,10 @@ class Envelope:
     """
     dict containing the mail headers (a list of strings for each header key)
     """
-    body = None
-    """mail body as unicode string"""
+    body_txt = None
+    """mail body (plaintext) as unicode string"""
+    body_html = None
+    """mail body (html) as unicode string"""
     tmpfile = None
     """template text for initial content"""
     attachments = None
@@ -77,8 +79,8 @@ class Envelope:
         if template:
             self.parse_template(template)
             logging.debug('PARSED TEMPLATE: %s', template)
-            logging.debug('BODY: %s', self.body)
-        self.body = bodytext or ''
+            logging.debug('BODY: %s', self.body_txt)
+        self.body_txt = bodytext or ''
         # TODO: if this was as collections.defaultdict a number of methods
         # could be simplified.
         self.headers = headers or {}
@@ -96,7 +98,7 @@ class Envelope:
         self.account = account
 
     def __str__(self):
-        return "Envelope (%s)\n%s" % (self.headers, self.body)
+        return "Envelope (%s)\n%s" % (self.headers, self.body_txt)
 
     def __setitem__(self, name, val):
         """setter for header values. This allows adding header like so:
@@ -183,7 +185,7 @@ class Envelope:
         """
         # Build body text part. To properly sign/encrypt messages later on, we
         # convert the text to its canonical format (as per RFC 2015).
-        canonical_format = self.body.encode('utf-8')
+        canonical_format = self.body_txt.encode('utf-8')
         textpart = MIMEText(canonical_format, 'plain', 'utf-8')
 
         # wrap it in a multipart container if necessary

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -167,7 +167,8 @@ namedqueries_statusbar = mixed_list(string, string, default=list('[{buffer_no}: 
 # these strings may contain variables:
 #
 # * `{to}`: To-header of the envelope
-envelope_statusbar = mixed_list(string, string, default=list('[{buffer_no}: envelope]','{input_queue} total messages: {total_messages}'))
+# * `{displaypart}`: which body part alternative is currently in view (can be 'plaintext,'src', or 'html')
+envelope_statusbar = mixed_list(string, string, default=list('[{buffer_no}: envelope ({displaypart})]','{input_queue} total messages: {total_messages}'))
 
 # timestamp format in `strftime format syntax <http://docs.python.org/library/datetime.html#strftime-strptime-behavior>`_
 timestamp_format = string(default=None)

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -258,6 +258,11 @@ auto_replyto_mailinglist = boolean(default=False)
 # prefer plaintext alternatives over html content in multipart/alternative
 prefer_plaintext = boolean(default=False)
 
+# always edit the given body text alternative when editing outgoing messages in envelope mode.
+# alternative, and not the html source, even if that is currently displayed.
+# If unset, html content will be edited unless the current envelope shows the plaintext alternative.
+envelope_edit_default_alternative = option('plaintext', 'html', default=None)
+
 # Use this command to construct a html alternative message body text in envelope mode.
 # If unset, we send only the plaintext part, without html alternative.
 # The command will receive the plaintex on stdin and should produce html on stdout.

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -257,6 +257,17 @@ auto_replyto_mailinglist = boolean(default=False)
 # prefer plaintext alternatives over html content in multipart/alternative
 prefer_plaintext = boolean(default=False)
 
+# Use this command to construct a html alternative message body text in envelope mode.
+# If unset, we send only the plaintext part, without html alternative.
+# The command will receive the plaintex on stdin and should produce html on stdout.
+# (as `pandoc -t html` does for example).
+envelope_txt2html = string(default=None)
+
+# Use this command to turn a html message body to plaintext in envelope mode.
+# The command will receive the html on stdin and should produce text on stdout
+# (as `pandoc -f html -t markdown` does for example).
+envelope_html2txt = string(default=None)
+
 # In a thread buffer, hide from messages summaries tags that are commom to all
 # messages in that thread.
 msg_summary_hides_threadwide_tags = boolean(default=True)

--- a/alot/errors.py
+++ b/alot/errors.py
@@ -27,3 +27,6 @@ class GPGProblem(Exception):
 
 class CompletionError(Exception):
     pass
+
+class ConversionError(Exception):
+    pass

--- a/alot/errors.py
+++ b/alot/errors.py
@@ -28,5 +28,6 @@ class GPGProblem(Exception):
 class CompletionError(Exception):
     pass
 
+
 class ConversionError(Exception):
     pass

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -736,6 +736,18 @@
     :default: None
 
 
+.. _txt2html-converter:
+
+.. describe:: txt2html_converter
+
+     Use this command to construct a html alternative from the messages body before sendout.
+     The command will receive the plaintex on stdin and should produce html as stdout
+     (as `pandoc -t html` for example). If unset, we send only the plaintext part.
+
+    :type: string
+    :default: None
+
+
 .. _user-agent:
 
 .. describe:: user_agent

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -231,6 +231,18 @@
     :default: In-Reply-To, References
 
 
+.. _envelope-html2txt:
+
+.. describe:: envelope_html2txt
+
+     Use this command to turn a html message body to plaintext in envelope mode.
+     The command will receive the html on stdin and should produce text on stdout
+     (as `pandoc -f html -t markdown` does for example).
+
+    :type: string
+    :default: None
+
+
 .. _envelope-statusbar:
 
 .. describe:: envelope_statusbar
@@ -241,9 +253,23 @@
      these strings may contain variables:
 
      * `{to}`: To-header of the envelope
+     * `{displaypart}`: which body part alternative is currently in view (can be 'plaintext,'src', or 'html')
 
     :type: mixed_list
-    :default: [{buffer_no}: envelope], {input_queue} total messages: {total_messages}
+    :default: [{buffer_no}: envelope ({displaypart})], {input_queue} total messages: {total_messages}
+
+
+.. _envelope-txt2html:
+
+.. describe:: envelope_txt2html
+
+     Use this command to construct a html alternative message body text in envelope mode.
+     If unset, we send only the plaintext part, without html alternative.
+     The command will receive the plaintex on stdin and should produce html on stdout.
+     (as `pandoc -t html` does for example).
+
+    :type: string
+    :default: None
 
 
 .. _exclude-tags:
@@ -743,18 +769,6 @@
 .. describe:: timestamp_format
 
      timestamp format in `strftime format syntax <http://docs.python.org/library/datetime.html#strftime-strptime-behavior>`_
-
-    :type: string
-    :default: None
-
-
-.. _txt2html-converter:
-
-.. describe:: txt2html_converter
-
-     Use this command to construct a html alternative from the messages body before sendout.
-     The command will receive the plaintex on stdin and should produce html as stdout
-     (as `pandoc -t html` for example). If unset, we send only the plaintext part.
 
     :type: string
     :default: None

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -209,6 +209,18 @@
     :default: "UTF-8"
 
 
+.. _envelope-edit-default-alternative:
+
+.. describe:: envelope_edit_default_alternative
+
+     always edit the given body text alternative when editing outgoing messages in envelope mode.
+     alternative, and not the html source, even if that is currently displayed.
+     If unset, html content will be edited unless the current envelope shows the plaintext alternative.
+
+    :type: option, one of ['plaintext', 'html']
+    :default: None
+
+
 .. _envelope-headers-blacklist:
 
 .. describe:: envelope_headers_blacklist

--- a/docs/source/usage/modes/envelope.rst
+++ b/docs/source/usage/modes/envelope.rst
@@ -68,6 +68,13 @@ The following commands are available in envelope mode:
         header to refine
 
 
+.. _cmd.envelope.removehtml:
+
+.. describe:: removehtml
+
+    remove HTML alternative from the envelope
+
+
 .. _cmd.envelope.retag:
 
 .. describe:: retag

--- a/docs/source/usage/modes/envelope.rst
+++ b/docs/source/usage/modes/envelope.rst
@@ -15,6 +15,16 @@ The following commands are available in envelope mode:
         file(s) to attach (accepts wildcads)
 
 
+.. _cmd.envelope.display:
+
+.. describe:: display
+
+    change which body alternative to display
+
+    argument
+        part to show
+
+
 .. _cmd.envelope.edit:
 
 .. describe:: edit
@@ -24,6 +34,7 @@ The following commands are available in envelope mode:
     optional arguments
         :---spawn: spawn editor in new terminal
         :---refocus: refocus envelope after editing (defaults to: 'True')
+        :---part: which alternative to edit ("html" or "plaintext"); valid choices are: 'html','plaintext'
 
 .. _cmd.envelope.encrypt:
 
@@ -36,6 +47,16 @@ The following commands are available in envelope mode:
 
     optional arguments
         :---trusted: only add trusted keys
+
+.. _cmd.envelope.html2txt:
+
+.. describe:: html2txt
+
+    convert html to plaintext alternative
+
+    argument
+        converter command to use
+
 
 .. _cmd.envelope.refine:
 
@@ -152,6 +173,16 @@ The following commands are available in envelope mode:
 
     argument
         comma separated list of tags
+
+
+.. _cmd.envelope.txt2html:
+
+.. describe:: txt2html
+
+    convert plaintext to html alternative
+
+    argument
+        converter command to use
 
 
 .. _cmd.envelope.unattach:

--- a/tests/commands/test_global.py
+++ b/tests/commands/test_global.py
@@ -101,7 +101,7 @@ class TestComposeCommand(unittest.TestCase):
         self.assertEqual({'To': [to],
                           'From': [_from],
                           'Subject': [subject]}, cmd.envelope.headers)
-        self.assertEqual(body, cmd.envelope.body)
+        self.assertEqual(body, cmd.envelope.body_txt)
 
 
 class TestExternalCommand(unittest.TestCase):

--- a/tests/db/test_envelope.py
+++ b/tests/db/test_envelope.py
@@ -105,5 +105,5 @@ class TestEnvelope(unittest.TestCase):
             'To': ['bar@example.com, baz@example.com'],
             'Subject': ['Fwd: Test email']
         })
-        self.assertEqual(envlp.body,
+        self.assertEqual(envlp.body_txt,
                          'Some body content: which is not a header.')


### PR DESCRIPTION
as discussed in #1051.

This will use a new config string "txt2html_converter" to translate plaintext body message to html and change the created mime structure accordingly.
See https://stackoverflow.com/questions/10631856/mime-type-to-satisfy-html-email-images-and-plain-text

It works nicely for me when I compose simple markdown and use "pandoc -t html" as converter.
But I expect it to get messy with reply quotes (untested for now).