### PR TITLE
Fix gpg ambiguous key handling

### DIFF
--- a/alot/ui.py
+++ b/alot/ui.py
@@ -484,7 +484,7 @@ class UI(object):
         self.update()
 
     def choice(self, message, choices=None, select=None, cancel=None,
-               msg_position='above'):
+               msg_position='above', return_index=False):
         """
         prompt user to make a choice.
 
@@ -501,12 +501,16 @@ class UI(object):
         :param msg_position: determines if `message` is above or left of the
                              prompt. Must be `above` or `left`.
         :type msg_position: str
+        :param return_index: Return the (0 based) index of the option instead
+                             of the value
+        :type return_index: bool
         :rtype:  :class:`twisted.defer.Deferred`
         """
         choices = choices or {'y': 'yes', 'n': 'no'}
         assert select is None or select in choices.itervalues()
         assert cancel is None or cancel in choices.itervalues()
         assert msg_position in ['left', 'above']
+        assert isinstance(return_index, bool)
 
         d = defer.Deferred()  # create return deferred
         oldroot = self.mainloop.widget
@@ -520,8 +524,12 @@ class UI(object):
 
         # set up widgets
         msgpart = urwid.Text(message)
-        choicespart = ChoiceWidget(choices, callback=select_or_cancel,
-                                   select=select, cancel=cancel)
+        choicespart = ChoiceWidget(
+            choices,
+            callback=select_or_cancel,
+            select=select,
+            cancel=cancel,
+            return_value='key' if return_index else 'value')
 
         # build widget
         if msg_position == 'left':

--- a/alot/widgets/globals.py
+++ b/alot/widgets/globals.py
@@ -45,12 +45,14 @@ class AttachmentWidget(urwid.WidgetWrap):
 
 class ChoiceWidget(urwid.Text):
     def __init__(self, choices, callback, cancel=None, select=None,
-                 separator=' '):
+                 separator=' ', return_value='value'):
         self.choices = choices
         self.callback = callback
         self.cancel = cancel
         self.select = select
         self.separator = separator
+        assert return_value in ['key', 'value']
+        self.return_value = return_value
 
         items = []
         for k, v in choices.iteritems():
@@ -70,7 +72,11 @@ class ChoiceWidget(urwid.Text):
         elif key == 'esc' and self.cancel is not None:
             self.callback(self.cancel)
         elif key in self.choices:
-            self.callback(self.choices[key])
+            if self.return_value == 'value':
+                rt = self.choices[key]
+            else:
+                rt = key
+            self.callback(rt)
         else:
             return key
 


### PR DESCRIPTION
Currently what happens if there is an ambiguous key, we will present
two potentially identical uids, then add the uid to the list of
potential uid. This results in an infinite loop (although it looks like
it's frozen, it's actually processing input).

To fix this we need to not add the key to the potential keys to
consider, we need to add it to the list of keys we've already
considered. This requires some changes to the core widgets to make work.