### PR TITLE
Fix templates with non-ascii characters.

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -770,8 +770,11 @@ class ComposeCommand(Command):
                           priority='error')
                 return
             try:
-                with open(path) as f:
-                    self.envelope.parse_template(f.read())
+                with open(path, 'rb') as f:
+                    blob = f.read()
+                encoding = helper.guess_encoding(blob)
+                logging.debug('template encoding: `%s`' % encoding)
+                self.envelope.parse_template(blob.decode(encoding))
             except Exception as e:
                 ui.notify(str(e), priority='error')
                 return


### PR DESCRIPTION
Fixes #1198 for me.

Two questions:
- Is it okay to just assume that files on Linux are encoded as 'utf-8', or should we guess the encoding (either by reading the file, or by following the hints given by environment variables)?
- The template string is passed to [parse_template](https://github.com/pazz/alot/blob/d03cd3f582818651157aa9588e5723cdaa81dc3e/alot/db/envelope.py#L281) which seems to require byte strings, such that headers like "Subject: =?iso-8859-1?q?p=F6stal?=" can be decoded later. But I don't think anyone would use a template file like that, such that it should be okay to decode the file when it's opened.