### PR TITLE
Respect colour mode set in config file

### DIFF
--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -38,8 +38,8 @@ def parser():
                         validator=cargparse.require_file,
                         help='notmuch config')
     parser.add_argument('-C', '--colour-mode',
-                        choices=(1, 16, 256), type=int, default=256,
-                        help='terminal colour mode [default: %(default)s].')
+                        choices=(1, 16, 256), type=int,
+                        help='terminal colour mode')
     parser.add_argument('-p', '--mailindex-path',
                         action=cargparse.ValidatedStoreAction,
                         validator=cargparse.require_dir,

--- a/docs/source/usage/cli_options.rst
+++ b/docs/source/usage/cli_options.rst
@@ -1,7 +1,7 @@
 -r, --read-only                open db in read only mode
 -c, --config=FILENAME          config file (default: ~/.config/alot/config)
 -n, --notmuch-config=FILENAME  notmuch config (default: $NOTMUCH_CONFIG or ~/.notmuch-config)
--C, --colour-mode=COLOUR       terminal colour mode (default: 256). Must be 1, 16 or 256
+-C, --colour-mode=COLOUR       terminal colour mode. Must be 1, 16 or 256
 -p, --mailindex-path=PATH      path to notmuch index
 -d, --debug-level=LEVEL        debug log (default: info). Must be one of debug,info,warning or error
 -l, --logfile=FILENAME         logfile (default: /dev/null)


### PR DESCRIPTION
The config file setting for the colour mode used not to be respected, because a default value of a command-line option overrode it. Removing the default fixes this. I also removed the default from the command-line help as the simplest solution, but it's possible to do something more informative.