### PR TITLE
Replace twisted with asyncio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ install:
   - |
     set -e
     if [[ $JOB = docs ]]; then
-      pip install configobj twisted python-magic urwidtrees
+      pip install configobj python-magic urwidtrees
       # Mock all "difficult" dependencies of alot in order to be able to import
       # alot when rebuilding the documentation.  Notmuch would have to be
       # installed by hand in order to get a recent enough version on travis.

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 0.8:
 * Port to python 3. Python 2.x no longer supported
 * feature: Add a new 'namedqueries' buffer type for displaying named queries.
+* feature: Replace twisted with asyncio
 
 0.7:
 * info: missing html mailcap entry now reported as mail body text

--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -6,6 +6,9 @@ import logging
 import os
 import sys
 
+from twisted.internet import asyncioreactor
+asyncioreactor.install()
+
 import alot
 from alot.settings.const import settings
 from alot.settings.errors import ConfigError

--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -6,9 +6,6 @@ import logging
 import os
 import sys
 
-from twisted.internet import asyncioreactor
-asyncioreactor.install()
-
 import alot
 from alot.settings.const import settings
 from alot.settings.errors import ConfigError

--- a/alot/buffers/search.py
+++ b/alot/buffers/search.py
@@ -2,6 +2,7 @@
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 import urwid
+from notmuch import NotmuchError
 
 from .buffer import Buffer
 from ..settings.const import settings

--- a/alot/buffers/thread.py
+++ b/alot/buffers/thread.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2011-2018  Patrick Totzke <patricktotzke@gmail.com>
+# Copyright © 2018 Dylan Baker
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
+import asyncio
 import urwid
 import logging
 from urwidtrees import ArrowTree, TreeBox, NestedTree
@@ -112,7 +114,8 @@ class ThreadBuffer(Buffer):
                         self._auto_unread_writing = True
                         msg.remove_tags(['unread'], afterwards=clear)
                         fcmd = commands.globals.FlushCommand(silent=True)
-                        self.ui.apply_command(fcmd)
+                        asyncio.get_event_loop().create_task(
+                            self.ui.apply_command(fcmd))
                     else:
                         logging.debug('Tbuffer: No, msg not unread')
                 else:

--- a/alot/commands/bufferlist.py
+++ b/alot/commands/bufferlist.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# Copyright © 2018 Dylan Baker
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 from ..commands import Command, registerCommand
@@ -18,14 +19,11 @@ class BufferFocusCommand(Command):
 @registerCommand(MODE, 'close')
 class BufferCloseCommand(Command):
     """close focussed buffer"""
-    def apply(self, ui):
+
+    async def apply(self, ui):
         bufferlist = ui.current_buffer
         selected = bufferlist.get_selected_buffer()
-        d = ui.apply_command(globals.BufferCloseCommand(buffer=selected))
-
-        def cb(_):
-            if bufferlist is not selected:
-                bufferlist.rebuild()
-            ui.update()
-        d.addCallback(cb)
-        return d
+        await ui.apply_command(globals.BufferCloseCommand(buffer=selected))
+        if bufferlist is not selected:
+            bufferlist.rebuild()
+        ui.update()

--- a/alot/commands/common.py
+++ b/alot/commands/common.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# Copyright © 2018 Dylan Baker
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 
@@ -10,7 +11,7 @@ from .globals import PromptCommand
 class RetagPromptCommand(Command):
 
     """prompt to retag selected thread's or message's tags"""
-    def apply(self, ui):
+    async def apply(self, ui):
         get_selected_item = getattr(ui.current_buffer, {
                 'search': 'get_selected_thread',
                 'thread': 'get_selected_message'}[ui.mode])
@@ -25,4 +26,5 @@ class RetagPromptCommand(Command):
             elif tag:
                 tags.append(tag)
         initial_tagstring = ','.join(sorted(tags)) + ','
-        return ui.apply_command(PromptCommand('retag ' + initial_tagstring))
+        r = await ui.apply_command(PromptCommand('retag ' + initial_tagstring))
+        return r

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -246,10 +246,11 @@ class SendCommand(Command):
                 cmd = commands.globals.BufferCloseCommand(self.envelope_buffer)
                 ui.apply_command(cmd)
             ui.notify('mail sent successfully')
-            if self.envelope.replied:
-                self.envelope.replied.add_tags(account.replied_tags)
-            if self.envelope.passed:
-                self.envelope.passed.add_tags(account.passed_tags)
+            if self.envelope is not None:
+                if self.envelope.replied:
+                    self.envelope.replied.add_tags(account.replied_tags)
+                if self.envelope.passed:
+                    self.envelope.passed.add_tags(account.passed_tags)
 
             # store mail locally
             # This can raise StoreMailError

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -11,6 +11,8 @@ import re
 import tempfile
 import textwrap
 
+from twisted.internet.defer import ensureDeferred
+
 from . import Command, registerCommand
 from . import globals
 from . import utils
@@ -279,7 +281,7 @@ class SendCommand(Command):
         clearme = ui.notify('sending..', timeout=-1)
         if self.envelope is not None:
             self.envelope.sending = True
-        d = account.send_mail(self.mail)
+        d = ensureDeferred(account.send_mail(self.mail))
         d.addCallback(afterwards)
         d.addErrback(send_errb)
         d.addErrback(store_errb)

--- a/alot/commands/namedqueries.py
+++ b/alot/commands/namedqueries.py
@@ -20,11 +20,11 @@ class NamedqueriesSelectCommand(Command):
         self._filt = filt
         Command.__init__(self, **kwargs)
 
-    def apply(self, ui):
+    async def apply(self, ui):
         query_name = ui.current_buffer.get_selected_query()
         query = ['query:"%s"' % query_name]
         if self._filt:
             query.extend(['and'] + self._filt)
 
         cmd = SearchCommand(query=query)
-        ui.apply_command(cmd)
+        await ui.apply_command(cmd)

--- a/alot/commands/search.py
+++ b/alot/commands/search.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# Copyright © 2018 Dylan Baker
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 import argparse
@@ -87,10 +88,10 @@ class RefinePromptCommand(Command):
     """prompt to change this buffers querystring"""
     repeatable = True
 
-    def apply(self, ui):
+    async def apply(self, ui):
         sbuffer = ui.current_buffer
         oldquery = sbuffer.querystring
-        return ui.apply_command(PromptCommand('refine ' + oldquery))
+        return await ui.apply_command(PromptCommand('refine ' + oldquery))
 
 
 RetagPromptCommand = registerCommand(MODE, 'retagprompt')(RetagPromptCommand)
@@ -164,7 +165,7 @@ class TagCommand(Command):
         self.flush = flush
         Command.__init__(self, **kwargs)
 
-    def apply(self, ui):
+    async def apply(self, ui):
         searchbuffer = ui.current_buffer
         threadline_widget = searchbuffer.get_selected_threadline()
         # pass if the current buffer has no selected threadline
@@ -226,7 +227,8 @@ class TagCommand(Command):
 
         # flush index
         if self.flush:
-            ui.apply_command(commands.globals.FlushCommand(callback=refresh))
+            await ui.apply_command(
+                commands.globals.FlushCommand(callback=refresh))
 
 
 @registerCommand(

--- a/alot/commands/taglist.py
+++ b/alot/commands/taglist.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2011-2012  Patrick Totzke <patricktotzke@gmail.com>
+# Copyright © 2018 Dylan Baker
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 from . import Command, registerCommand
@@ -11,7 +12,7 @@ MODE = 'taglist'
 class TaglistSelectCommand(Command):
 
     """search for messages with selected tag"""
-    def apply(self, ui):
+    async def apply(self, ui):
         tagstring = ui.current_buffer.get_selected_tag()
         cmd = SearchCommand(query=['tag:"%s"' % tagstring])
-        ui.apply_command(cmd)
+        await ui.apply_command(cmd)

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -11,7 +11,6 @@ import tempfile
 from email.utils import getaddresses, parseaddr, formataddr
 from email.message import Message
 
-from twisted.internet.defer import inlineCallbacks
 import urwid
 from io import BytesIO
 
@@ -424,8 +423,7 @@ class BounceMailCommand(Command):
         self.message = message
         Command.__init__(self, **kwargs)
 
-    @inlineCallbacks
-    def apply(self, ui):
+    async def apply(self, ui):
         # get mail to bounce
         if not self.message:
             self.message = ui.current_buffer.get_selected_message()
@@ -462,7 +460,7 @@ class BounceMailCommand(Command):
             completer = ContactsCompleter(abooks)
         else:
             completer = None
-        to = yield ui.prompt('To', completer=completer,
+        to = await ui.prompt('To', completer=completer,
                              history=ui.recipienthistory)
         if to is None:
             raise CommandCanceled()
@@ -709,8 +707,7 @@ class PipeCommand(Command):
         self.done_msg = done_msg
         self.field_key = field_key
 
-    @inlineCallbacks
-    def apply(self, ui):
+    async def apply(self, ui):
         # abort if command unset
         if not self.cmd:
             ui.notify(self.noop_msg, priority='error')
@@ -727,7 +724,7 @@ class PipeCommand(Command):
 
         # ask for confirmation if needed
         if self.confirm_msg:
-            if (yield ui.choice(self.confirm_msg, select='yes',
+            if (await ui.choice(self.confirm_msg, select='yes',
                                 cancel='no')) == 'no':
                 return
 
@@ -790,7 +787,7 @@ class PipeCommand(Command):
 
         # display 'done' message
         if self.done_msg:
-            ui.notify(self.done_msg)
+            await ui.notify(self.done_msg)
 
 
 @registerCommand(MODE, 'remove', arguments=[
@@ -808,8 +805,7 @@ class RemoveCommand(Command):
         Command.__init__(self, **kwargs)
         self.all = all
 
-    @inlineCallbacks
-    def apply(self, ui):
+    async def apply(self, ui):
         threadbuffer = ui.current_buffer
         # get messages and notification strings
         if self.all:
@@ -825,7 +821,7 @@ class RemoveCommand(Command):
             ok_msg = 'removed message: %s' % msg.get_message_id()
 
         # ask for confirmation
-        if (yield ui.choice(confirm_msg, select='yes', cancel='no')) == 'no':
+        if (await ui.choice(confirm_msg, select='yes', cancel='no')) == 'no':
             return
 
         # notify callback
@@ -907,14 +903,13 @@ class SaveAttachmentCommand(Command):
         self.all = all
         self.path = path
 
-    @inlineCallbacks
-    def apply(self, ui):
+    async def apply(self, ui):
         pcomplete = PathCompleter()
         savedir = settings.get('attachment_prefix', '~')
         if self.all:
             msg = ui.current_buffer.get_selected_message()
             if not self.path:
-                self.path = yield ui.prompt('save attachments to',
+                self.path = await ui.prompt('save attachments to',
                                             text=os.path.join(savedir, ''),
                                             completer=pcomplete)
             if self.path:
@@ -939,7 +934,7 @@ class SaveAttachmentCommand(Command):
                 if not self.path:
                     msg = 'save attachment (%s) to ' % filename
                     initialtext = os.path.join(savedir, filename)
-                    self.path = yield ui.prompt(msg,
+                    self.path = await ui.prompt(msg,
                                                 completer=pcomplete,
                                                 text=initialtext)
                 if self.path:

--- a/alot/commands/utils.py
+++ b/alot/commands/utils.py
@@ -4,16 +4,13 @@
 import re
 import logging
 
-from twisted.internet.defer import inlineCallbacks, returnValue
-
 from ..errors import GPGProblem, GPGCode
 from ..settings.const import settings
 from ..settings.errors import NoMatchingAccount
 from .. import crypto
 
 
-@inlineCallbacks
-def update_keys(ui, envelope, block_error=False, signed_only=False):
+async def update_keys(ui, envelope, block_error=False, signed_only=False):
     """Find and set the encryption keys in an envolope.
 
     :param ui: the main user interface object
@@ -41,7 +38,7 @@ def update_keys(ui, envelope, block_error=False, signed_only=False):
             encrypt_keys.append(recipient)
 
     logging.debug("encryption keys: " + str(encrypt_keys))
-    keys = yield _get_keys(ui, encrypt_keys, block_error=block_error,
+    keys = await _get_keys(ui, encrypt_keys, block_error=block_error,
                            signed_only=signed_only)
     if keys:
         envelope.encrypt_keys = keys
@@ -63,8 +60,7 @@ def update_keys(ui, envelope, block_error=False, signed_only=False):
         envelope.encrypt = False
 
 
-@inlineCallbacks
-def _get_keys(ui, encrypt_keyids, block_error=False, signed_only=False):
+async def _get_keys(ui, encrypt_keyids, block_error=False, signed_only=False):
     """Get several keys from the GPG keyring.  The keys are selected by keyid
     and are checked if they can be used for encryption.
 
@@ -93,7 +89,7 @@ def _get_keys(ui, encrypt_keyids, block_error=False, signed_only=False):
                 choices = {str(i): t for i, t in enumerate(tmp_choices, 1)}
                 keys_to_return = {str(i): t for i, t in enumerate([k for k in
                                   crypto.list_keys(hint=keyid)], 1)}
-                choosen_key = yield ui.choice("ambiguous keyid! Which " +
+                choosen_key = await ui.choice("ambiguous keyid! Which " +
                                               "key do you want to use?",
                                               choices=choices,
                                               choices_to_return=keys_to_return)
@@ -104,4 +100,4 @@ def _get_keys(ui, encrypt_keyids, block_error=False, signed_only=False):
                 ui.notify(str(e), priority='error', block=block_error)
                 continue
         keys[key.fpr] = key
-    returnValue(keys)
+    return keys

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -327,7 +327,7 @@ class UI(object):
         """
         history = history or []
 
-        d = defer.Deferred()  # create return deferred
+        fut = asyncio.Future()
         oldroot = self.mainloop.widget
 
         def select_or_cancel(text):
@@ -335,7 +335,7 @@ class UI(object):
             with the given text."""
             self.mainloop.widget = oldroot
             self._passall = False
-            d.callback(text)
+            fut.set_result(text)
 
         def cerror(e):
             logging.error(e)
@@ -371,7 +371,7 @@ class UI(object):
                                 None)
         self.mainloop.widget = overlay
         self._passall = True
-        return d  # return deferred
+        return defer.Deferred.fromFuture(fut)
 
     @staticmethod
     def exit():
@@ -556,7 +556,7 @@ class UI(object):
         assert cancel is None or cancel in choices.values()
         assert msg_position in ['left', 'above']
 
-        d = defer.Deferred()  # create return deferred
+        fut = asyncio.Future()  # Create a returned future
         oldroot = self.mainloop.widget
 
         def select_or_cancel(text):
@@ -564,7 +564,7 @@ class UI(object):
             with the given text."""
             self.mainloop.widget = oldroot
             self._passall = False
-            d.callback(text)
+            fut.set_result(text)
 
         # set up widgets
         msgpart = urwid.Text(message)
@@ -593,7 +593,7 @@ class UI(object):
                                 None)
         self.mainloop.widget = overlay
         self._passall = True
-        return d  # return deferred
+        return defer.Deferred.fromFuture(fut)
 
     def notify(self, message, priority='normal', timeout=0, block=False):
         """

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -140,20 +140,7 @@ class UI(object):
         # start urwids mainloop
         self.mainloop.run()
 
-    def _error_handler(self, failure):
-        """Default handler for exceptions in callbacks."""
-        if failure.check(CommandParseError):
-            self.notify(failure.getErrorMessage(), priority='error')
-        elif failure.check(CommandCanceled):
-            self.notify("operation cancelled", priority='error')
-        else:
-            logging.error(failure.getTraceback())
-            errmsg = failure.getErrorMessage()
-            if errmsg:
-                msg = "{}\n(check the log for details)".format(errmsg)
-                self.notify(msg, priority='error')
-
-    def _error_handler2(self, exception):
+    def _error_handler(self, exception):
         if isinstance(exception, CommandParseError):
             self.notify(str(exception), priority='error')
         elif isinstance(exception, CommandCanceled):
@@ -280,7 +267,7 @@ class UI(object):
             for c in split_commandline(cmdline):
                 await apply_this_command(c)
         except Exception as e:
-            self._error_handler2(e)
+            self._error_handler(e)
 
     @staticmethod
     def _unhandled_input(key):
@@ -723,7 +710,7 @@ class UI(object):
                 else:
                     cmd.apply(self)
             except Exception as e:
-                self._error_handler2(e)
+                self._error_handler(e)
             else:
                 if cmd.posthook:
                     logging.info('calling post-hook')

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -707,6 +707,8 @@ class UI(object):
 
             # call cmd.apply
             def call_apply(_):
+                if asyncio.iscoroutinefunction(cmd.apply):
+                    return defer.ensureDeferred(cmd.apply(self))
                 return defer.maybeDeferred(cmd.apply, self)
 
             prehook = cmd.prehook or (lambda **kwargs: None)

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -6,8 +6,9 @@ import os
 import signal
 import codecs
 import contextlib
+import asyncio
 
-from twisted.internet import reactor, defer, task
+from twisted.internet import defer, task
 import urwid
 
 from .settings.const import settings
@@ -105,7 +106,7 @@ class UI(object):
         self.mainloop = urwid.MainLoop(
             self.root_widget,
             handle_mouse=settings.get('handle_mouse'),
-            event_loop=urwid.TwistedEventLoop(),
+            event_loop=urwid.AsyncioEventLoop(),
             unhandled_input=self._unhandled_input,
             input_filter=self._input_filter)
 
@@ -359,10 +360,11 @@ class UI(object):
         """
         exit_msg = None
         try:
-            reactor.stop()
+            loop = asyncio.get_event_loop()
+            loop.stop()
         except Exception as e:
-            exit_msg = 'Could not stop reactor: {}.'.format(e)
-            logging.error('%s\nShutting down anyway..', exit_msg)
+            logging.error('Could not stop loop: %s\nShutting down anyway..',
+                          str(e))
 
     @contextlib.contextmanager
     def paused(self):

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -9,7 +9,6 @@ import contextlib
 import asyncio
 import traceback
 
-from twisted.internet import defer
 import urwid
 
 from .settings.const import settings
@@ -307,8 +306,7 @@ class UI(object):
     def prompt(self, prefix, text=u'', completer=None, tab=0, history=None):
         """
         prompt for text input.
-        This returns a :class:`~twisted.defer.Deferred` that calls back with
-        the input string.
+        This returns a :class:`asyncio.Future`, which will have a string value
 
         :param prefix: text to print before the input field
         :type prefix: str
@@ -321,7 +319,7 @@ class UI(object):
         :type tab: int
         :param history: history to be used for up/down keys
         :type history: list of str
-        :rtype: :class:`twisted.defer.Deferred`
+        :rtype: asyncio.Future
         """
         history = history or []
 
@@ -369,7 +367,7 @@ class UI(object):
                                 None)
         self.mainloop.widget = overlay
         self._passall = True
-        return defer.Deferred.fromFuture(fut)
+        return fut
 
     @staticmethod
     def exit():
@@ -547,7 +545,7 @@ class UI(object):
         :param msg_position: determines if `message` is above or left of the
                              prompt. Must be `above` or `left`.
         :type msg_position: str
-        :rtype:  :class:`twisted.defer.Deferred`
+        :rtype: asyncio.Future
         """
         choices = choices or {'y': 'yes', 'n': 'no'}
         assert select is None or select in choices.values()
@@ -591,7 +589,7 @@ class UI(object):
                                 None)
         self.mainloop.widget = overlay
         self._passall = True
-        return defer.Deferred.fromFuture(fut)
+        return fut
 
     def notify(self, message, priority='normal', timeout=0, block=False):
         """

--- a/docs/source/api/conf.py
+++ b/docs/source/api/conf.py
@@ -30,10 +30,6 @@ class Mock(object):
         return Mock() if name not in ('__file__', '__path__') else '/dev/null'
 
 MOCK_MODULES = ['notmuch', 'notmuch.globals',
-                'twisted', 'twisted.internet',
-                'twisted.internet.defer',
-                'twisted.python',
-                'twisted.python.failure',
                 'urwid',
                 'magic',
                 'argparse']

--- a/docs/source/api/interface.rst
+++ b/docs/source/api/interface.rst
@@ -15,22 +15,13 @@ key presses to the wrapped root widget and thereby accessing standard urwid
 behaviour.
 
 In order to keep the interface non-blocking and react to events like
-terminal size changes, alot makes use of twisted's deferred_ - a
-framework that makes it easy to deal with callbacks. Many commands in alot make use of
-`inline callbacks`_, which allow you to treat deferred-returning functions almost like
-syncronous functions. Consider the following example of a function that prompts for some
-input and acts on it:
-
-.. _deferred: http://twistedmatrix.com/documents/current/core/howto/defer.html
-.. _`inline callbacks`: http://twistedmatrix.com/documents/8.1.0/api/twisted.internet.defer.html#inlineCallbacks
+terminal size changes, alot makes use of asyncio - which allows asynchronous calls
+without the use of callbacks. Alot makes use of the python 3.5 async/await syntax
 
 .. code-block:: python
 
-    from twisted.internet import defer
-
-    @defer.inlineCallbacks
-    def greet(ui):  # ui is instance of alot.ui.UI
-        name = yield ui.prompt('pls enter your name')
+    async def greet(ui):  # ui is instance of alot.ui.UI
+        name = await ui.prompt('pls enter your name')
         ui.notify('your name is: ' + name)
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,12 +23,7 @@ class MockModule(object):
     def __getattr__(cls, name):
         return Mock if name not in ('__file__', '__path__') else '/dev/null'
 
-MOCK_MODULES = ['twisted', 'twisted.internet',
-                'twisted.internet.defer',
-                'twisted.python',
-                'twisted.python.failure',
-                'twisted.internet.protocol',
-                'urwid',
+MOCK_MODULES = ['urwid',
                 'urwidtrees',
                 'magic',
                 'gpg',

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -73,3 +73,11 @@ FAQ
    Python 2 support. If you still need Python 2 support the 0.7 release is your
    best bet.
 
+.. _faq_8:
+
+8. I thought alot used twisted?
+
+   It used to. After we switched to python 3 we decided to switch to asyncio,
+   which reduced the number of dependencies we have. Twisted is an especially
+   heavy dependency, when we only used their async mechanisms, and not any of
+   the other goodness that twisted has to offer.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -9,7 +9,6 @@ A full list of dependencies is below:
 
 * `libmagic and python bindings <http://darwinsys.com/file/>`_, ≥ `5.04`
 * `configobj <http://www.voidspace.org.uk/python/configobj.html>`_, ≥ `4.7.0`
-* `twisted <http://twistedmatrix.com/trac/>`_, ≥ `10.2.0`:
 * `libnotmuch <http://notmuchmail.org/>`_ and it's python bindings, ≥ `0.13`
 * `urwid <http://excess.org/urwid/>`_ toolkit, ≥ `1.3.0`
 * `urwidtrees <https://github.com/pazz/urwidtrees>`_, ≥ `1.0`
@@ -26,11 +25,11 @@ A full list of dependencies is below:
 
 On debian/ubuntu the rest are packaged as::
 
-  python-setuptools python-magic python-configobj python-twisted python-notmuch python-urwid python-gpg
+  python-setuptools python-magic python-configobj python-notmuch python-urwid python-gpg
 
 On fedora/redhat these are packaged as::
 
-  python-setuptools python-magic python-configobj python-twisted python-notmuch python-urwid python-gpg
+  python-setuptools python-magic python-configobj python-notmuch python-urwid python-gpg
 
 Alot uses `mailcap <http://en.wikipedia.org/wiki/Mailcap>`_ to look up mime-handler for inline
 rendering and opening of attachments.  For a full description of the maicap protocol consider the

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         'notmuch>=0.26',
         'urwid>=1.3.0',
         'urwidtrees>=1.0',
-        'twisted>=10.2.0',
         'python-magic',
         'configobj>=4.7.0',
         'gpg'

--- a/tests/commands/envelope_test.py
+++ b/tests/commands/envelope_test.py
@@ -22,7 +22,7 @@ import tempfile
 import textwrap
 
 from twisted.trial import unittest
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import inlineCallbacks, ensureDeferred
 
 import mock
 
@@ -360,7 +360,7 @@ class TestSendCommand(unittest.TestCase):
         with mock.patch(
                 'alot.commands.envelope.settings.get_account_by_address',
                 mock.Mock(return_value=account)) as get_account_by_address:
-            yield cmd.apply(mock.Mock())
+            yield ensureDeferred(cmd.apply(mock.Mock()))
         get_account_by_address.assert_called_once_with('foo@example.com',
                                                        return_default=True)
         # check that the apply did run through till the end.
@@ -374,7 +374,7 @@ class TestSendCommand(unittest.TestCase):
         with mock.patch(
                 'alot.commands.envelope.settings.get_account_by_address',
                 mock.Mock(return_value=account)) as get_account_by_address:
-            yield cmd.apply(mock.Mock())
+            yield ensureDeferred(cmd.apply(mock.Mock()))
         get_account_by_address.assert_called_once_with('foo@example.com',
                                                        return_default=True)
         # check that the apply did run through till the end.

--- a/tests/commands/envelope_test.py
+++ b/tests/commands/envelope_test.py
@@ -20,8 +20,7 @@ import email
 import os
 import tempfile
 import textwrap
-
-from twisted.trial import unittest
+import unittest
 
 import mock
 

--- a/tests/commands/envelope_test.py
+++ b/tests/commands/envelope_test.py
@@ -1,5 +1,5 @@
 # encoding=utf-8
-# Copyright © 2017 Dylan Baker
+# Copyright © 2017-2018 Dylan Baker
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,7 +22,6 @@ import tempfile
 import textwrap
 
 from twisted.trial import unittest
-from twisted.internet.defer import inlineCallbacks, ensureDeferred
 
 import mock
 
@@ -353,28 +352,28 @@ class TestSendCommand(unittest.TestCase):
         Foo Bar Baz
         """)
 
-    @inlineCallbacks
-    def test_get_account_by_address_with_str(self):
+    @utilities.async_test
+    async def test_get_account_by_address_with_str(self):
         cmd = envelope.SendCommand(mail=self.mail)
         account = mock.Mock()
         with mock.patch(
                 'alot.commands.envelope.settings.get_account_by_address',
                 mock.Mock(return_value=account)) as get_account_by_address:
-            yield ensureDeferred(cmd.apply(mock.Mock()))
+            await cmd.apply(mock.Mock())
         get_account_by_address.assert_called_once_with('foo@example.com',
                                                        return_default=True)
         # check that the apply did run through till the end.
         account.send_mail.assert_called_once_with(self.mail)
 
-    @inlineCallbacks
-    def test_get_account_by_address_with_email_message(self):
+    @utilities.async_test
+    async def test_get_account_by_address_with_email_message(self):
         mail = email.message_from_string(self.mail)
         cmd = envelope.SendCommand(mail=mail)
         account = mock.Mock()
         with mock.patch(
                 'alot.commands.envelope.settings.get_account_by_address',
                 mock.Mock(return_value=account)) as get_account_by_address:
-            yield ensureDeferred(cmd.apply(mock.Mock()))
+            await cmd.apply(mock.Mock())
         get_account_by_address.assert_called_once_with('foo@example.com',
                                                        return_default=True)
         # check that the apply did run through till the end.

--- a/tests/commands/envelope_test.py
+++ b/tests/commands/envelope_test.py
@@ -30,6 +30,7 @@ from alot.db.envelope import Envelope
 from alot.errors import GPGProblem
 from alot.settings.errors import NoMatchingAccount
 from alot.settings.manager import SettingsManager
+from alot.account import Account
 
 from .. import utilities
 
@@ -352,10 +353,18 @@ class TestSendCommand(unittest.TestCase):
         Foo Bar Baz
         """)
 
+    class MockedAccount(Account):
+
+        def __init__(self):
+            super().__init__('foo@example.com')
+
+        async def send_mail(self, mail):
+            pass
+
     @utilities.async_test
     async def test_get_account_by_address_with_str(self):
         cmd = envelope.SendCommand(mail=self.mail)
-        account = mock.Mock()
+        account = mock.Mock(wraps=self.MockedAccount())
         with mock.patch(
                 'alot.commands.envelope.settings.get_account_by_address',
                 mock.Mock(return_value=account)) as get_account_by_address:
@@ -369,7 +378,7 @@ class TestSendCommand(unittest.TestCase):
     async def test_get_account_by_address_with_email_message(self):
         mail = email.message_from_string(self.mail)
         cmd = envelope.SendCommand(mail=mail)
-        account = mock.Mock()
+        account = mock.Mock(wraps=self.MockedAccount())
         with mock.patch(
                 'alot.commands.envelope.settings.get_account_by_address',
                 mock.Mock(return_value=account)) as get_account_by_address:

--- a/tests/commands/global_test.py
+++ b/tests/commands/global_test.py
@@ -18,8 +18,8 @@
 
 import os
 import tempfile
+import unittest
 
-from twisted.trial import unittest
 import mock
 
 from alot.commands import globals as g_commands
@@ -148,8 +148,8 @@ class TestComposeCommand(unittest.TestCase):
                           'Subject': [subject]}, cmd.envelope.headers)
         self.assertEqual(body, cmd.envelope.body)
 
-    @inlineCallbacks
-    def test_single_account_no_from(self):
+    @utilities.async_test
+    async def test_single_account_no_from(self):
         # issue #1277
         envelope = self._make_envelope_mock()
         del envelope.headers['From']
@@ -167,7 +167,7 @@ class TestComposeCommand(unittest.TestCase):
                 with mock.patch('alot.commands.globals.settings.get_addressbooks',
                                 mock.Mock(side_effect=Stop)):
                     try:
-                        yield ensureDeferred(cmd.apply(mock.Mock()))
+                        await cmd.apply(mock.Mock())
                     except Stop:
                         pass
 

--- a/tests/commands/global_test.py
+++ b/tests/commands/global_test.py
@@ -176,47 +176,54 @@ class TestComposeCommand(unittest.TestCase):
 
 class TestExternalCommand(unittest.TestCase):
 
+    @inlineCallbacks
     def test_no_spawn_no_stdin_success(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(u'true', refocus=False)
-        cmd.apply(ui)
+        yield ensureDeferred(cmd.apply(ui))
         ui.notify.assert_not_called()
 
+    @inlineCallbacks
     def test_no_spawn_stdin_success(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(u"awk '{ exit $0 }'", stdin=u'0',
                                          refocus=False)
-        cmd.apply(ui)
+        yield ensureDeferred(cmd.apply(ui))
         ui.notify.assert_not_called()
 
+    @inlineCallbacks
     def test_no_spawn_no_stdin_attached(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(u'test -t 0', refocus=False)
-        cmd.apply(ui)
+        yield ensureDeferred(cmd.apply(ui))
         ui.notify.assert_not_called()
 
+    @inlineCallbacks
     def test_no_spawn_stdin_attached(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(
             u"test -t 0", stdin=u'0', refocus=False)
-        cmd.apply(ui)
+        yield ensureDeferred(cmd.apply(ui))
         ui.notify.assert_called_once_with('', priority='error')
 
+    @inlineCallbacks
     def test_no_spawn_failure(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(u'false', refocus=False)
-        cmd.apply(ui)
+        yield ensureDeferred(cmd.apply(ui))
         ui.notify.assert_called_once_with('', priority='error')
 
+    @inlineCallbacks
     @mock.patch(
         'alot.commands.globals.settings.get', mock.Mock(return_value=''))
     @mock.patch.dict(os.environ, {'DISPLAY': ':0'})
     def test_spawn_no_stdin_success(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(u'true', refocus=False, spawn=True)
-        cmd.apply(ui)
+        yield ensureDeferred(cmd.apply(ui))
         ui.notify.assert_not_called()
 
+    @inlineCallbacks
     @mock.patch(
         'alot.commands.globals.settings.get', mock.Mock(return_value=''))
     @mock.patch.dict(os.environ, {'DISPLAY': ':0'})
@@ -225,14 +232,15 @@ class TestExternalCommand(unittest.TestCase):
         cmd = g_commands.ExternalCommand(
             u"awk '{ exit $0 }'",
             stdin=u'0', refocus=False, spawn=True)
-        cmd.apply(ui)
+        yield ensureDeferred(cmd.apply(ui))
         ui.notify.assert_not_called()
 
+    @inlineCallbacks
     @mock.patch(
         'alot.commands.globals.settings.get', mock.Mock(return_value=''))
     @mock.patch.dict(os.environ, {'DISPLAY': ':0'})
     def test_spawn_failure(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(u'false', refocus=False, spawn=True)
-        cmd.apply(ui)
+        yield ensureDeferred(cmd.apply(ui))
         ui.notify.assert_called_once_with('', priority='error')

--- a/tests/commands/global_test.py
+++ b/tests/commands/global_test.py
@@ -1,5 +1,5 @@
 # encoding=utf-8
-# Copyright © 2017 Dylan Baker
+# Copyright © 2017-2018 Dylan Baker
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,7 +20,6 @@ import os
 import tempfile
 
 from twisted.trial import unittest
-from twisted.internet.defer import inlineCallbacks, ensureDeferred
 import mock
 
 from alot.commands import globals as g_commands
@@ -55,8 +54,8 @@ class TestComposeCommand(unittest.TestCase):
         account.signature = None
         return account
 
-    @inlineCallbacks
-    def test_apply_sign_by_default_okay(self):
+    @utilities.async_test
+    async def test_apply_sign_by_default_okay(self):
         envelope = self._make_envelope_mock()
         account = self._make_account_mock()
         cmd = g_commands.ComposeCommand(envelope=envelope)
@@ -70,15 +69,15 @@ class TestComposeCommand(unittest.TestCase):
                 with mock.patch('alot.commands.globals.settings.get_addressbooks',
                                 mock.Mock(side_effect=Stop)):
                     try:
-                        yield ensureDeferred(cmd.apply(mock.Mock()))
+                        await cmd.apply(mock.Mock())
                     except Stop:
                         pass
 
         self.assertTrue(envelope.sign)
         self.assertIs(envelope.sign_key, mock.sentinel.gpg_key)
 
-    @inlineCallbacks
-    def test_apply_sign_by_default_false_doesnt_set_key(self):
+    @utilities.async_test
+    async def test_apply_sign_by_default_false_doesnt_set_key(self):
         envelope = self._make_envelope_mock()
         account = self._make_account_mock(sign_by_default=False)
         cmd = g_commands.ComposeCommand(envelope=envelope)
@@ -92,15 +91,15 @@ class TestComposeCommand(unittest.TestCase):
                 with mock.patch('alot.commands.globals.settings.get_addressbooks',
                                 mock.Mock(side_effect=Stop)):
                     try:
-                        yield ensureDeferred(cmd.apply(mock.Mock()))
+                        await cmd.apply(mock.Mock())
                     except Stop:
                         pass
 
         self.assertFalse(envelope.sign)
         self.assertIs(envelope.sign_key, None)
 
-    @inlineCallbacks
-    def test_apply_sign_by_default_but_no_key(self):
+    @utilities.async_test
+    async def test_apply_sign_by_default_but_no_key(self):
         envelope = self._make_envelope_mock()
         account = self._make_account_mock(gpg_key=None)
         cmd = g_commands.ComposeCommand(envelope=envelope)
@@ -114,15 +113,15 @@ class TestComposeCommand(unittest.TestCase):
                 with mock.patch('alot.commands.globals.settings.get_addressbooks',
                                 mock.Mock(side_effect=Stop)):
                     try:
-                        yield ensureDeferred(cmd.apply(mock.Mock()))
+                        await cmd.apply(mock.Mock())
                     except Stop:
                         pass
 
         self.assertFalse(envelope.sign)
         self.assertIs(envelope.sign_key, None)
 
-    @inlineCallbacks
-    def test_decode_template_on_loading(self):
+    @utilities.async_test
+    async def test_decode_template_on_loading(self):
         subject = u'This is a täßϑ subject.'
         to = u'recipient@mail.com'
         _from = u'foo.bar@mail.fr'
@@ -140,7 +139,7 @@ class TestComposeCommand(unittest.TestCase):
                 'alot.commands.globals.settings.get_account_by_address',
                 mock.Mock(side_effect=Stop)):
             try:
-                yield ensureDeferred(cmd.apply(mock.Mock()))
+                await cmd.apply(mock.Mock())
             except Stop:
                 pass
 
@@ -176,71 +175,71 @@ class TestComposeCommand(unittest.TestCase):
 
 class TestExternalCommand(unittest.TestCase):
 
-    @inlineCallbacks
-    def test_no_spawn_no_stdin_success(self):
+    @utilities.async_test
+    async def test_no_spawn_no_stdin_success(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(u'true', refocus=False)
-        yield ensureDeferred(cmd.apply(ui))
+        await cmd.apply(ui)
         ui.notify.assert_not_called()
 
-    @inlineCallbacks
-    def test_no_spawn_stdin_success(self):
+    @utilities.async_test
+    async def test_no_spawn_stdin_success(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(u"awk '{ exit $0 }'", stdin=u'0',
                                          refocus=False)
-        yield ensureDeferred(cmd.apply(ui))
+        await cmd.apply(ui)
         ui.notify.assert_not_called()
 
-    @inlineCallbacks
-    def test_no_spawn_no_stdin_attached(self):
+    @utilities.async_test
+    async def test_no_spawn_no_stdin_attached(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(u'test -t 0', refocus=False)
-        yield ensureDeferred(cmd.apply(ui))
+        await cmd.apply(ui)
         ui.notify.assert_not_called()
 
-    @inlineCallbacks
-    def test_no_spawn_stdin_attached(self):
+    @utilities.async_test
+    async def test_no_spawn_stdin_attached(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(
             u"test -t 0", stdin=u'0', refocus=False)
-        yield ensureDeferred(cmd.apply(ui))
+        await cmd.apply(ui)
         ui.notify.assert_called_once_with('', priority='error')
 
-    @inlineCallbacks
-    def test_no_spawn_failure(self):
+    @utilities.async_test
+    async def test_no_spawn_failure(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(u'false', refocus=False)
-        yield ensureDeferred(cmd.apply(ui))
+        await cmd.apply(ui)
         ui.notify.assert_called_once_with('', priority='error')
 
-    @inlineCallbacks
+    @utilities.async_test
     @mock.patch(
         'alot.commands.globals.settings.get', mock.Mock(return_value=''))
     @mock.patch.dict(os.environ, {'DISPLAY': ':0'})
-    def test_spawn_no_stdin_success(self):
+    async def test_spawn_no_stdin_success(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(u'true', refocus=False, spawn=True)
-        yield ensureDeferred(cmd.apply(ui))
+        await cmd.apply(ui)
         ui.notify.assert_not_called()
 
-    @inlineCallbacks
+    @utilities.async_test
     @mock.patch(
         'alot.commands.globals.settings.get', mock.Mock(return_value=''))
     @mock.patch.dict(os.environ, {'DISPLAY': ':0'})
-    def test_spawn_stdin_success(self):
+    async def test_spawn_stdin_success(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(
             u"awk '{ exit $0 }'",
             stdin=u'0', refocus=False, spawn=True)
-        yield ensureDeferred(cmd.apply(ui))
+        await cmd.apply(ui)
         ui.notify.assert_not_called()
 
-    @inlineCallbacks
+    @utilities.async_test
     @mock.patch(
         'alot.commands.globals.settings.get', mock.Mock(return_value=''))
     @mock.patch.dict(os.environ, {'DISPLAY': ':0'})
-    def test_spawn_failure(self):
+    async def test_spawn_failure(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(u'false', refocus=False, spawn=True)
-        yield ensureDeferred(cmd.apply(ui))
+        await cmd.apply(ui)
         ui.notify.assert_called_once_with('', priority='error')

--- a/tests/commands/global_test.py
+++ b/tests/commands/global_test.py
@@ -20,7 +20,7 @@ import os
 import tempfile
 
 from twisted.trial import unittest
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import inlineCallbacks, ensureDeferred
 import mock
 
 from alot.commands import globals as g_commands
@@ -70,7 +70,7 @@ class TestComposeCommand(unittest.TestCase):
                 with mock.patch('alot.commands.globals.settings.get_addressbooks',
                                 mock.Mock(side_effect=Stop)):
                     try:
-                        yield cmd.apply(mock.Mock())
+                        yield ensureDeferred(cmd.apply(mock.Mock()))
                     except Stop:
                         pass
 
@@ -92,7 +92,7 @@ class TestComposeCommand(unittest.TestCase):
                 with mock.patch('alot.commands.globals.settings.get_addressbooks',
                                 mock.Mock(side_effect=Stop)):
                     try:
-                        yield cmd.apply(mock.Mock())
+                        yield ensureDeferred(cmd.apply(mock.Mock()))
                     except Stop:
                         pass
 
@@ -114,7 +114,7 @@ class TestComposeCommand(unittest.TestCase):
                 with mock.patch('alot.commands.globals.settings.get_addressbooks',
                                 mock.Mock(side_effect=Stop)):
                     try:
-                        yield cmd.apply(mock.Mock())
+                        yield ensureDeferred(cmd.apply(mock.Mock()))
                     except Stop:
                         pass
 
@@ -140,7 +140,7 @@ class TestComposeCommand(unittest.TestCase):
                 'alot.commands.globals.settings.get_account_by_address',
                 mock.Mock(side_effect=Stop)):
             try:
-                yield cmd.apply(mock.Mock())
+                yield ensureDeferred(cmd.apply(mock.Mock()))
             except Stop:
                 pass
 
@@ -168,7 +168,7 @@ class TestComposeCommand(unittest.TestCase):
                 with mock.patch('alot.commands.globals.settings.get_addressbooks',
                                 mock.Mock(side_effect=Stop)):
                     try:
-                        yield cmd.apply(mock.Mock())
+                        yield ensureDeferred(cmd.apply(mock.Mock()))
                     except Stop:
                         pass
 

--- a/tests/commands/utils_tests.py
+++ b/tests/commands/utils_tests.py
@@ -17,10 +17,10 @@
 import tempfile
 import os
 import shutil
+import unittest
 
 import gpg
 import mock
-from twisted.trial import unittest
 
 from alot import crypto
 from alot import errors

--- a/tests/commands/utils_tests.py
+++ b/tests/commands/utils_tests.py
@@ -21,7 +21,6 @@ import shutil
 import gpg
 import mock
 from twisted.trial import unittest
-from twisted.internet.defer import inlineCallbacks
 
 from alot import crypto
 from alot import errors
@@ -110,7 +109,7 @@ class TestGetKeys(unittest.TestCase):
             FPR, validate=True, encrypt=True, signed_only=False)
         ui = utilities.make_ui()
 
-        # Creat a ui.choice object that can satisfy twisted, but can also be
+        # Creat a ui.choice object that can satisfy asyncio, but can also be
         # queried for calls as a mock
         async def choice(*args, **kwargs):
             return None

--- a/tests/helper_test.py
+++ b/tests/helper_test.py
@@ -22,9 +22,9 @@ import email
 import errno
 import os
 import random
+import unittest
 
 import mock
-from twisted.trial import unittest
 
 from alot import helper
 
@@ -258,7 +258,7 @@ class TestPrettyDatetime(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     # Returns 'just now', instead of 'from future' or something similar
-    @utilities.expected_failure
+    @unittest.expectedFailure
     def test_future_minutes(self):
         test = self.now + datetime.timedelta(minutes=5)
         actual = helper.pretty_datetime(test)
@@ -266,7 +266,7 @@ class TestPrettyDatetime(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     # Returns 'just now', instead of 'from future' or something similar
-    @utilities.expected_failure
+    @unittest.expectedFailure
     def test_future_hours(self):
         test = self.now + datetime.timedelta(hours=1)
         actual = helper.pretty_datetime(test)
@@ -274,7 +274,7 @@ class TestPrettyDatetime(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     # Returns 'just now', instead of 'from future' or something similar
-    @utilities.expected_failure
+    @unittest.expectedFailure
     def test_future_days(self):
         def make_expected():
             # Uses the hourfmt instead of the hourminfmt from pretty_datetime
@@ -291,7 +291,7 @@ class TestPrettyDatetime(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     # Returns 'just now', instead of 'from future' or something similar
-    @utilities.expected_failure
+    @unittest.expectedFailure
     def test_future_week(self):
         test = self.now + datetime.timedelta(days=7)
         actual = helper.pretty_datetime(test)
@@ -299,7 +299,7 @@ class TestPrettyDatetime(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     # Returns 'just now', instead of 'from future' or something similar
-    @utilities.expected_failure
+    @unittest.expectedFailure
     def test_future_month(self):
         test = self.now + datetime.timedelta(days=31)
         actual = helper.pretty_datetime(test)
@@ -307,7 +307,7 @@ class TestPrettyDatetime(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     # Returns 'just now', instead of 'from future' or something similar
-    @utilities.expected_failure
+    @unittest.expectedFailure
     def test_future_year(self):
         test = self.now + datetime.timedelta(days=365)
         actual = helper.pretty_datetime(test)

--- a/tests/helper_test.py
+++ b/tests/helper_test.py
@@ -1,5 +1,5 @@
 # encoding=utf-8
-# Copyright © 2016-2017 Dylan Baker
+# Copyright © 2016-2018 Dylan Baker
 # Copyright © 2017 Lucas Hoffman
 
 # This program is free software: you can redistribute it and/or modify
@@ -25,8 +25,6 @@ import random
 
 import mock
 from twisted.trial import unittest
-from twisted.internet.defer import inlineCallbacks
-from twisted.internet.error import ProcessTerminated
 
 from alot import helper
 
@@ -427,20 +425,20 @@ class TestShorten(unittest.TestCase):
 
 class TestCallCmdAsync(unittest.TestCase):
 
-    @inlineCallbacks
-    def test_no_stdin(self):
-        ret = yield helper.call_cmd_async(['echo', '-n', 'foo'])
-        self.assertEqual(ret, 'foo')
+    @utilities.async_test
+    async def test_no_stdin(self):
+        ret = await helper.call_cmd_async(['echo', '-n', 'foo'])
+        self.assertEqual(ret[0], 'foo')
 
-    @inlineCallbacks
-    def test_stdin(self):
-        ret = yield helper.call_cmd_async(['cat', '-'], stdin='foo')
-        self.assertEqual(ret, 'foo')
+    @utilities.async_test
+    async def test_stdin(self):
+        ret = await helper.call_cmd_async(['cat', '-'], stdin='foo')
+        self.assertEqual(ret[0], 'foo')
 
-    @inlineCallbacks
-    def test_env_set(self):
+    @utilities.async_test
+    async def test_env_set(self):
         with mock.patch.dict(os.environ, {}, clear=True):
-            ret = yield helper.call_cmd_async(
+            ret = await helper.call_cmd_async(
                 # Thanks to the future import it doesn't matter if python is
                 # python2 or python3
                 ['python', '-c', 'from __future__ import print_function; '
@@ -448,21 +446,20 @@ class TestCallCmdAsync(unittest.TestCase):
                                  'print(os.environ.get("foo", "fail"), end="")'
                 ],
                 env={'foo': 'bar'})
-        self.assertEqual(ret, 'bar')
+        self.assertEqual(ret[0], 'bar')
 
-    @inlineCallbacks
-    def test_env_doesnt_pollute(self):
+    @utilities.async_test
+    async def test_env_doesnt_pollute(self):
         with mock.patch.dict(os.environ, {}, clear=True):
-            yield helper.call_cmd_async(['echo', '-n', 'foo'],
+            await helper.call_cmd_async(['echo', '-n', 'foo'],
                                         env={'foo': 'bar'})
             self.assertEqual(os.environ, {})
 
-    @inlineCallbacks
-    def test_command_fails(self):
-        with self.assertRaises(ProcessTerminated) as cm:
-            yield helper.call_cmd_async(['_____better_not_exist'])
-        self.assertEqual(cm.exception.exitCode, 1)
-        self.assertTrue(cm.exception.stderr)
+    @utilities.async_test
+    async def test_command_fails(self):
+        _, err, ret = await helper.call_cmd_async(['_____better_not_exist'])
+        self.assertEqual(ret, 1)
+        self.assertTrue(err)
 
 
 class TestGetEnv(unittest.TestCase):

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -179,16 +179,6 @@ def make_ui(**kwargs):
     return ui
 
 
-def expected_failure(func):
-    """For marking expected failures for twisted.trial based unit tests.
-
-    The builtin unittest.expectedFailure does not work with twisted.trail,
-    there is an outstanding bug for this, but no one has ever fixed it.
-    """
-    func.todo = 'expected failure'
-    return func
-
-
 def async_test(coro):
     """Run an asyncrounous test synchronously."""
 

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -16,6 +16,7 @@
 
 """Helpers for unittests themselves."""
 
+import asyncio
 import functools
 import unittest
 
@@ -186,3 +187,14 @@ def expected_failure(func):
     """
     func.todo = 'expected failure'
     return func
+
+
+def async_test(coro):
+    """Run an asyncrounous test synchronously."""
+
+    @functools.wraps(coro)
+    def _actual(*args, **kwargs):
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(coro(*args, **kwargs))
+
+    return _actual


### PR DESCRIPTION
I got a bit of free time, and sat down to work on something I'd really wanted to work on since we started the transition to python 3, using asyncio.

I think there are some benefits for us to using asyncio instead of twisted. Asyncio is part of the language, and it gives us nice language features like `async def` and `await`. On the downside it doesn't have as many nice convenience functions as twisted does. It also removes a pretty big, heavy dependency. Twisted is pretty cool, and you can do a lot of cool stuff with it, but we're basically just using the event loop and deferreds.

This series has been lightly tested, it does pass all of the unittests, although there are some obvious holes in the coverage of our test suite :/. I'm currently dog fooding it, but if anyone sees obvious mistakes or problems I'd be glad to start working through them sooner than later (as time at $job and $life allows).