### PR TITLE
RFC: Add message subject to the message summary widget.

### DIFF
--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -58,9 +58,14 @@ class MessageSummaryWidget(urwid.WidgetWrap):
         urwid.WidgetWrap.__init__(self, line)
 
     def __str__(self):
+        mail = self.message.get_email()
+
+        subj = mail.get_all('subject', [''])
+        subj = ','.join([decode_header(s, normalize = True) for s in subj])
+
         author, address = self.message.get_author()
         date = self.message.get_datestring()
-        rep = author if author != '' else address
+        rep = '%s: %s' % (author if author != '' else address, subj)
         if date is not None:
             rep += " (%s)" % date
         return rep


### PR DESCRIPTION
Currently, the folded message summary in thread mode only displays the sender and the date. In threads with many different subjects (such as patch series sent with git-send-email) it is very useful to see the subject as well. I've used this patch in my local tree for quite a while and would like to hear opinions on upstreaming it.

Some possible tweaks:
- make it configurable?
- only show the subject when it's different from the thread subject (perhaps also filtering out the "Re:"s at the beginning)?