### PR TITLE
Run tests with python3 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ python:
   # We can add more version strings here when we support other python
   # versions.
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
 
@@ -34,8 +32,6 @@ env:
 # python version 2.7 above.
 jobs:
   allow_failures:
-    - python: "3.3"
-    - python: "3.4"
     - python: "3.5"
     - python: "3.6"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,26 @@ python:
   # We can add more version strings here when we support other python
   # versions.
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 
 # We start two containers in parallel, one to check and build the docs and the
 # other to run the test suite.
 env:
   - JOB=docs
   - JOB=tests
+
+# Until the switch to python3 is complete we allow the tests to fail with
+# python3.  When merging a working python3 version wen can remove this and the
+# python version 2.7 above.
+jobs:
+  allow_failures:
+    - python: "3.3"
+    - python: "3.4"
+    - python: "3.5"
+    - python: "3.6"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,11 @@ python:
 # We start two containers in parallel, one to check and build the docs and the
 # other to run the test suite.
 env:
-  - JOB=docs
   - JOB=tests
+  # This job is temporarily included in the build matrix directly in order to
+  # only check the docs on python2 for now.  When we finished switching to
+  # python3 we can put this back here and remove matrix.include.
+  #- JOB=docs
 
 # Until the switch to python3 is complete we allow the tests to fail with
 # python3.  When merging a working python3 version wen can remove this and the
@@ -35,6 +38,14 @@ jobs:
     - python: "3.4"
     - python: "3.5"
     - python: "3.6"
+
+# Check the docs only on python2 until we really support python3.  See "env"
+# above and
+# https://docs.travis-ci.com/user/customizing-the-build/#Explicitly-Including-Jobs
+matrix:
+  include:
+    - python: 2.7
+      env: JOB=docs
 
 addons:
   apt:


### PR DESCRIPTION
This is designed to *not break* even though we do not yet support py3.  One can mark travis jobs as "allowed failures".   As such it can be merged right now even before any actual porting to py3 has happend.

With this we can track the move to py3 on travis and it hopefully helps with #1055.