### PR TITLE
Lift version requirement to run tests on travis (prep for #1055)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,5 @@ setup(
     ],
     provides=['alot'],
     test_suite="tests",
-    python_requires=">=2.7,<3.0",
+    python_requires=">=2.7",
 )


### PR DESCRIPTION
Otherwise the tests will not be run with py3 on travis.  With this we can hopefully see which tests pass with #1055.  Currently the tests abort with a warning about this version requirement.

All other updates to the setup and travis file can come after #1055.