### PR TITLE
New buffer type for notmuch's named query strings

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 0.8:
 * Port to python 3. Python 2.x no longer supported
+* feature: Add a new 'namedqueries' buffer type for displaying named queries.
 
 0.7:
 * info: missing html mailcap entry now reported as mail body text

--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -17,7 +17,8 @@ from alot.commands import CommandParseError, COMMANDS
 from alot.utils import argparse as cargparse
 
 
-_SUBCOMMANDS = ['search', 'compose', 'bufferlist', 'taglist', 'pyshell']
+_SUBCOMMANDS = ['search', 'compose', 'bufferlist', 'taglist', 'namedqueries',
+                'pyshell']
 
 
 def parser():

--- a/alot/buffers/__init__.py
+++ b/alot/buffers/__init__.py
@@ -8,3 +8,4 @@ from .envelope import EnvelopeBuffer
 from .search import SearchBuffer
 from .taglist import TagListBuffer
 from .thread import ThreadBuffer
+from .namedqueries import NamedQueriesBuffer

--- a/alot/buffers/namedqueries.py
+++ b/alot/buffers/namedqueries.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2011-2018  Patrick Totzke <patricktotzke@gmail.com>
+# This file is released under the GNU GPL, version 3 or a later revision.
+# For further details see the COPYING file
+import urwid
+
+from .buffer import Buffer
+from ..settings.const import settings
+from ..widgets.namedqueries import QuerylineWidget
+
+
+class NamedQueriesBuffer(Buffer):
+    """lists named queries present in the notmuch database"""
+
+    modename = 'namedqueries'
+
+    def __init__(self, ui, filtfun):
+        self.ui = ui
+        self.filtfun = filtfun
+        self.isinitialized = False
+        self.querylist = None
+        self.rebuild()
+        Buffer.__init__(self, ui, self.body)
+
+    def rebuild(self):
+        self.queries = self.ui.dbman.get_named_queries()
+
+        if self.isinitialized:
+            focusposition = self.querylist.get_focus()[1]
+        else:
+            focusposition = 0
+
+        lines = []
+        for (num, key) in enumerate(self.queries):
+            value = self.queries[key]
+            count = self.ui.dbman.count_messages('query:"%s"' % key)
+            count_unread = self.ui.dbman.count_messages('query:"%s" and '
+                                                        'tag:unread' % key)
+            line = QuerylineWidget(key, value, count, count_unread)
+
+            if (num % 2) == 0:
+                attr = settings.get_theming_attribute('namedqueries',
+                                                      'line_even')
+            else:
+                attr = settings.get_theming_attribute('namedqueries',
+                                                      'line_odd')
+            focus_att = settings.get_theming_attribute('namedqueries',
+                                                       'line_focus')
+
+            line = urwid.AttrMap(line, attr, focus_att)
+            lines.append(line)
+
+        self.querylist = urwid.ListBox(urwid.SimpleListWalker(lines))
+        self.body = self.querylist
+
+        self.querylist.set_focus(focusposition % len(self.queries))
+
+        self.isinitialized = True
+
+    def focus_first(self):
+        """Focus the first line in the query list."""
+        self.body.set_focus(0)
+
+    def focus_last(self):
+        allpos = self.querylist.body.positions(reverse=True)
+        if allpos:
+            lastpos = allpos[0]
+            self.body.set_focus(lastpos)
+
+    def get_selected_query(self):
+        """returns selected query"""
+        return self.querylist.get_focus()[0].original_widget.query
+
+    def get_info(self):
+        info = {}
+
+        info['query_count'] = len(self.queries)
+
+        return info

--- a/alot/commands/__init__.py
+++ b/alot/commands/__init__.py
@@ -38,6 +38,7 @@ COMMANDS = {
     'envelope': {},
     'bufferlist': {},
     'taglist': {},
+    'namedqueries': {},
     'thread': {},
     'global': {},
 }

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -553,6 +553,21 @@ class TagListCommand(Command):
             ui.buffer_open(buffers.TagListBuffer(ui, tags, self.filtfun))
 
 
+@registerCommand(MODE, 'namedqueries')
+class NamedQueriesCommand(Command):
+    """opens named queries buffer"""
+    def __init__(self, filtfun=bool, **kwargs):
+        """
+        :param filtfun: filter to apply to displayed list
+        :type filtfun: callable (str->bool)
+        """
+        self.filtfun = filtfun
+        Command.__init__(self, **kwargs)
+
+    def apply(self, ui):
+        ui.buffer_open(buffers.NamedQueriesBuffer(ui, self.filtfun))
+
+
 @registerCommand(MODE, 'flush')
 class FlushCommand(Command):
 

--- a/alot/commands/namedqueries.py
+++ b/alot/commands/namedqueries.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2011-2018  Patrick Totzke <patricktotzke@gmail.com>
+# This file is released under the GNU GPL, version 3 or a later revision.
+# For further details see the COPYING file
+import argparse
+
+from . import Command, registerCommand
+from .globals import SearchCommand
+
+MODE = 'namedqueries'
+
+
+@registerCommand(MODE, 'select', arguments=[
+    (['filt'], {'nargs': argparse.REMAINDER,
+                'help': 'additional filter to apply to query'}),
+])
+class NamedqueriesSelectCommand(Command):
+
+    """search for messages with selected query"""
+    def __init__(self, filt=None, **kwargs):
+        self._filt = filt
+        Command.__init__(self, **kwargs)
+
+    def apply(self, ui):
+        query_name = ui.current_buffer.get_selected_query()
+        query = ['query:"%s"' % query_name]
+        if self._filt:
+            query.extend(['and'] + self._filt)
+
+        cmd = SearchCommand(query=query)
+        ui.apply_command(cmd)

--- a/alot/commands/search.py
+++ b/alot/commands/search.py
@@ -7,6 +7,7 @@ import logging
 from . import Command, registerCommand
 from .globals import PromptCommand
 from .globals import MoveCommand
+from .globals import SaveQueryCommand as GlobalSaveQueryCommand
 from .common import RetagPromptCommand
 from .. import commands
 
@@ -241,3 +242,24 @@ class MoveFocusCommand(MoveCommand):
             ui.update()
         else:
             MoveCommand.apply(self, ui)
+
+
+@registerCommand(
+    MODE, 'savequery',
+    arguments=[
+        (['--no-flush'], {'action': 'store_false', 'dest': 'flush',
+                          'default': 'True',
+                          'help': 'postpone a writeout to the index'}),
+        (['alias'], {'help': 'alias to use for query string'}),
+        (['query'], {'help': 'query string to store',
+                     'nargs': argparse.REMAINDER,
+                     }),
+    ],
+    help='store query string as a "named query" in the database. '
+         'This falls back to the current search query in search buffers.')
+class SaveQueryCommand(GlobalSaveQueryCommand):
+    def apply(self, ui):
+        searchbuffer = ui.current_buffer
+        if not self.query:
+            self.query = searchbuffer.querystring
+        GlobalSaveQueryCommand.apply(self, ui)

--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -152,6 +152,11 @@ class DBManager(object):
                         path = current_item[2]
                         db.remove_message(path)
 
+                    elif cmd == 'setconfig':
+                        key = current_item[2]
+                        value = current_item[3]
+                        db.set_config(key, value)
+
                     else:  # tag/set/untag
                         querystring, tags = current_item[2:]
                         query = db.create_query(querystring)
@@ -446,3 +451,36 @@ class DBManager(object):
             raise DatabaseROError()
         path = message.get_filename()
         self.writequeue.append(('remove', afterwards, path))
+
+    def save_named_query(self, alias, querystring, afterwards=None):
+        """
+        add an alias for a query string.
+
+        These are stored in the notmuch database and can be used as part of
+        more complex queries using the syntax "query:alias".
+        See :manpage:`notmuch-search-terms(7)` for more info.
+
+        :param alias: name of shortcut
+        :type alias: str
+        :param querystring: value, i.e., the full query string
+        :type querystring: str
+        :param afterwards: callback to trigger after adding the alias
+        :type afterwards: callable or None
+        """
+        if self.ro:
+            raise DatabaseROError()
+        self.writequeue.append(('setconfig', afterwards, 'query.' + alias,
+                                querystring))
+
+    def remove_named_query(self, alias, afterwards=None):
+        """
+        remove a named query from the notmuch database.
+
+        :param alias: name of shortcut
+        :type alias: str
+        :param afterwards: callback to trigger after adding the alias
+        :type afterwards: callable or None
+        """
+        if self.ro:
+            raise DatabaseROError()
+        self.writequeue.append(('setconfig', afterwards, 'query.' + alias, ''))

--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -298,6 +298,14 @@ class DBManager(object):
         db = Database(path=self.path)
         return [t for t in db.get_all_tags()]
 
+    def get_named_queries(self):
+        """
+        returns the named queries stored in the database.
+        :rtype: dict (str -> str) mapping alias to full query string
+        """
+        db = Database(path=self.path)
+        return {k[6:]: v for k, v in db.get_configs('query.')}
+
     def async(self, cbl, fun):
         """
         return a pair (pipe, process) so that the process writes

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -152,6 +152,12 @@ thread_statusbar = mixed_list(string, string, default=list('[{buffer_no}: thread
 # that will be substituted accordingly.
 taglist_statusbar = mixed_list(string, string, default=list('[{buffer_no}: taglist]','{input_queue} total messages: {total_messages}'))
 
+# Format of the status-bar in named query list mode.
+# This is a pair of strings to be left and right aligned in the status-bar.
+# These strings may contain variables listed at :ref:`bufferlist_statusbar <bufferlist-statusbar>`
+# that will be substituted accordingly.
+namedqueries_statusbar = mixed_list(string, string, default=list('[{buffer_no}: namedqueries]','{query_count} named queries'))
+
 # Format of the status-bar in envelope mode.
 # This is a pair of strings to be left and right aligned in the status-bar.
 # Apart from the global variables listed at :ref:`bufferlist_statusbar <bufferlist-statusbar>`

--- a/alot/defaults/default.bindings
+++ b/alot/defaults/default.bindings
@@ -58,6 +58,9 @@ q = exit
 [taglist]
     enter = select
 
+[namedqueries]
+    enter = select
+
 [thread]
     enter = select
     C = fold *

--- a/alot/defaults/default.theme
+++ b/alot/defaults/default.theme
@@ -24,6 +24,10 @@
     line_focus = 'standout','','yellow','light gray','#ff8','g58'
     line_even = 'default','','light gray','black','default','g3'
     line_odd = 'default','','light gray','black','default','default'
+[namedqueries]
+    line_focus = 'standout','','yellow','light gray','#ff8','g58'
+    line_even = 'default','','light gray','black','default','g3'
+    line_odd = 'default','','light gray','black','default','default'
 [thread]
     arrow_heads = '','','dark red','','#a00',''
     arrow_bars = '','','dark red','','#800',''

--- a/alot/defaults/theme.spec
+++ b/alot/defaults/theme.spec
@@ -22,6 +22,10 @@
     line_focus = attrtriple
     line_even = attrtriple
     line_odd = attrtriple
+[namedqueries]
+    line_focus = attrtriple
+    line_even = attrtriple
+    line_odd = attrtriple
 [search]
     [[threadline]]
         normal = attrtriple

--- a/alot/widgets/namedqueries.py
+++ b/alot/widgets/namedqueries.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2011-2018  Patrick Totzke <patricktotzke@gmail.com>
+# This file is released under the GNU GPL, version 3 or a later revision.
+# For further details see the COPYING file
+
+"""
+Widgets specific to Namedqueries mode
+"""
+import urwid
+
+
+class QuerylineWidget(urwid.Columns):
+    def __init__(self, key, value, count, count_unread):
+        self.query = key
+
+        count_widget = urwid.Text('{0:>7} {1:7}'.\
+                format(count, '({0})'.format(count_unread)))
+        key_widget = urwid.Text(key)
+        value_widget = urwid.Text(value)
+
+        urwid.Columns.__init__(self, (key_widget, count_widget, value_widget),
+                               dividechars=1)
+
+    def selectable(self):
+        return True
+
+    def keypress(self, size, key):
+        return key
+
+    def get_query(self):
+        return self.query

--- a/docs/source/api/commands.rst
+++ b/docs/source/api/commands.rst
@@ -73,6 +73,12 @@ Taglist
 .. automodule:: alot.commands.taglist
   :members:
 
+Namedqueries
+------------
+
+.. automodule:: alot.commands.namedqueries
+  :members:
+
 Thread
 --------
 

--- a/docs/source/api/interface.rst
+++ b/docs/source/api/interface.rst
@@ -53,18 +53,19 @@ Different modes are defined by subclasses of the following base class.
 
 Available modes are:
 
-========== ========================================
-   Mode     Buffer Subclass
-========== ========================================
-search     :class:`~alot.buffers.SearchBuffer`
-thread     :class:`~alot.buffers.ThreadBuffer`
-bufferlist :class:`~alot.buffers.BufferlistBuffer`
-taglist    :class:`~alot.buffers.TagListBuffer`
-envelope   :class:`~alot.buffers.EnvelopeBuffer`
-========== ========================================
+============ ========================================
+   Mode       Buffer Subclass
+============ ========================================
+search       :class:`~alot.buffers.SearchBuffer`
+thread       :class:`~alot.buffers.ThreadBuffer`
+bufferlist   :class:`~alot.buffers.BufferlistBuffer`
+taglist      :class:`~alot.buffers.TagListBuffer`
+namedqueries :class:`~alot.buffers.NamedQueriesBuffer`
+envelope     :class:`~alot.buffers.EnvelopeBuffer`
+============ ========================================
 
 .. automodule:: alot.buffers
-    :members: BufferlistBuffer, EnvelopeBuffer,SearchBuffer,ThreadBuffer,TagListBuffer
+    :members: BufferlistBuffer, EnvelopeBuffer, NamedQueriesBuffer, SearchBuffer, ThreadBuffer, TagListBuffer
 
 Widgets
 --------

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -391,6 +391,19 @@
     :default: True
 
 
+.. _namedqueries-statusbar:
+
+.. describe:: namedqueries_statusbar
+
+     Format of the status-bar in named query list mode.
+     This is a pair of strings to be left and right aligned in the status-bar.
+     These strings may contain variables listed at :ref:`bufferlist_statusbar <bufferlist-statusbar>`
+     that will be substituted accordingly.
+
+    :type: mixed_list
+    :default: [{buffer_no}: namedqueries], {query_count} named queries
+
+
 .. _notify-timeout:
 
 .. describe:: notify_timeout

--- a/docs/source/configuration/key_bindings.rst
+++ b/docs/source/configuration/key_bindings.rst
@@ -21,11 +21,12 @@ and be able to toggle this tag in search mode, you'd add this to your config
 
 Known modes are:
 
-* envelope
-* search
-* thread
-* taglist
 * bufferlist
+* envelope
+* namedqueries
+* search
+* taglist
+* thread
 
 Have a look at `the urwid User Input documentation <http://excess.org/urwid/wiki/UserInput>`_ on how key strings are formatted.
 

--- a/docs/source/usage/cli_commands.rst
+++ b/docs/source/usage/cli_commands.rst
@@ -11,5 +11,8 @@ bufferlist
 taglist
     start with only a taglist buffer open
 
+namedqueries
+    start with list of named queries
+
 pyshell
     start the interactive python shell inside alot

--- a/docs/source/usage/commands.rst
+++ b/docs/source/usage/commands.rst
@@ -13,25 +13,28 @@ See the sections below for which commands are available in which (UI) mode.
 
 :doc:`modes/global`
     globally available commands
-:doc:`modes/search`
-    commands available when showing thread search results
-:doc:`modes/thread`
-    commands available while displaying a thread
-:doc:`modes/envelope`
-    commands during message composition
 :doc:`modes/bufferlist`
     commands while listing active buffers
+:doc:`modes/envelope`
+    commands during message composition
+:doc:`modes/namedqueries`
+    commands while listing all named queries from the notmuch database
+:doc:`modes/search`
+    commands available when showing thread search results
 :doc:`modes/taglist`
     commands while listing all tagstrings present in the notmuch database
+:doc:`modes/thread`
+    commands available while displaying a thread
 
 .. toctree::
    :maxdepth: 2
    :hidden:
 
    modes/global
-   modes/search
-   modes/thread
-   modes/envelope
    modes/bufferlist
+   modes/envelope
+   modes/namedqueries
+   modes/search
    modes/taglist
+   modes/thread
 

--- a/docs/source/usage/modes/global.rst
+++ b/docs/source/usage/modes/global.rst
@@ -117,6 +117,13 @@ The following commands are available globally
         up, down, [half]page up, [half]page down, first, last
 
 
+.. _cmd.global.namedqueries:
+
+.. describe:: namedqueries
+
+    opens named queries buffer
+
+
 .. _cmd.global.prompt:
 
 .. describe:: prompt
@@ -148,12 +155,38 @@ The following commands are available globally
     Reload all configuration files
 
 
+.. _cmd.global.removequery:
+
+.. describe:: removequery
+
+    removes a "named query" from the database
+
+    argument
+        alias to remove
+
+    optional arguments
+        :---no-flush: postpone a writeout to the index (Defaults to: 'True').
+
 .. _cmd.global.repeat:
 
 .. describe:: repeat
 
     Repeats the command executed last time
 
+
+.. _cmd.global.savequery:
+
+.. describe:: savequery
+
+    store query string as a "named query" in the database
+
+    positional arguments
+        0: alias to use for query string
+        1: query string to store
+
+
+    optional arguments
+        :---no-flush: postpone a writeout to the index (Defaults to: 'True').
 
 .. _cmd.global.search:
 

--- a/docs/source/usage/modes/namedqueries.rst
+++ b/docs/source/usage/modes/namedqueries.rst
@@ -1,0 +1,17 @@
+.. CAUTION: THIS FILE IS AUTO-GENERATED!
+
+
+Commands in `namedqueries` mode
+-------------------------------
+The following commands are available in namedqueries mode
+
+.. _cmd.namedqueries.select:
+
+.. describe:: select
+
+    search for messages with selected query
+
+    argument
+        additional filter to apply to query
+
+

--- a/docs/source/usage/modes/search.rst
+++ b/docs/source/usage/modes/search.rst
@@ -54,6 +54,20 @@ The following commands are available in search mode
     prompt to retag selected thread's or message's tags
 
 
+.. _cmd.search.savequery:
+
+.. describe:: savequery
+
+    store query string as a "named query" in the database. This falls back to the current search query in search buffers.
+
+    positional arguments
+        0: alias to use for query string
+        1: query string to store
+
+
+    optional arguments
+        :---no-flush: postpone a writeout to the index (Defaults to: 'True').
+
 .. _cmd.search.select:
 
 .. describe:: select

--- a/extra/themes/mutt
+++ b/extra/themes/mutt
@@ -21,6 +21,10 @@
     line_even = '','','light gray','black','light gray','black'
     line_odd = '','','light gray','black','light gray','black'
     line_focus = 'standout','','black','dark cyan','black','dark cyan'
+[namedqueries]
+    line_even = '','','light gray','black','light gray','black'
+    line_odd = '','','light gray','black','light gray','black'
+    line_focus = 'standout','','black','dark cyan','black','dark cyan'
 [taglist]
     line_even = '','','light gray','black','light gray','black'
     line_odd = '','','light gray','black','light gray','black'

--- a/extra/themes/solarized_dark
+++ b/extra/themes/solarized_dark
@@ -42,6 +42,10 @@ green = 'dark green'
     section = 'underline','default','%(cyan)s,bold','%(base02)s','%(cyan)s,bold','%(base02)s'
     title = 'standout','default','%(yellow)s','%(base02)s','%(yellow)s','%(base02)s'
     frame = 'standout','default','%(base1)s','%(base02)s','%(base1)s,bold','%(base02)s'
+[namedqueries]
+    line_even = 'default','default','%(base0)s','%(base02)s','%(base0)s','%(base02)s'
+    line_focus = 'standout','default','%(base1)s','%(base01)s','%(base1)s','%(base01)s'
+    line_odd = 'default','default','%(base0)s','%(base03)s','%(base0)s','%(base03)s'
 [taglist]
     line_even = 'default','default','%(base0)s','%(base02)s','%(base0)s','%(base02)s'
     line_focus = 'standout','default','%(base1)s','%(base01)s','%(base1)s','%(base01)s'

--- a/extra/themes/solarized_light
+++ b/extra/themes/solarized_light
@@ -58,6 +58,10 @@
     text = 'default','default','%(16_base00)s','%(16_base2)s','%(256_base00)s','%(256_base2)s'
     section = 'underline','default','%(16_base01)s,underline','%(16_base2)s','%(256_base01)s,underline','%(256_base2)s'
     title = 'standout','default','%(16_base01)s','%(16_base2)s','%(256_base01)s','%(256_base2)s'
+[namedqueries]
+    line_focus = 'standout','default','%(16_base2)s','%(16_yellow)s','%(256_base2)s','%(256_yellow)s'
+    line_even = 'default','default','%(16_base00)s','%(16_base3)s','%(256_base00)s','%(256_base3)s'
+    line_odd = 'default','default','%(16_base00)s','%(16_base2)s','%(256_base00)s','%(256_base2)s'
 [taglist]
     line_focus = 'standout','default','%(16_base2)s','%(16_yellow)s','%(256_base2)s','%(256_yellow)s'
     line_even = 'default','default','%(16_base00)s','%(16_base3)s','%(256_base00)s','%(256_base3)s'

--- a/extra/themes/sup
+++ b/extra/themes/sup
@@ -21,6 +21,10 @@
     line_even = '','','light gray','black','light gray','g0'
     line_odd = '','','light gray','black','light gray','g0'
     line_focus = 'standout','','black','dark cyan','black','dark cyan'
+[namedqueries]
+    line_even = '','','light gray','black','light gray','g0'
+    line_odd = '','','light gray','black','light gray','g0'
+    line_focus = 'standout','','black','dark cyan','black','dark cyan'
 [taglist]
     line_even = '','','light gray','black','light gray','g0'
     line_odd = '','','light gray','black','light gray','g0'

--- a/extra/themes/tomorrow
+++ b/extra/themes/tomorrow
@@ -71,6 +71,10 @@ error = 'dark red'
     text = 'default','default','%(16_text_fg)s','%(16_gray_bg)s','%(256_text_fg)s','%(256_gray_bg)s'
     section = 'underline','default','%(16_alternate)s,underline','%(16_gray_bg)s','%(256_alternate)s,underline','%(256_gray_bg)s'
     title = 'standout','default','%(16_alternate)s','%(16_gray_bg)s','%(256_alternate)s','%(256_gray_bg)s'
+[namedqueries]
+    line_focus = 'standout','default','%(16_focus_fg)s','%(16_focus_bg)s','%(256_focus_fg)s','%(256_focus_bg)s'
+    line_even = 'default','default','%(16_text_fg)s','%(16_normal_bg)s','%(256_text_fg)s','%(256_normal_bg)s'
+    line_odd = 'default','default','%(16_text_fg)s','%(16_normal_bg)s','%(256_text_fg)s','%(256_normal_bg)s'
 [taglist]
     line_focus = 'standout','default','%(16_focus_fg)s','%(16_focus_bg)s','%(256_focus_fg)s','%(256_focus_bg)s'
     line_even = 'default','default','%(16_text_fg)s','%(16_normal_bg)s','%(256_text_fg)s','%(256_normal_bg)s'

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
             ['alot = alot.__main__:main'],
     },
     install_requires=[
-        'notmuch>=0.13',
+        'notmuch>=0.26',
         'urwid>=1.3.0',
         'urwidtrees>=1.0',
         'twisted>=10.2.0',

--- a/tests/db/manager_test.py
+++ b/tests/db/manager_test.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2018 Patrick Totzke
+# This file is released under the GNU GPL, version 3 or a later revision.
+# For further details see the COPYING file
+
+"""Test suite for alot.db.manager module."""
+
+import tempfile
+import textwrap
+import os
+import shutil
+
+from alot.db.manager import DBManager
+from alot.settings.const import settings
+from notmuch import Database
+
+from .. import utilities
+
+
+class TestDBManager(utilities.TestCaseClassCleanup):
+
+    @classmethod
+    def setUpClass(cls):
+
+        # create temporary notmuch config
+        with tempfile.NamedTemporaryFile(mode='w+', delete=False) as f:
+            f.write(textwrap.dedent("""\
+                [maildir]
+                synchronize_flags = true
+                """))
+            cls.notmuch_config_path = f.name
+        cls.addClassCleanup(os.unlink, f.name)
+
+        # define an empty notmuch database in a temporary directory
+        cls.dbpath = tempfile.mkdtemp()
+        cls.db = Database(path=cls.dbpath, create=True)
+        cls.db.close()
+        cls.manager = DBManager(cls.dbpath)
+
+        # clean up temporary database
+        cls.addClassCleanup(cls.manager.kill_search_processes)
+        cls.addClassCleanup(shutil.rmtree, cls.dbpath)
+
+        # let global settings manager read our temporary notmuch config
+        settings.read_notmuch_config(cls.notmuch_config_path)
+
+    def test_save_named_query(self):
+        alias = 'key'
+        querystring = 'query string'
+        self.manager.save_named_query(alias, querystring)
+        self.manager.flush()
+
+        named_queries_dict = self.manager.get_named_queries()
+        self.assertDictEqual(named_queries_dict, {alias: querystring})

--- a/tests/settings/theme_test.py
+++ b/tests/settings/theme_test.py
@@ -34,6 +34,10 @@ DUMMY_THEME = """\
     line_even = '', '', '', '', '', ''
     line_focus = '', '', '', '', '', ''
     line_odd = '', '', '', '', '', ''
+[namedqueries]
+    line_even = '', '', '', '', '', ''
+    line_focus = '', '', '', '', '', ''
+    line_odd = '', '', '', '', '', ''
 [search]
     focus = '', '', '', '', '', ''
     normal = '', '', '', '', '', ''


### PR DESCRIPTION
This adds a new buffer that displays named queries similar to the taglist mode.
It so far offers only one command: select, which opens a new search buffer for the selected named query.

This is a rebased , fully splitted and refactored version of #1206, for easy review.
TODO:

- [x]  update the theme files in `alot/extra/themes`
- [x] check in auto-generated docs
- [x] add commands to manimulate named queries in this buffer
- [x] add command to save a query in search buffers
- [x] tab completion for named queries in prompts
- [ ] tests
To test this, add some named queries manually via the notmuch CLI:

```
notmuch config set query.foo "bar"
```