### PR TITLE
crypto: Use session-key to decrypt messages if present in the index

### DIFF
--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -54,6 +54,11 @@ class Message(object):
         self._attachments = None  # will be read upon first use
         self._tags = set(msg.get_tags())
 
+        self._session_keys = []
+        for name, value in msg.get_properties("session-key", exact=True):
+            if name == "session-key":
+                self._session_keys.append(value)
+
         try:
             sender = decode_header(msg.get_header('From'))
             if not sender:
@@ -102,7 +107,8 @@ class Message(object):
         if not self._email:
             try:
                 with open(path, 'rb') as f:
-                    self._email = utils.decrypted_message_from_bytes(f.read())
+                    self._email = utils.decrypted_message_from_bytes(
+                            f.read(), self._session_keys)
             except IOError:
                 self._email = email.message_from_string(
                     warning, policy=email.policy.SMTP)

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
             ['alot = alot.__main__:main'],
     },
     install_requires=[
-        'notmuch>=0.26',
+        'notmuch>=0.27',
         'urwid>=1.3.0',
         'urwidtrees>=1.0',
         'twisted>=10.2.0',

--- a/tests/db/message_test.py
+++ b/tests/db/message_test.py
@@ -57,6 +57,9 @@ class MockNotmuchMessage(object):
     def get_tags(self):
         return self.mock_tags
 
+    def get_properties(self, prop, exact=False):
+        return []
+
 
 class TestMessage(unittest.TestCase):
 


### PR DESCRIPTION
notmuch caches the OpenPGP session keys if configured to do so. See
index.decrypt on:
https://notmuchmail.org/manpages/notmuch-config-1/

Using the cached session key decryption of messages can be done without
the need of having the private OpenPGP key. There is some speed up on
decryption, mostly notable on long encrypted threads.

---

This depends on a feature that hasn't being released yet:
https://git.notmuchmail.org/git?p=notmuch;a=commit;h=5e05f00fe59d2f2d7dceadefaab30bcc12b0e8df

Not sure how is this normally handled here. Should we wait for the release to merge it? Should we do a pull-req to develop or another branch? Do we need to wait certain time after the release of the feature on notmuch? Do you prefer me to close it now and open it once the time is right?