### PR TITLE
CompleteEdit: go up when the up key is pressed

### DIFF
--- a/alot/widgets/globals.py
+++ b/alot/widgets/globals.py
@@ -167,7 +167,7 @@ class CompleteEdit(urwid.Edit):
                 if self.historypos is None:
                     self.history.append(self.edit_text)
                     self.historypos = len(self.history) - 1
-                if key == 'cursor up':
+                if key == 'up':
                     self.historypos = (self.historypos + 1) % len(self.history)
                 else:
                     self.historypos = (self.historypos - 1) % len(self.history)


### PR DESCRIPTION
The code currently uses "cursor up", which seems wrong to me. This
corrects searching through prompt history only moving in one direction.

Fixes #1216