### PR TITLE
envelope: Update encryption keys when CC, To, or From is changed

### DIFF
--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -418,12 +418,19 @@ class SetCommand(Command):
         self.reset = not append
         Command.__init__(self, **kwargs)
 
+    @inlineCallbacks
     def apply(self, ui):
         envelope = ui.current_buffer.envelope
         if self.reset:
             if self.key in envelope:
                 del envelope[self.key]
         envelope.add(self.key, self.value)
+        # FIXME: handle BCC as well
+        # Currently we don't handle bcc because it creates a side channel leak,
+        # as the key of the person BCC'd will be available to other recievers,
+        # defeating the purpose of BCCing them
+        if self.key.lower() in ['to', 'from', 'cc']:
+            yield utils.set_encrypt(ui, ui.current_buffer.envelope)
         ui.current_buffer.rebuild()
 
 
@@ -439,8 +446,15 @@ class UnsetCommand(Command):
         self.key = key
         Command.__init__(self, **kwargs)
 
+    @inlineCallbacks
     def apply(self, ui):
         del ui.current_buffer.envelope[self.key]
+        # FIXME: handle BCC as well
+        # Currently we don't handle bcc because it creates a side channel leak,
+        # as the key of the person BCC'd will be available to other recievers,
+        # defeating the purpose of BCCing them
+        if self.key.lower() in ['to', 'from', 'cc']:
+            yield utils.set_encrypt(ui, ui.current_buffer.envelope)
         ui.current_buffer.rebuild()
 
 

--- a/alot/commands/utils.py
+++ b/alot/commands/utils.py
@@ -46,7 +46,7 @@ def set_encrypt(ui, envelope, block_error=False, signed_only=False):
     keys = yield _get_keys(ui, encrypt_keys, block_error=block_error,
                            signed_only=signed_only)
     if keys:
-        envelope.encrypt_keys.update(keys)
+        envelope.encrypt_keys = keys
         envelope.encrypt = True
 
         if 'From' in envelope.headers:


### PR DESCRIPTION
Currently the encryption keys will only be updated when they are
toggled, which means that if you change a Cc or To then the keys
encrypted to might be wrong, either too many keys will be encrypted to,
or not enough, or just the wrong ones.

This patches fixes this by calling set_encrypt whenever the 'To', 'Cc',
or 'From' headers are changed by set or unset.

Fixes #1227