### PR TITLE
Tag replied passed

### DIFF
--- a/alot/account.py
+++ b/alot/account.py
@@ -208,7 +208,8 @@ class Account(object):
                  realname=None, gpg_key=None, signature=None,
                  signature_filename=None, signature_as_attachment=False,
                  sent_box=None, sent_tags=None, draft_box=None,
-                 draft_tags=None, abook=None, sign_by_default=False,
+                 draft_tags=None, replied_tags=None, passed_tags=None,
+                 abook=None, sign_by_default=False,
                  encrypt_by_default=u"none", encrypt_to_self=None,
                  case_sensitive_username=False, **_):
         sent_tags = sent_tags or []
@@ -217,6 +218,8 @@ class Account(object):
         draft_tags = draft_tags or []
         if 'draft' not in draft_tags:
             draft_tags.append('draft')
+        replied_tags = replied_tags or []
+        passed_tags = passed_tags or []
 
         self.address = Address.from_string(address, case_sensitive=case_sensitive_username)
         self.aliases = [Address.from_string(a, case_sensitive=case_sensitive_username)
@@ -233,6 +236,8 @@ class Account(object):
         self.sent_tags = sent_tags
         self.draft_box = draft_box
         self.draft_tags = draft_tags
+        self.replied_tags = replied_tags
+        self.passed_tags = passed_tags
         self.abook = abook
         # Handle encrypt_by_default in an backwards compatible way.  The
         # logging info call can later be upgraded to warning or error.

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -248,6 +248,10 @@ class SendCommand(Command):
                 cmd = commands.globals.BufferCloseCommand(self.envelope_buffer)
                 ui.apply_command(cmd)
             ui.notify('mail sent successfully')
+            if self.envelope.replied:
+                self.envelope.replied.add_tags(account.replied_tags)
+            if self.envelope.passed:
+                self.envelope.passed.add_tags(account.passed_tags)
 
             # store mail locally
             # This can raise StoreMailError

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -160,7 +160,7 @@ class ReplyCommand(Command):
             for line in self.message.accumulate_body().splitlines():
                 mailcontent += quote_prefix + line + '\n'
 
-        envelope = Envelope(bodytext=mailcontent)
+        envelope = Envelope(bodytext=mailcontent, replied=self.message)
 
         # copy subject
         subject = decode_header(mail.get('Subject', ''))
@@ -346,7 +346,7 @@ class ForwardCommand(Command):
             self.message = ui.current_buffer.get_selected_message()
         mail = self.message.get_email()
 
-        envelope = Envelope()
+        envelope = Envelope(passed=self.message)
 
         if self.inline:  # inline mode
             # set body text

--- a/alot/db/envelope.py
+++ b/alot/db/envelope.py
@@ -50,7 +50,8 @@ class Envelope(object):
 
     def __init__(
             self, template=None, bodytext=None, headers=None, attachments=None,
-            sign=False, sign_key=None, encrypt=False, tags=None):
+            sign=False, sign_key=None, encrypt=False, tags=None, replied=None,
+            passed=None):
         """
         :param template: if not None, the envelope will be initialised by
                          :meth:`parsing <parse_template>` this string before
@@ -64,6 +65,10 @@ class Envelope(object):
         :type attachments: list of :class:`~alot.db.attachment.Attachment`
         :param tags: tags to add after successful sendout and saving this msg
         :type tags: list of str
+        :param replied: message being replied to
+        :type replied: :class:`~alot.db.message.Message`
+        :param passed: message being passed on
+        :type replied: :class:`~alot.db.message.Message`
         """
         logging.debug('TEMPLATE: %s', template)
         if template:
@@ -80,6 +85,8 @@ class Envelope(object):
         self.encrypt = encrypt
         self.encrypt_keys = {}
         self.tags = tags or []  # tags to add after successful sendout
+        self.replied = replied  # message being replied to
+        self.passed = passed  # message being passed on
         self.sent_time = None
         self.modified_since_sent = False
         self.sending = False  # semaphore to avoid accidental double sendout

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -324,6 +324,9 @@ thread_focus_linewise = boolean(default=True)
         # list of tags to automatically add to outgoing messages
         sent_tags = force_list(default='sent')
 
+        # list of tags to automatically add to draft messages
+        draft_tags = force_list(default='draft')
+
         # path to signature file that gets attached to all outgoing mails from this account, optionally
         # renamed to :ref:`signature_filename <signature-filename>`.
         signature = string(default=None)

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -322,7 +322,7 @@ thread_focus_linewise = boolean(default=True)
         draft_box = mail_container(default=None)
 
         # list of tags to automatically add to outgoing messages
-        sent_tags = force_list(default=list('sent'))
+        sent_tags = force_list(default='sent')
 
         # path to signature file that gets attached to all outgoing mails from this account, optionally
         # renamed to :ref:`signature_filename <signature-filename>`.

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -327,6 +327,12 @@ thread_focus_linewise = boolean(default=True)
         # list of tags to automatically add to draft messages
         draft_tags = force_list(default='draft')
 
+        # list of tags to automatically add to replied messages
+        replied_tags = force_list(default='replied')
+
+        # list of tags to automatically add to passed messages
+        passed_tags = force_list(default='passed')
+
         # path to signature file that gets attached to all outgoing mails from this account, optionally
         # renamed to :ref:`signature_filename <signature-filename>`.
         signature = string(default=None)

--- a/docs/source/configuration/accounts_table
+++ b/docs/source/configuration/accounts_table
@@ -87,7 +87,7 @@
      list of tags to automatically add to outgoing messages
 
     :type: string list
-    :default: sent,
+    :default: sent
 
 
 .. _signature:

--- a/docs/source/configuration/accounts_table
+++ b/docs/source/configuration/accounts_table
@@ -90,6 +90,16 @@
     :default: sent
 
 
+.. _draft-tags:
+
+.. describe:: draft_tags
+
+     list of tags to automatically add to draft messages
+
+    :type: string list
+    :default: draft
+
+
 .. _signature:
 
 .. describe:: signature

--- a/docs/source/configuration/accounts_table
+++ b/docs/source/configuration/accounts_table
@@ -100,6 +100,26 @@
     :default: draft
 
 
+.. _replied-tags:
+
+.. describe:: replied_tags
+
+     list of tags to automatically add to replied messages
+
+    :type: string list
+    :default: replied
+
+
+.. _passed-tags:
+
+.. describe:: passed_tags
+
+     list of tags to automatically add to passed messages
+
+    :type: string list
+    :default: passed
+
+
 .. _signature:
 
 .. describe:: signature


### PR DESCRIPTION
These patches are meant to help the sync from  tags to maildir flags to IMAP flags for the states "replied" and "passed": make alot set those tags so that notmuch updates the maildir flags accordingly and IMAP sync software can pick them up from there.

I do think they make good defaults (just like "sent"); backwards-compatibility would require an empty tag list, though.