### PR TITLE
Remove old __future__ imports

### DIFF
--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import argparse
 import logging
 import os

--- a/alot/account.py
+++ b/alot/account.py
@@ -3,8 +3,6 @@
 # Copyright © 2017 Dylan Baker
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import abc
 import glob
 import logging

--- a/alot/addressbook/__init__.py
+++ b/alot/addressbook/__init__.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2015  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import re
 import abc
 

--- a/alot/addressbook/abook.py
+++ b/alot/addressbook/abook.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2015  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import os
 from . import AddressBook
 from ..settings.utils import read_config

--- a/alot/addressbook/external.py
+++ b/alot/addressbook/external.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2015  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import re
 
 from ..helper import call_cmd

--- a/alot/buffers.py
+++ b/alot/buffers.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import logging
 import os
 

--- a/alot/commands/__init__.py
+++ b/alot/commands/__init__.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import argparse
 import glob
 import logging

--- a/alot/commands/bufferlist.py
+++ b/alot/commands/bufferlist.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 from ..commands import Command, registerCommand
 from . import globals
 

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import argparse
 import datetime
 import email

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -1,9 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-from __future__ import division
-
 import argparse
 import code
 import email

--- a/alot/commands/search.py
+++ b/alot/commands/search.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import argparse
 import logging
 

--- a/alot/commands/taglist.py
+++ b/alot/commands/taglist.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 from . import Command, registerCommand
 from .globals import SearchCommand
 

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import argparse
 import logging
 import mailcap

--- a/alot/commands/utils.py
+++ b/alot/commands/utils.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2015  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import re
 import logging
 

--- a/alot/completion.py
+++ b/alot/completion.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import abc
 import argparse
 import email.utils

--- a/alot/crypto.py
+++ b/alot/crypto.py
@@ -2,8 +2,6 @@
 # Copyright © 2017-2018 Dylan Baker <dylan@pnwbakers.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import gpg
 
 from .errors import GPGProblem, GPGCode

--- a/alot/db/__init__.py
+++ b/alot/db/__init__.py
@@ -1,9 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-
-from __future__ import absolute_import
-
 from .thread import Thread
 from .message import Message
 DB_ENC = 'UTF-8'

--- a/alot/db/attachment.py
+++ b/alot/db/attachment.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import os
 import tempfile
 import email.charset as charset

--- a/alot/db/envelope.py
+++ b/alot/db/envelope.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import glob
 import logging
 import os

--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 from collections import deque
 import errno
 import logging

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import email
 import email.charset as charset
 import functools

--- a/alot/db/thread.py
+++ b/alot/db/thread.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 from datetime import datetime
 
 from .message import Message

--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -3,8 +3,6 @@
 # Copyright © 2017 Dylan Baker <dylan@pnwbakers.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import os
 import email
 import email.charset as charset

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -3,9 +3,6 @@
 # Copyright © 2017 Dylan Baker
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-from __future__ import division
-
 from datetime import timedelta
 from datetime import datetime
 from collections import deque

--- a/alot/settings/const.py
+++ b/alot/settings/const.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 from .manager import SettingsManager
 
 settings = SettingsManager()

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import imp
 import itertools
 import logging

--- a/alot/settings/theme.py
+++ b/alot/settings/theme.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import os
 
 from ..utils import configobj as checks

--- a/alot/settings/utils.py
+++ b/alot/settings/utils.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import logging
 
 from configobj import (ConfigObj, ConfigObjError, flatten_errors,

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import logging
 import os
 import signal

--- a/alot/utils/argparse.py
+++ b/alot/utils/argparse.py
@@ -17,8 +17,6 @@
 
 """Custom extensions of the argparse module."""
 
-from __future__ import absolute_import
-
 import argparse
 import collections
 import functools

--- a/alot/utils/configobj.py
+++ b/alot/utils/configobj.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import mailbox
 import re
 from urllib.parse import urlparse

--- a/alot/walker.py
+++ b/alot/walker.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import logging
 import urwid
 

--- a/alot/widgets/bufferlist.py
+++ b/alot/widgets/bufferlist.py
@@ -5,8 +5,6 @@
 """
 Widgets specific to Bufferlist mode
 """
-from __future__ import absolute_import
-
 import urwid
 
 

--- a/alot/widgets/globals.py
+++ b/alot/widgets/globals.py
@@ -5,8 +5,6 @@
 """
 This contains alot-specific :class:`urwid.Widget` used in more than one mode.
 """
-from __future__ import absolute_import
-
 import re
 import operator
 import urwid

--- a/alot/widgets/search.py
+++ b/alot/widgets/search.py
@@ -4,8 +4,6 @@
 """
 Widgets specific to search mode
 """
-from __future__ import absolute_import
-
 import urwid
 
 from ..settings.const import settings

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -4,8 +4,6 @@
 """
 Widgets specific to thread mode
 """
-from __future__ import absolute_import
-
 import logging
 import urwid
 from urwidtrees import Tree, SimpleTree, CollapsibleTree

--- a/alot/widgets/utils.py
+++ b/alot/widgets/utils.py
@@ -5,8 +5,6 @@
 """
 Utility Widgets not specific to alot
 """
-from __future__ import absolute_import
-
 import urwid
 
 

--- a/docs/source/api/conf.py
+++ b/docs/source/api/conf.py
@@ -11,8 +11,6 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-from __future__ import absolute_import
-
 import sys, os
 
 ###############################

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 # alot documentation build configuration file
-from __future__ import absolute_import
-
 import sys, os
 
 ###############################

--- a/docs/source/generate_commands.py
+++ b/docs/source/generate_commands.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import argparse
 import sys
 import os

--- a/docs/source/generate_configs.py
+++ b/docs/source/generate_configs.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import sys
 import os
 import re

--- a/extra/colour_picker.py
+++ b/extra/colour_picker.py
@@ -32,10 +32,7 @@
 Palette test.  Shows the available foreground and background settings
 in monochrome, 16 color, 88 color and 256 color modes.
 """
-from __future__ import absolute_import
-
 import re
-import sys
 
 import urwid
 import urwid.raw_display

--- a/tests/addressbook/abook_test.py
+++ b/tests/addressbook/abook_test.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2017  Lucas Hoffmann
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import os
 import tempfile
 import unittest

--- a/tests/addressbook/external_test.py
+++ b/tests/addressbook/external_test.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2017  Lucas Hoffmann
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import unittest
 
 import mock

--- a/tests/addressbook/init_test.py
+++ b/tests/addressbook/init_test.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2017  Lucas Hoffmann
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import unittest
 
 from alot import addressbook

--- a/tests/commands/envelope_test.py
+++ b/tests/commands/envelope_test.py
@@ -16,7 +16,6 @@
 
 """Tests for the alot.commands.envelope module."""
 
-from __future__ import absolute_import
 import contextlib
 import email
 import os

--- a/tests/commands/global_test.py
+++ b/tests/commands/global_test.py
@@ -16,7 +16,6 @@
 
 """Tests for global commands."""
 
-from __future__ import absolute_import
 import os
 import tempfile
 

--- a/tests/commands/init_test.py
+++ b/tests/commands/init_test.py
@@ -2,8 +2,6 @@
 
 """Test suite for alot.commands.__init__ module."""
 
-from __future__ import absolute_import
-
 import argparse
 import unittest
 

--- a/tests/commands/thread_test.py
+++ b/tests/commands/thread_test.py
@@ -4,8 +4,6 @@
 # For further details see the COPYING file
 
 """Test suite for alot.commands.thread module."""
-from __future__ import absolute_import
-
 import email
 import unittest
 

--- a/tests/commands/utils_tests.py
+++ b/tests/commands/utils_tests.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
 import tempfile
 import os
 import shutil

--- a/tests/completion_test.py
+++ b/tests/completion_test.py
@@ -4,8 +4,6 @@
 # For further details see the COPYING file
 
 """Tests for the alot.completion module."""
-from __future__ import absolute_import
-
 import unittest
 
 import mock

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2017 Lucas Hoffmann
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import os
 import shutil
 import signal

--- a/tests/db/envelope_test.py
+++ b/tests/db/envelope_test.py
@@ -1,6 +1,4 @@
 # encoding=utf-8
-from __future__ import absolute_import
-
 import unittest
 
 from alot.db import envelope

--- a/tests/db/message_test.py
+++ b/tests/db/message_test.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
 import unittest
 
 import mock

--- a/tests/db/thread_test.py
+++ b/tests/db/thread_test.py
@@ -15,8 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Tests for the alot.db.thread module."""
-from __future__ import absolute_import
-
 import datetime
 import unittest
 

--- a/tests/db/utils_test.py
+++ b/tests/db/utils_test.py
@@ -3,8 +3,6 @@
 # Copyright © 2017 Dylan Baker
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
-from __future__ import absolute_import
-
 import base64
 import codecs
 import email

--- a/tests/helper_test.py
+++ b/tests/helper_test.py
@@ -17,7 +17,6 @@
 
 """Test suite for alot.helper module."""
 
-from __future__ import absolute_import
 import datetime
 import email
 import errno

--- a/tests/settings/manager_test.py
+++ b/tests/settings/manager_test.py
@@ -4,8 +4,6 @@
 
 """Test suite for alot.settings.manager module."""
 
-from __future__ import absolute_import
-
 import os
 import tempfile
 import textwrap

--- a/tests/settings/theme_test.py
+++ b/tests/settings/theme_test.py
@@ -2,8 +2,6 @@
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 
-from __future__ import absolute_import
-
 import unittest
 
 from alot.settings import theme

--- a/tests/settings/utils_test.py
+++ b/tests/settings/utils_test.py
@@ -4,8 +4,6 @@
 
 """Tests for the alot.setting.utils module."""
 
-from __future__ import absolute_import
-
 import unittest
 
 import mock

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -16,8 +16,6 @@
 
 """Helpers for unittests themselves."""
 
-from __future__ import absolute_import
-
 import functools
 import unittest
 

--- a/tests/utils/argparse_test.py
+++ b/tests/utils/argparse_test.py
@@ -16,8 +16,6 @@
 
 """Tests for alot.utils.argparse"""
 
-from __future__ import absolute_import
-
 import argparse
 import contextlib
 import os

--- a/tests/utils/configobj_test.py
+++ b/tests/utils/configobj_test.py
@@ -1,6 +1,4 @@
 # encoding=utf-8
-from __future__ import absolute_import
-
 import unittest
 
 from alot.utils import configobj as checks

--- a/tests/widgets/globals_test.py
+++ b/tests/widgets/globals_test.py
@@ -16,8 +16,6 @@
 
 """Tests for the alot.widgets.globals module."""
 
-from __future__ import absolute_import
-
 import unittest
 
 import mock


### PR DESCRIPTION
The ones we had were not needed for py3 any more.