### PR TITLE
widgets/globals: inverse search keys (up/down)

### DIFF
--- a/alot/widgets/globals.py
+++ b/alot/widgets/globals.py
@@ -166,9 +166,9 @@ class CompleteEdit(urwid.Edit):
                     self.history.append(self.edit_text)
                     self.historypos = len(self.history) - 1
                 if key == 'up':
-                    self.historypos = (self.historypos + 1) % len(self.history)
-                else:
                     self.historypos = (self.historypos - 1) % len(self.history)
+                else:
+                    self.historypos = (self.historypos + 1) % len(self.history)
                 self.set_edit_text(self.history[self.historypos])
         elif key == 'enter':
             self.on_exit(self.edit_text)


### PR DESCRIPTION
This has really annoyed me for a while, the search is reversed from vim.
In alot currently up is older searches, whiles down is newer. In vim
it's reversed.