### PR TITLE
Fix `LANG=C alot` with custom bindings.

### DIFF
--- a/alot/ui.py
+++ b/alot/ui.py
@@ -75,6 +75,9 @@ class UI(object):
         # alarm handle for callback that clears input queue (to cancel alarm)
         self._alarm = None
 
+        # force urwid to pass key events as unicode, independent of LANG
+        urwid.set_encoding('utf-8')
+
         # create root widget
         global_att = settings.get_theming_attribute('global', 'body')
         mainframe = urwid.Frame(urwid.SolidFill())


### PR DESCRIPTION
This fixes two crashes I encountered when playing around with `LANG=C alot` in #673, but @pazz couldn't reproduce it. As requested, I post the one-line change here, but if no one can reproduce it I'm not sure it's worth it :-)

Reproduction steps:
- Set a custom binding in your config file. E.g.:
[bindings]
    S = toggletags spam
- start alot with LANG=C: LANG=C alot
- variant A: type ö
- variant B: type :search ö

Problem: ConfigObj reads the custom binding as a unicode string, but ö is
passed as a binary string. The interaction of both leads to crashes.

Related to #673

Edit: backtrace from variant A (LANG=C alot, type ö) from #673:
```
LANG=C alot -l log -d debug
Traceback (most recent call last):
  File "/home/kelvin/tmp/alot/venv/bin/alot", line 11, in <module>
    load_entry_point('alot==0.7.0.dev0', 'console_scripts', 'alot')()
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/alot-0.7.0.dev0-py2.7.egg/alot/__main__.py", line 130, in main
    UI(dbman, cmdstring)
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/alot-0.7.0.dev0-py2.7.egg/alot/ui.py", line 124, in __init__
    self.mainloop.run()
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/urwid-1.3.1-py2.7-linux-x86_64.egg/urwid/main_loop.py", line 278, in run
    self._run()
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/urwid-1.3.1-py2.7-linux-x86_64.egg/urwid/main_loop.py", line 376, in _run
    self.event_loop.run()
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/urwid-1.3.1-py2.7-linux-x86_64.egg/urwid/main_loop.py", line 1200, in wrapper
    rval = f(*args,**kargs)
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/urwid-1.3.1-py2.7-linux-x86_64.egg/urwid/raw_display.py", line 393, in <lambda>
    event_loop, callback, self.get_available_raw_input())
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/urwid-1.3.1-py2.7-linux-x86_64.egg/urwid/raw_display.py", line 493, in parse_input
    callback(processed, processed_codes)
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/urwid-1.3.1-py2.7-linux-x86_64.egg/urwid/main_loop.py", line 400, in _update
    keys = self.input_filter(keys, raw)
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/urwid-1.3.1-py2.7-linux-x86_64.egg/urwid/main_loop.py", line 539, in input_filter
    return self._input_filter(keys, raw)
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/alot-0.7.0.dev0-py2.7.egg/alot/ui.py", line 189, in _input_filter
    prefix=keyseq)
  File "/home/kelvin/tmp/alot/venv/lib/python2.7/site-packages/alot-0.7.0.dev0-py2.7.egg/alot/settings/manager.py", line 356, in get_mapped_input_keysequences
    cand = [c for c in candidates if c.startswith(prefixes)]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
```

Log entry:
```
DEBUG:ui:Got key (['\xc3', '\xb6'], [195, 182])
```