### PR TITLE
Named query

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+next:
+* feature: Add a new 'namedqueries' buffer type for displaying named queries.
+
 0.7:
 * info: missing html mailcap entry now reported as mail body text
 * feature: Allow regex special characters in tagstrings

--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -19,7 +19,8 @@ from alot.commands import CommandParseError, COMMANDS
 from alot.utils import argparse as cargparse
 
 
-_SUBCOMMANDS = ['search', 'compose', 'bufferlist', 'taglist', 'pyshell']
+_SUBCOMMANDS = ['search', 'compose', 'bufferlist', 'taglist', 'namedqueries',
+                'pyshell']
 
 
 def parser():

--- a/alot/commands/__init__.py
+++ b/alot/commands/__init__.py
@@ -40,6 +40,7 @@ COMMANDS = {
     'envelope': {},
     'bufferlist': {},
     'taglist': {},
+    'namedqueries': {},
     'thread': {},
     'global': {},
 }

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -551,6 +551,30 @@ class TagListCommand(Command):
             ui.buffer_open(buffers.TagListBuffer(ui, tags, self.filtfun))
 
 
+@registerCommand(MODE, 'namedqueries', arguments=[
+    (['--queries'], {'nargs': '+', 'help': 'named queries to display'}),
+])
+class NamedQueriesCommand(Command):
+    """opens named queries buffer"""
+    def __init__(self, queries=None, **kwargs):
+        """
+        :param queries: list of names of the named queries to display
+        """
+        self.queries = queries
+        Command.__init__(self, **kwargs)
+
+    def apply(self, ui):
+        queries = self.queries or ui.dbman.list_named_queries()
+        qlists = ui.get_buffers_of_type(buffers.NamedQueriesBuffer)
+        if qlists:
+            buf = qlists[0]
+            buf.queries = queries
+            buf.rebuild()
+            ui.buffer_focus(buf)
+        else:
+            ui.buffer_open(buffers.NamedQueriesBuffer(ui, queries))
+
+
 @registerCommand(MODE, 'flush')
 class FlushCommand(Command):
 

--- a/alot/commands/namedqueries.py
+++ b/alot/commands/namedqueries.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# This file is released under the GNU GPL, version 3 or a later revision.
+# For further details see the COPYING file
+from __future__ import absolute_import
+
+import argparse
+
+from . import Command, registerCommand
+from .globals import SearchCommand
+
+MODE = 'namedqueries'
+
+
+@registerCommand(MODE, 'select', arguments=[
+    (['filt'], {'nargs': argparse.REMAINDER,
+                'help': 'additional filter to apply to query'}),
+])
+class NamedqueriesSelectCommand(Command):
+
+    """search for messages with selected query"""
+    def __init__(self, filt=None, **kwargs):
+        self._filt = filt
+        Command.__init__(self, **kwargs)
+
+    def apply(self, ui):
+        query_name = ui.current_buffer.get_selected_query()
+        query = ['query:"%s"' % query_name]
+        if self._filt:
+            query.extend(['and'] + self._filt)
+
+        cmd = SearchCommand(query=query)
+        ui.apply_command(cmd)

--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -305,6 +305,36 @@ class DBManager(object):
         db = Database(path=self.path)
         return [t for t in db.get_all_tags()]
 
+    def set_named_query(self, name, query):
+        """
+        Save a new named query.
+        :param name: the name of the query, without the `query.` prefix.
+        :param query: the query as str, empty to delete the query
+        """
+        db = Database(path=self.path)
+        try:
+            db.set_config('query.{}'.format(name), query)
+        except NotmuchError:
+            raise DatabaseError('Error when setting the query: `%s`' % query)
+
+    def get_named_query(self, name):
+        """
+        returns the named query, or an empty string, if it doesn't exist.
+        :param name: the name of the query
+        :rtype: str
+        """
+        db = Database(path=self.path)
+        return db.get_config('query.{}'.format(name))
+
+    def list_named_queries(self):
+        """
+        returns the names of all named queries stored in the database without
+        the `query.` prefix.
+        :rtype: list of query names
+        """
+        db = Database(path=self.path)
+        return [k.split('query.', 1)[1] for k, _ in db.get_configs('query.')]
+
     def async(self, cbl, fun):
         """
         return a pair (pipe, process) so that the process writes

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -152,6 +152,12 @@ thread_statusbar = mixed_list(string, string, default=list('[{buffer_no}: thread
 # that will be substituted accordingly.
 taglist_statusbar = mixed_list(string, string, default=list('[{buffer_no}: taglist]','{input_queue} total messages: {total_messages}'))
 
+# Format of the status-bar in named query list mode.
+# This is a pair of strings to be left and right aligned in the status-bar.
+# These strings may contain variables listed at :ref:`bufferlist_statusbar <bufferlist-statusbar>`
+# that will be substituted accordingly.
+namedqueries_statusbar = mixed_list(string, string, default=list('[{buffer_no}: namedqueries]','{query_count} named queries'))
+
 # Format of the status-bar in envelope mode.
 # This is a pair of strings to be left and right aligned in the status-bar.
 # Apart from the global variables listed at :ref:`bufferlist_statusbar <bufferlist-statusbar>`

--- a/alot/defaults/default.bindings
+++ b/alot/defaults/default.bindings
@@ -58,6 +58,9 @@ q = exit
 [taglist]
     enter = select
 
+[namedqueries]
+    enter = select
+
 [thread]
     enter = select
     C = fold *

--- a/alot/defaults/default.theme
+++ b/alot/defaults/default.theme
@@ -24,6 +24,10 @@
     line_focus = 'standout','','yellow','light gray','#ff8','g58'
     line_even = 'default','','light gray','black','default','g3'
     line_odd = 'default','','light gray','black','default','default'
+[namedqueries]
+    line_focus = 'standout','','yellow','light gray','#ff8','g58'
+    line_even = 'default','','light gray','black','default','g3'
+    line_odd = 'default','','light gray','black','default','default'
 [thread]
     arrow_heads = '','','dark red','','#a00',''
     arrow_bars = '','','dark red','','#800',''

--- a/alot/defaults/theme.spec
+++ b/alot/defaults/theme.spec
@@ -22,6 +22,10 @@
     line_focus = attrtriple
     line_even = attrtriple
     line_odd = attrtriple
+[namedqueries]
+    line_focus = attrtriple
+    line_even = attrtriple
+    line_odd = attrtriple
 [search]
     [[threadline]]
         normal = attrtriple

--- a/alot/widgets/namedqueries.py
+++ b/alot/widgets/namedqueries.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# This file is released under the GNU GPL, version 3 or a later revision.
+# For further details see the COPYING file
+
+"""
+Widgets specific to Namedqueries mode
+"""
+from __future__ import absolute_import
+
+import urwid
+
+
+class QuerylineWidget(urwid.Columns):
+    def __init__(self, query, count, count_unread):
+        self.query = query
+
+        count_widget = urwid.Text('{0:>7} {1:7}'.\
+                format(count, '({0})'.format(count_unread)))
+        name_widget = urwid.Text(query)
+
+        urwid.Columns.__init__(self, (count_widget, name_widget),
+                               dividechars=1)
+
+    def selectable(self):
+        return True
+
+    def keypress(self, size, key):
+        return key
+
+    def get_query(self):
+        return self.query

--- a/docs/source/api/commands.rst
+++ b/docs/source/api/commands.rst
@@ -73,6 +73,12 @@ Taglist
 .. automodule:: alot.commands.taglist
   :members:
 
+Querylist
+---------
+
+.. automodule:: alot.commands.namedqueries
+  :members:
+
 Thread
 --------
 

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -391,6 +391,19 @@
     :default: True
 
 
+.. _namedqueries-statusbar:
+
+.. describe:: namedqueries_statusbar
+
+     Format of the status-bar in named query list mode.
+     This is a pair of strings to be left and right aligned in the status-bar.
+     These strings may contain variables listed at :ref:`bufferlist_statusbar <bufferlist-statusbar>`
+     that will be substituted accordingly.
+
+    :type: mixed_list
+    :default: [{buffer_no}: namedqueries], {query_count} named queries
+
+
 .. _notify-timeout:
 
 .. describe:: notify_timeout

--- a/docs/source/usage/commands.rst
+++ b/docs/source/usage/commands.rst
@@ -23,6 +23,8 @@ See the sections below for which commands are available in which (UI) mode.
     commands while listing active buffers
 :doc:`modes/taglist`
     commands while listing all tagstrings present in the notmuch database
+:doc:`modes/namedqueries`
+    commands while listing named queries present in the notmuch database
 
 .. toctree::
    :maxdepth: 2
@@ -34,4 +36,5 @@ See the sections below for which commands are available in which (UI) mode.
    modes/envelope
    modes/bufferlist
    modes/taglist
+   modes/namedqueries
 

--- a/docs/source/usage/modes/global.rst
+++ b/docs/source/usage/modes/global.rst
@@ -97,6 +97,15 @@ The following commands are available globally
         :---thread: run in separate thread.
         :---refocus: refocus current buffer after command has finished.
 
+.. _cmd.global.namedqueries:
+
+.. describe:: namedqueries
+
+    opens named queries buffer
+
+    optional arguments
+        :---queries: named queries to display.
+
 .. _cmd.global.refresh:
 
 .. describe:: refresh

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
             ['alot = alot.__main__:main'],
     },
     install_requires=[
-        'notmuch>=0.13',
+        'notmuch>=0.26',
         'urwid>=1.3.0',
         'urwidtrees>=1.0',
         'twisted>=10.2.0',

--- a/tests/settings/theme_test.py
+++ b/tests/settings/theme_test.py
@@ -36,6 +36,10 @@ DUMMY_THEME = """\
     line_even = '', '', '', '', '', ''
     line_focus = '', '', '', '', '', ''
     line_odd = '', '', '', '', '', ''
+[namedqueries]
+    line_even = '', '', '', '', '', ''
+    line_focus = '', '', '', '', '', ''
+    line_odd = '', '', '', '', '', ''
 [search]
     focus = '', '', '', '', '', ''
     normal = '', '', '', '', '', ''


### PR DESCRIPTION
Slightly polished patches from Julian, as he said in #1011 he has no time for them. The changes done by myself are:
- to avoid confusion between "query" (any notmuch search), "saved search" (a notmuch-emacs feature which this intends to mimic) and "named query" (the official notmuch name for this), I tried to consistently use the "named query" terminology everywhere.
- slightly fancier formatting of the buffer, displaying the number of messages (total and unread)

There are of course plenty other possible improvements, but I think this can be useful enough as it is.