### PR TITLE
provide retagprompt command in thread mode

### DIFF
--- a/alot/commands/common.py
+++ b/alot/commands/common.py
@@ -9,13 +9,16 @@ from .globals import PromptCommand
 
 class RetagPromptCommand(Command):
 
-    """prompt to retag selected threads\' tags"""
+    """prompt to retag selected thread's or message's tags"""
     def apply(self, ui):
-        thread = ui.current_buffer.get_selected_thread()
-        if not thread:
+        get_selected_item = getattr(ui.current_buffer, {
+                'search': 'get_selected_thread',
+                'thread': 'get_selected_message'}[ui.mode])
+        item = get_selected_item()
+        if not item:
             return
         tags = []
-        for tag in thread.get_tags():
+        for tag in item.get_tags():
             if ' ' in tag:
                 tags.append('"%s"' % tag)
             # skip empty tags

--- a/alot/commands/common.py
+++ b/alot/commands/common.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# This file is released under the GNU GPL, version 3 or a later revision.
+# For further details see the COPYING file
+
+from . import Command
+
+from .globals import PromptCommand
+
+
+class RetagPromptCommand(Command):
+
+    """prompt to retag selected threads\' tags"""
+    def apply(self, ui):
+        thread = ui.current_buffer.get_selected_thread()
+        if not thread:
+            return
+        tags = []
+        for tag in thread.get_tags():
+            if ' ' in tag:
+                tags.append('"%s"' % tag)
+            # skip empty tags
+            elif tag:
+                tags.append(tag)
+        initial_tagstring = ','.join(sorted(tags)) + ','
+        return ui.apply_command(PromptCommand('retag ' + initial_tagstring))

--- a/alot/commands/search.py
+++ b/alot/commands/search.py
@@ -7,6 +7,7 @@ import logging
 from . import Command, registerCommand
 from .globals import PromptCommand
 from .globals import MoveCommand
+from .common import RetagPromptCommand
 from .. import commands
 
 from .. import buffers
@@ -91,23 +92,7 @@ class RefinePromptCommand(Command):
         return ui.apply_command(PromptCommand('refine ' + oldquery))
 
 
-@registerCommand(MODE, 'retagprompt')
-class RetagPromptCommand(Command):
-
-    """prompt to retag selected threads\' tags"""
-    def apply(self, ui):
-        thread = ui.current_buffer.get_selected_thread()
-        if not thread:
-            return
-        tags = []
-        for tag in thread.get_tags():
-            if ' ' in tag:
-                tags.append('"%s"' % tag)
-            # skip empty tags
-            elif tag:
-                tags.append(tag)
-        initial_tagstring = ','.join(sorted(tags)) + ','
-        return ui.apply_command(PromptCommand('retag ' + initial_tagstring))
+RetagPromptCommand = registerCommand(MODE, 'retagprompt')(RetagPromptCommand)
 
 
 @registerCommand(

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -21,6 +21,7 @@ from .globals import FlushCommand
 from .globals import ComposeCommand
 from .globals import MoveCommand
 from .globals import CommandCanceled
+from .common import RetagPromptCommand
 from .envelope import SendCommand
 from ..completion import ContactsCompleter, PathCompleter
 from ..db.utils import decode_header
@@ -1078,6 +1079,9 @@ class ThreadSelectCommand(Command):
             ui.apply_command(OpenAttachmentCommand(focus.get_attachment()))
         else:
             ui.apply_command(ChangeDisplaymodeCommand(visible='toggle'))
+
+
+RetagPromptCommand = registerCommand(MODE, 'retagprompt')(RetagPromptCommand)
 
 
 @registerCommand(

--- a/docs/source/usage/modes/search.rst
+++ b/docs/source/usage/modes/search.rst
@@ -51,7 +51,7 @@ The following commands are available in search mode
 
 .. describe:: retagprompt
 
-    prompt to retag selected threads' tags
+    prompt to retag selected thread's or message's tags
 
 
 .. _cmd.search.select:

--- a/docs/source/usage/modes/thread.rst
+++ b/docs/source/usage/modes/thread.rst
@@ -125,6 +125,13 @@ The following commands are available in thread mode
         :---all: tag all messages in thread.
         :---no-flush: postpone a writeout to the index (Defaults to: 'True').
 
+.. _cmd.thread.retagprompt:
+
+.. describe:: retagprompt
+
+    prompt to retag selected thread's or message's tags
+
+
 .. _cmd.thread.save:
 
 .. describe:: save


### PR DESCRIPTION
retagprompt in search mode allows to retag a whole thread. The new
thread mode version allows to do the same for each selected message.