### PR TITLE
hooks: Add a new type of hook for getting a sending address

### DIFF
--- a/docs/source/configuration/hooks.rst
+++ b/docs/source/configuration/hooks.rst
@@ -214,3 +214,15 @@ Apart from command pre- and posthooks, the following hooks will be interpreted:
 
     :param ui: the main user interface
     :type ui: :class:`alot.ui.UI`
+
+.. py:function:: get_account(mail, ui)
+
+    Custom logic to control the account replied, forwareded, or bounched from.
+    This function must be a coroutine, either by returning a
+    :class:`twisted.internet.defer.Deferred` or by decaration as a
+    :func:`twisted.internet.defer.inlineCallbacks`.
+
+    :param mail: The message being acted on
+    :type mail: :class:`email.Message`
+    :param ui: the main user interface
+    :type ui: :class:`alot.ui.UI`


### PR DESCRIPTION
I get a good deal of mail generated by an exchange mailing list. There
is nothing in these mails to tell that they are sent to any specific
address, but I need to reply to them with a specific address, which is
not my primary. It also doesn't make sense to me to change my primary
address, since I rarely compose new mail with the address I need to
reply with in this case.

This adds a hook that is called when trying to determine which address
to reply from. This hook will be passed the email and the ui instance,
and is a coroutine (it must either return a deferred or be an
inlineCallbacks decorated callable). The later is required for the hook
to be able to use the UI for non-trivial tasks, such as prompting the
user.