### PR TITLE
Open signatures as binary

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -844,7 +844,7 @@ class ComposeCommand(Command):
                     self.envelope.attach(sig, filename=name)
                     logging.debug('attached')
                 else:
-                    with open(sig) as f:
+                    with open(sig, 'rb') as f:
                         sigcontent = f.read()
                     mimetype = helper.guess_mimetype(sigcontent)
                     if mimetype.startswith('text'):


### PR DESCRIPTION
Otherwise it will think that it's octet-stream and won't attach the signature.  Also use file-magic to detect the encoding, because I've had problems with chardet incorrectly identifying my signatures as ISO-8859-1.