### PR TITLE
Add support for optional diff and quoting highlighting

### DIFF
--- a/alot/defaults/default.theme
+++ b/alot/defaults/default.theme
@@ -31,9 +31,17 @@
     attachment_focus = 'underline','','light gray','light green','light gray','light green'
     body = 'default','','light gray','default','light gray','default'
     body_focus = 'default','','light gray','default','white','default'
+    diff_add = 'default','','light gray','default','light gray','default'
+    diff_del = 'default','','light gray','default','light gray','default'
+    diff_head = 'default','','light gray','default','light gray','default'
     header = 'default','','white','dark gray','white','dark gray'
     header_key = 'default','','white','dark gray','white','dark gray'
     header_value = 'default','','light gray','dark gray','light gray','dark gray'
+    nested1 = 'default','','light gray','default','light gray','default'
+    nested2 = 'default','','light gray','default','light gray','default'
+    nested3 = 'default','','light gray','default','light gray','default'
+    nested4 = 'default','','light gray','default','light gray','default'
+    nested5 = 'default','','light gray','default','light gray','default'
 
     [[summary]]
         even = 'default','','white','light blue','white','#006'

--- a/alot/defaults/theme.spec
+++ b/alot/defaults/theme.spec
@@ -53,9 +53,17 @@
     attachment_focus = attrtriple
     body = attrtriple
     body_focus = attrtriple(default=None)
+    diff_add = attrtriple
+    diff_del = attrtriple
+    diff_head = attrtriple
     header = attrtriple
     header_key = attrtriple
     header_value = attrtriple
+    nested1 = attrtriple
+    nested2 = attrtriple
+    nested3 = attrtriple
+    nested4 = attrtriple
+    nested5 = attrtriple
     [[summary]]
         even = attrtriple
         odd = attrtriple

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -93,12 +93,39 @@ class TextlinesList(SimpleTree):
         for each line in content.
         """
         structure = []
+        attr_diff_add = settings.get_theming_attribute('thread', 'diff_add')
+        attr_diff_del = settings.get_theming_attribute('thread', 'diff_del')
+        attr_diff_head = settings.get_theming_attribute('thread', 'diff_head')
+        attr_nested1 = settings.get_theming_attribute('thread', 'nested1')
+        attr_nested2 = settings.get_theming_attribute('thread', 'nested2')
+        attr_nested3 = settings.get_theming_attribute('thread', 'nested3')
+        attr_nested4 = settings.get_theming_attribute('thread', 'nested4')
+        attr_nested5 = settings.get_theming_attribute('thread', 'nested5')
 
         # depending on this config setting, we either add individual lines
         # or the complete context as focusable objects.
         if settings.get('thread_focus_linewise'):
             for line in content.splitlines():
-                structure.append((FocusableText(line, attr, attr_focus), None))
+                if line.startswith("> > > > >"):
+                    curr_attr = attr_nested5
+                elif line.startswith("> > > >"):
+                    curr_attr = attr_nested4
+                elif line.startswith("> > >"):
+                    curr_attr = attr_nested3
+                elif line.startswith("> >"):
+                    curr_attr = attr_nested2
+                elif line.startswith(">"):
+                    curr_attr = attr_nested1
+                elif line.startswith("+"):
+                    curr_attr = attr_diff_add
+                elif line.startswith("-"):
+                    curr_attr = attr_diff_del
+                elif line.startswith("@@") or line.startswith("diff "):
+                    curr_attr = attr_diff_head
+                else:
+                    curr_attr = attr
+
+                structure.append((FocusableText(line, curr_attr, attr_focus), None))
         else:
             structure.append((FocusableText(content, attr, attr_focus), None))
         SimpleTree.__init__(self, structure)


### PR DESCRIPTION
Introducing couple of new configurations options in [thread] section:
 * diff_add  - applied to lines starting with +
 * diff_del  - applied to lines starting with -
 * diff_head - applied to lines staring with either "@@" or "diff "
 * nested1 to nested5 - for highlighting nested quoted messages (lines
                        starting with something like "> > >")

Due to how urwid and alot handle displaying text - one widget per line
(or whole message) and styling happening per widget - this change works
only with thread_focus_linewise turned on (the default) and the
highlighting is line-wide.

This is a very rough and ready patch to provide those features as fast
as possible and encourage discussion on a proper implementation.