### PR TITLE
widgets/search: Don't try to sort an iterator

### DIFF
--- a/alot/widgets/search.py
+++ b/alot/widgets/search.py
@@ -98,13 +98,12 @@ class ThreadlineWidget(urwid.AttrMap):
 
         elif name == 'content':
             if self.thread:
-                msgs = self.thread.get_messages().keys()
+                msgs = sorted(self.thread.get_messages().keys(),
+                              key=lambda msg: msg.get_date(), reverse=True)
+                lastcontent = ' '.join(m.get_text_content() for m in msgs)
+                contentstring = pad(lastcontent.replace('\n', ' ').strip())
             else:
-                msgs = []
-            # sort the most recent messages first
-            msgs.sort(key=lambda msg: msg.get_date(), reverse=True)
-            lastcontent = ' '.join([m.get_text_content() for m in msgs])
-            contentstring = pad(lastcontent.replace('\n', ' ').strip())
+                contentstring = pad('')
             content_w = AttrFlipWidget(urwid.Text(contentstring, wrap='clip'),
                                        struct['content'])
             width = len(contentstring)


### PR DESCRIPTION
We currently call dict_keys.sort(), which doesn't work because it
doesn't exist. The whole function is kinda strange anyway, since there's
a lot of work done in general that only applies in once case.