### PR TITLE
lazy reading of config files in SettingsManager

### DIFF
--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -90,20 +90,17 @@ def main():
                         filemode='w', format=logformat)
 
     # locate alot config files
+    cpath = options.config
     if options.config is None:
         xdg_dir = get_xdg_env('XDG_CONFIG_HOME',
                               os.path.expanduser('~/.config'))
         alotconfig = os.path.join(xdg_dir, 'alot', 'config')
         if os.path.exists(alotconfig):
-            settings.alot_rc_path = alotconfig
-    else:
-        settings.alot_rc_path = options.config
-
-    settings.notmuch_rc_path = options.notmuch_config
+            cpath = alotconfig
 
     try:
-        settings.read_config()
-        settings.read_notmuch_config()
+        settings.read_config(cpath)
+        settings.read_notmuch_config(options.notmuch_config)
     except (ConfigError, OSError, IOError) as e:
         print('Error when parsing a config file. '
               'See log for potential details.')

--- a/tests/commands/envelope_test.py
+++ b/tests/commands/envelope_test.py
@@ -319,7 +319,8 @@ class TestSignCommand(unittest.TestCase):
         self.addCleanup(os.unlink, f.name)
 
         # Set the gpg_key separately to avoid validation failures
-        manager = SettingsManager(alot_rc=f.name)
+        manager = SettingsManager()
+        manager.read_config(f.name)
         manager.get_accounts()[0].gpg_key = mock.sentinel.gpg_key
         return manager
 


### PR DESCRIPTION
This prevents SettingsManager from reading the config files right when it is instantiated and instead waits for the main module to call `read_[notmuch]config` with the right path.

This should prevent problems with accidentally reading the default config paths despite being told otherwise (via commandline options)