### PR TITLE
Copyedit documentation

### DIFF
--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -22,35 +22,40 @@ _SUBCOMMANDS = ['search', 'compose', 'bufferlist', 'taglist', 'pyshell']
 
 def parser():
     """Parse command line arguments, validate them, and return them."""
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-v', '--version', action='version',
-                        version=alot.__version__)
+    parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument('-r', '--read-only', action='store_true',
                         help='open notmuch database in read-only mode')
-    parser.add_argument('-c', '--config',
+    parser.add_argument('-c', '--config', metavar='FILENAME',
                         action=cargparse.ValidatedStoreAction,
                         validator=cargparse.require_file,
                         help='configuration file')
-    parser.add_argument('-n', '--notmuch-config', default=os.environ.get(
+    parser.add_argument('-n', '--notmuch-config', metavar='FILENAME',
+                        default=os.environ.get(
                             'NOTMUCH_CONFIG',
                             os.path.expanduser('~/.notmuch-config')),
                         action=cargparse.ValidatedStoreAction,
                         validator=cargparse.require_file,
                         help='notmuch configuration file')
-    parser.add_argument('-C', '--colour-mode',
+    parser.add_argument('-C', '--colour-mode', metavar='COLOURS',
                         choices=(1, 16, 256), type=int,
                         help='number of colours to use')
-    parser.add_argument('-p', '--mailindex-path',
+    parser.add_argument('-p', '--mailindex-path', metavar='PATH',
                         action=cargparse.ValidatedStoreAction,
                         validator=cargparse.require_dir,
                         help='path to notmuch index')
-    parser.add_argument('-d', '--debug-level', default='info',
+    parser.add_argument('-d', '--debug-level', metavar='LEVEL', default='info',
                         choices=('debug', 'info', 'warning', 'error'),
                         help='debug level [default: %(default)s]')
-    parser.add_argument('-l', '--logfile', default='/dev/null',
+    parser.add_argument('-l', '--logfile', metavar='FILENAME',
+                        default='/dev/null',
                         action=cargparse.ValidatedStoreAction,
                         validator=cargparse.optional_file_like,
                         help='log file [default: %(default)s]')
+    parser.add_argument('-h', '--help', action='help',
+                        help='display this help and exit')
+    parser.add_argument('-v', '--version', action='version',
+                        version=alot.__version__,
+                        help='output version information and exit')
     # We will handle the subcommands in a separate run of argparse as argparse
     # does not support optional subcommands until now.
     parser.add_argument('command', nargs=argparse.REMAINDER,

--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -46,7 +46,7 @@ def parser():
                         help='path to notmuch index')
     parser.add_argument('-d', '--debug-level', default='info',
                         choices=('debug', 'info', 'warning', 'error'),
-                        help='debug log [default: %(default)s]')
+                        help='debug level [default: %(default)s]')
     parser.add_argument('-l', '--logfile', default='/dev/null',
                         action=cargparse.ValidatedStoreAction,
                         validator=cargparse.optional_file_like,

--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -39,7 +39,7 @@ def parser():
                         help='notmuch configuration file')
     parser.add_argument('-C', '--colour-mode',
                         choices=(1, 16, 256), type=int,
-                        help='terminal colour mode')
+                        help='number of colours to use')
     parser.add_argument('-p', '--mailindex-path',
                         action=cargparse.ValidatedStoreAction,
                         validator=cargparse.require_dir,

--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -26,17 +26,17 @@ def parser():
     parser.add_argument('-v', '--version', action='version',
                         version=alot.__version__)
     parser.add_argument('-r', '--read-only', action='store_true',
-                        help='open db in read only mode')
+                        help='open notmuch database in read-only mode')
     parser.add_argument('-c', '--config',
                         action=cargparse.ValidatedStoreAction,
                         validator=cargparse.require_file,
-                        help='config file')
+                        help='configuration file')
     parser.add_argument('-n', '--notmuch-config', default=os.environ.get(
                             'NOTMUCH_CONFIG',
                             os.path.expanduser('~/.notmuch-config')),
                         action=cargparse.ValidatedStoreAction,
                         validator=cargparse.require_file,
-                        help='notmuch config')
+                        help='notmuch configuration file')
     parser.add_argument('-C', '--colour-mode',
                         choices=(1, 16, 256), type=int,
                         help='terminal colour mode')
@@ -50,7 +50,7 @@ def parser():
     parser.add_argument('-l', '--logfile', default='/dev/null',
                         action=cargparse.ValidatedStoreAction,
                         validator=cargparse.optional_file_like,
-                        help='logfile [default: %(default)s]')
+                        help='log file [default: %(default)s]')
     # We will handle the subcommands in a separate run of argparse as argparse
     # does not support optional subcommands until now.
     parser.add_argument('command', nargs=argparse.REMAINDER,

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -621,7 +621,7 @@ class EncryptCommand(Command):
 @registerCommand(
     MODE, 'retag', forced={'action': 'set'},
     arguments=[(['tags'], {'help': 'comma separated list of tags'})],
-    help='set message tags.',
+    help='set message tags',
 )
 @registerCommand(
     MODE, 'untag', forced={'action': 'remove'},

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -40,14 +40,14 @@ MODE = 'global'
 
 @registerCommand(MODE, 'exit')
 class ExitCommand(Command):
-    """Shut down cleanly.
-
-    The _prompt variable is for internal use only, it's used to control
-    prompting to close without sending, and is used by the BufferCloseCommand
-    if settings change after yielding to the UI.
-    """
+    """shut down cleanly"""
 
     def __init__(self, _prompt=True, **kwargs):
+        """
+        :param _prompt: For internal use only, used to control prompting to
+        close without sending, and is used by the BufferCloseCommand if
+        settings change after yielding to the UI.
+        """
         super(ExitCommand, self).__init__(**kwargs)
         self.prompt_to_send = _prompt
 
@@ -352,7 +352,7 @@ class PythonShellCommand(Command):
 @registerCommand(MODE, 'repeat')
 class RepeatCommand(Command):
 
-    """Repeats the command executed last time"""
+    """repeat the command executed last time"""
     def __init__(self, **kwargs):
         Command.__init__(self, **kwargs)
 
@@ -367,7 +367,7 @@ class RepeatCommand(Command):
     (['command'], {'help': 'python command string to call'})])
 class CallCommand(Command):
 
-    """Executes python code"""
+    """execute python code"""
     repeatable = True
 
     def __init__(self, command, **kwargs):
@@ -601,8 +601,8 @@ class FlushCommand(Command):
     (['commandname'], {'help': 'command or \'bindings\''})])
 class HelpCommand(Command):
 
-    """display help for a command. Use \'bindings\' to display all keybings
-    interpreted in current mode.'"""
+    """display help for a command (use \'bindings\' to display all keybindings
+    interpreted in current mode)"""
     def __init__(self, commandname='', **kwargs):
         """
         :param commandname: command to document
@@ -968,7 +968,7 @@ class MoveCommand(Command):
                       priority='error')
 
 
-@registerCommand(MODE, 'reload', help='Reload all configuration files')
+@registerCommand(MODE, 'reload', help='reload all configuration files')
 class ReloadCommand(Command):
 
     """Reload configuration."""

--- a/alot/commands/search.py
+++ b/alot/commands/search.py
@@ -135,10 +135,8 @@ RetagPromptCommand = registerCommand(MODE, 'retagprompt')(RetagPromptCommand)
                           'default': 'True',
                           'help': 'postpone a writeout to the index'}),
         (['tags'], {'help': 'comma separated list of tags'})],
-    help='flip presence of tags on this thread. A tag is considered present '
-         'if at least one message contained in this thread is tagged with it. '
-         'In that case this command will remove the tag from every message in '
-         'the thread.')
+    help='flip presence of tags on this thread: a tag is considered present '
+         'and removed if at least one message in this thread is tagged with it')
 class TagCommand(Command):
 
     """manipulate message tags"""

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -1069,9 +1069,9 @@ class MoveFocusCommand(MoveCommand):
 @registerCommand(MODE, 'select')
 class ThreadSelectCommand(Command):
 
-    """select focussed element. The fired action depends on the focus:
-        - if message summary, this toggles visibility of the message,
-        - if attachment line, this opens the attachment"""
+    """select focussed element:
+        - if it is a message summary, toggle visibility of the message;
+        - if it is an attachment line, open the attachment"""
     def apply(self, ui):
         focus = ui.get_deep_focus()
         if isinstance(focus, AttachmentWidget):

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -105,7 +105,7 @@
 
 .. describe:: colourmode
 
-     number of colours to use
+     number of colours to use on the terminal
 
     :type: option, one of ['1', '16', '256']
     :default: 256

--- a/docs/source/generate_commands.py
+++ b/docs/source/generate_commands.py
@@ -53,20 +53,20 @@ def rstify_parser(parser):
         a = parser._positionals._group_actions[0]
         out += ' '*8 + str(parser._positionals._group_actions[0].help)
         if a.choices:
-            out += ". valid choices are: %s." % ','.join(['\`%s\`' % s for s
+            out += "; valid choices are: %s" % ','.join(['\`%s\`' % s for s
                                                           in a.choices])
         if a.default:
-            out += ". defaults to: '%s'." % a.default
+            out += " (defaults to: '%s')" % a.default
         out += '\n\n'
     elif len(parser._positionals._group_actions) > 1:
         out += "    positional arguments\n"
         for index, a in enumerate(parser._positionals._group_actions):
             out += "        %s: %s" % (index, a.help)
             if a.choices:
-                out += ". valid choices are: %s." % ','.join(
+                out += "; valid choices are: %s" % ','.join(
                     ['\`%s\`' % s for s in a.choices])
             if a.default:
-                out += ". defaults to: '%s'." % a.default
+                out += " (defaults to: '%s')" % a.default
             out += '\n'
         out += '\n\n'
 
@@ -76,11 +76,11 @@ def rstify_parser(parser):
         switches = [s.replace('--', '---') for s in a.option_strings]
         out += "        :%s: %s" % (', '.join(switches), a.help)
         if a.choices and not isinstance(a, BooleanAction):
-            out += ". Valid choices are: %s" % ','.join(['\`%s\`' % s for s
+            out += "; valid choices are: %s" % ','.join(['\`%s\`' % s for s
                                                          in a.choices])
         if a.default:
-            out += " (Defaults to: '%s')" % a.default
-        out += '.\n'
+            out += " (defaults to: '%s')" % a.default
+        out += '\n'
     out += '\n'
 
     return out
@@ -110,7 +110,7 @@ if __name__ == "__main__":
             modefile.write('The following commands are available in %s mode'
                            '\n\n' % mode)
         else:
-            header = 'Global Commands'
+            header = 'Global commands'
             modefile.write('%s\n%s\n' % (header, '-' * len(header)))
             modefile.write('The following commands are available globally\n\n')
         for cmdstring, struct in sorted(modecommands.items()):

--- a/docs/source/usage/cli_commands.rst
+++ b/docs/source/usage/cli_commands.rst
@@ -1,5 +1,5 @@
 search
-    start in a search buffer using the querystring provided as
+    start in a search buffer using the query string provided as
     parameter (see :manpage:`notmuch-search-terms(7)`)
 
 compose

--- a/docs/source/usage/cli_commands.rst
+++ b/docs/source/usage/cli_commands.rst
@@ -1,6 +1,6 @@
 search
     start in a search buffer using the querystring provided as
-    parameter. See also :manpage:`notmuch-search-terms(7)`.
+    parameter (see :manpage:`notmuch-search-terms(7)`)
 
 compose
     compose a new message

--- a/docs/source/usage/cli_options.rst
+++ b/docs/source/usage/cli_options.rst
@@ -4,13 +4,13 @@
 -n FILENAME, --notmuch-config=FILENAME
                  notmuch config (default: $NOTMUCH_CONFIG or ~/.notmuch-config)
 -C COLOUR, --colour-mode=COLOUR
-                 terminal colour. Must be 1, 16 or 256
+                 terminal colour; must be 1, 16 or 256
 -p PATH, --mailindex-path=PATH
                  path to notmuch index
 -d LEVEL, --debug-level=LEVEL
-                 debug level (default: info). Must be one of debug, info,
-                 warning or error
+                 debug level; must be one of debug, info, warning or error
+                 (default: info)
 -l FILENAME, --logfile=FILENAME
                  logfile (default: /dev/null)
--v, --version    Display version string and exit
--h, --help       Display help and exit
+-v, --version    display version string and exit
+-h, --help       display help and exit

--- a/docs/source/usage/cli_options.rst
+++ b/docs/source/usage/cli_options.rst
@@ -14,5 +14,5 @@
                  (default: info)
 -l FILENAME, --logfile=FILENAME
                  log file (default: /dev/null)
--v, --version    display version string and exit
 -h, --help       display help and exit
+-v, --version    output version information and exit

--- a/docs/source/usage/cli_options.rst
+++ b/docs/source/usage/cli_options.rst
@@ -1,8 +1,9 @@
--r, --read-only  open db in read only mode
+-r, --read-only  open notmuch database in read-only mode
 -c FILENAME, --config=FILENAME
-                 config file (default: ~/.config/alot/config)
+                 configuration file (default: ~/.config/alot/config)
 -n FILENAME, --notmuch-config=FILENAME
-                 notmuch config (default: $NOTMUCH_CONFIG or ~/.notmuch-config)
+                 notmuch configuration file (default: $NOTMUCH_CONFIG
+                 or ~/.notmuch-config)
 -C COLOUR, --colour-mode=COLOUR
                  terminal colour; must be 1, 16 or 256
 -p PATH, --mailindex-path=PATH
@@ -11,6 +12,6 @@
                  debug level; must be one of debug, info, warning or error
                  (default: info)
 -l FILENAME, --logfile=FILENAME
-                 logfile (default: /dev/null)
+                 log file (default: /dev/null)
 -v, --version    display version string and exit
 -h, --help       display help and exit

--- a/docs/source/usage/cli_options.rst
+++ b/docs/source/usage/cli_options.rst
@@ -1,9 +1,9 @@
 -r, --read-only                open db in read only mode
--c, --config=FILENAME          config file (default: ~/.config/alot/config)
--n, --notmuch-config=FILENAME  notmuch config (default: $NOTMUCH_CONFIG or ~/.notmuch-config)
--C, --colour-mode=COLOUR       terminal colour mode. Must be 1, 16 or 256
--p, --mailindex-path=PATH      path to notmuch index
--d, --debug-level=LEVEL        debug log (default: info). Must be one of debug,info,warning or error
--l, --logfile=FILENAME         logfile (default: /dev/null)
+-c FILENAME, --config=FILENAME          config file (default: ~/.config/alot/config)
+-n FILENAME, --notmuch-config=FILENAME  notmuch config (default: $NOTMUCH_CONFIG or ~/.notmuch-config)
+-C COLOUR, --colour-mode=COLOUR         terminal colour mode. Must be 1, 16 or 256
+-p PATH, --mailindex-path=PATH          path to notmuch index
+-d LEVEL, --debug-level=LEVEL           debug log (default: info). Must be one of debug,info,warning or error
+-l FILENAME, --logfile=FILENAME         logfile (default: /dev/null)
 -v, --version                  Display version string and exit
 -h, --help                     Display  help and exit

--- a/docs/source/usage/cli_options.rst
+++ b/docs/source/usage/cli_options.rst
@@ -1,9 +1,16 @@
--r, --read-only                open db in read only mode
--c FILENAME, --config=FILENAME          config file (default: ~/.config/alot/config)
--n FILENAME, --notmuch-config=FILENAME  notmuch config (default: $NOTMUCH_CONFIG or ~/.notmuch-config)
--C COLOUR, --colour-mode=COLOUR         terminal colour mode. Must be 1, 16 or 256
--p PATH, --mailindex-path=PATH          path to notmuch index
--d LEVEL, --debug-level=LEVEL           debug log (default: info). Must be one of debug,info,warning or error
--l FILENAME, --logfile=FILENAME         logfile (default: /dev/null)
--v, --version                  Display version string and exit
--h, --help                     Display  help and exit
+-r, --read-only  open db in read only mode
+-c FILENAME, --config=FILENAME
+                 config file (default: ~/.config/alot/config)
+-n FILENAME, --notmuch-config=FILENAME
+                 notmuch config (default: $NOTMUCH_CONFIG or ~/.notmuch-config)
+-C COLOUR, --colour-mode=COLOUR
+                 terminal colour. Must be 1, 16 or 256
+-p PATH, --mailindex-path=PATH
+                 path to notmuch index
+-d LEVEL, --debug-level=LEVEL
+                 debug log (default: info). Must be one of debug, info, warning
+                 or error
+-l FILENAME, --logfile=FILENAME
+                 logfile (default: /dev/null)
+-v, --version    Display version string and exit
+-h, --help       Display help and exit

--- a/docs/source/usage/cli_options.rst
+++ b/docs/source/usage/cli_options.rst
@@ -4,8 +4,9 @@
 -n FILENAME, --notmuch-config=FILENAME
                  notmuch configuration file (default: $NOTMUCH_CONFIG
                  or ~/.notmuch-config)
--C COLOUR, --colour-mode=COLOUR
-                 terminal colour; must be 1, 16 or 256
+-C COLOURS, --colour-mode=COLOURS
+                 number of colours to use on the terminal; must be 1, 16 or 256
+                 (default: configuration option `colourmode` or 256)
 -p PATH, --mailindex-path=PATH
                  path to notmuch index
 -d LEVEL, --debug-level=LEVEL

--- a/docs/source/usage/cli_options.rst
+++ b/docs/source/usage/cli_options.rst
@@ -8,8 +8,8 @@
 -p PATH, --mailindex-path=PATH
                  path to notmuch index
 -d LEVEL, --debug-level=LEVEL
-                 debug log (default: info). Must be one of debug, info, warning
-                 or error
+                 debug level (default: info). Must be one of debug, info,
+                 warning or error
 -l FILENAME, --logfile=FILENAME
                  logfile (default: /dev/null)
 -v, --version    Display version string and exit

--- a/docs/source/usage/first_steps.rst
+++ b/docs/source/usage/first_steps.rst
@@ -7,4 +7,4 @@ between them, close the current buffer with `d` and list them all with `;`.
 
 The buffer type or *mode* (displayed at the bottom left) determines which prompt commands
 are available. Usage information on any command can be listed by typing `help YOURCOMMAND`
-to the prompt; The key bindings for the current mode are listed upon pressing `?`.
+to the prompt. The keybindings for the current mode are listed upon pressing `?`.

--- a/docs/source/usage/modes/envelope.rst
+++ b/docs/source/usage/modes/envelope.rst
@@ -22,8 +22,8 @@ The following commands are available in envelope mode
     edit mail
 
     optional arguments
-        :---spawn: spawn editor in new terminal.
-        :---refocus: refocus envelope after editing (Defaults to: 'True').
+        :---spawn: spawn editor in new terminal
+        :---refocus: refocus envelope after editing (defaults to: 'True')
 
 .. _cmd.envelope.encrypt:
 
@@ -35,7 +35,7 @@ The following commands are available in envelope mode
         keyid of the key to encrypt with
 
     optional arguments
-        :---trusted: only add trusted keys.
+        :---trusted: only add trusted keys
 
 .. _cmd.envelope.refine:
 
@@ -51,7 +51,7 @@ The following commands are available in envelope mode
 
 .. describe:: retag
 
-    set message tags.
+    set message tags
 
     argument
         comma separated list of tags
@@ -93,7 +93,7 @@ The following commands are available in envelope mode
 
 
     optional arguments
-        :---append: keep previous values.
+        :---append: keep previous values
 
 .. _cmd.envelope.sign:
 
@@ -125,7 +125,7 @@ The following commands are available in envelope mode
         keyid of the key to encrypt with
 
     optional arguments
-        :---trusted: only add trusted keys.
+        :---trusted: only add trusted keys
 
 .. _cmd.envelope.toggleheaders:
 

--- a/docs/source/usage/modes/global.rst
+++ b/docs/source/usage/modes/global.rst
@@ -1,7 +1,7 @@
 .. CAUTION: THIS FILE IS AUTO-GENERATED!
 
 
-Global Commands
+Global commands
 ---------------
 The following commands are available globally
 
@@ -12,8 +12,8 @@ The following commands are available globally
     close a buffer
 
     optional arguments
-        :---redraw: redraw current buffer after command has finished.
-        :---force: never ask for confirmation.
+        :---redraw: redraw current buffer after command has finished
+        :---force: never ask for confirmation
 
 .. _cmd.global.bnext:
 
@@ -50,7 +50,7 @@ The following commands are available globally
 
 .. describe:: call
 
-    Executes python code
+    execute python code
 
     argument
         python command string to call
@@ -66,27 +66,22 @@ The following commands are available globally
         None
 
     optional arguments
-        :---sender: sender.
-        :---template: path to a template message file.
-        :---tags: comma-separated list of tags to apply to message.
-        :---subject: subject line.
-        :---to: recipients.
-        :---cc: copy to.
-        :---bcc: blind copy to.
-        :---attach: attach files.
-        :---omit_signature: do not add signature.
-        :---spawn: spawn editor in new terminal.
+        :---sender: sender
+        :---template: path to a template message file
+        :---tags: comma-separated list of tags to apply to message
+        :---subject: subject line
+        :---to: recipients
+        :---cc: copy to
+        :---bcc: blind copy to
+        :---attach: attach files
+        :---omit_signature: do not add signature
+        :---spawn: spawn editor in new terminal
 
 .. _cmd.global.exit:
 
 .. describe:: exit
 
-    Shut down cleanly.
-
-    The _prompt variable is for internal use only, it's used to control
-    prompting to close without sending, and is used by the BufferCloseCommand
-    if settings change after yielding to the UI.
-    
+    shut down cleanly
 
 
 .. _cmd.global.flush:
@@ -100,8 +95,8 @@ The following commands are available globally
 
 .. describe:: help
 
-    display help for a command. Use 'bindings' to display all keybings
-    interpreted in current mode.'
+    display help for a command (use 'bindings' to display all keybindings
+    interpreted in current mode)
 
     argument
         command or 'bindings'
@@ -145,14 +140,14 @@ The following commands are available globally
 
 .. describe:: reload
 
-    Reload all configuration files
+    reload all configuration files
 
 
 .. _cmd.global.repeat:
 
 .. describe:: repeat
 
-    Repeats the command executed last time
+    repeat the command executed last time
 
 
 .. _cmd.global.search:
@@ -166,7 +161,7 @@ The following commands are available globally
         search string
 
     optional arguments
-        :---sort: sort order. Valid choices are: \`oldest_first\`,\`newest_first\`,\`message_id\`,\`unsorted\`.
+        :---sort: sort order; valid choices are: \`oldest_first\`,\`newest_first\`,\`message_id\`,\`unsorted\`
 
 .. _cmd.global.shellescape:
 
@@ -178,9 +173,9 @@ The following commands are available globally
         command line to execute
 
     optional arguments
-        :---spawn: run in terminal window.
-        :---thread: run in separate thread.
-        :---refocus: refocus current buffer after command has finished.
+        :---spawn: run in terminal window
+        :---thread: run in separate thread
+        :---refocus: refocus current buffer after command has finished
 
 .. _cmd.global.taglist:
 
@@ -189,5 +184,5 @@ The following commands are available globally
     opens taglist buffer
 
     optional arguments
-        :---tags: tags to display.
+        :---tags: tags to display
 

--- a/docs/source/usage/modes/search.rst
+++ b/docs/source/usage/modes/search.rst
@@ -25,7 +25,7 @@ The following commands are available in search mode
         search string
 
     optional arguments
-        :---sort: sort order. Valid choices are: \`oldest_first\`,\`newest_first\`,\`message_id\`,\`unsorted\`.
+        :---sort: sort order; valid choices are: \`oldest_first\`,\`newest_first\`,\`message_id\`,\`unsorted\`
 
 .. _cmd.search.refineprompt:
 
@@ -44,8 +44,8 @@ The following commands are available in search mode
         comma separated list of tags
 
     optional arguments
-        :---no-flush: postpone a writeout to the index (Defaults to: 'True').
-        :---all: retag all messages in search result.
+        :---no-flush: postpone a writeout to the index (defaults to: 'True')
+        :---all: retag all messages in search result
 
 .. _cmd.search.retagprompt:
 
@@ -68,7 +68,7 @@ The following commands are available in search mode
     set sort order
 
     argument
-        sort order. valid choices are: \`oldest_first\`,\`newest_first\`,\`message_id\`,\`unsorted\`.
+        sort order; valid choices are: \`oldest_first\`,\`newest_first\`,\`message_id\`,\`unsorted\`
 
 
 .. _cmd.search.tag:
@@ -81,20 +81,20 @@ The following commands are available in search mode
         comma separated list of tags
 
     optional arguments
-        :---no-flush: postpone a writeout to the index (Defaults to: 'True').
-        :---all: retag all messages in search result.
+        :---no-flush: postpone a writeout to the index (defaults to: 'True')
+        :---all: retag all messages in search result
 
 .. _cmd.search.toggletags:
 
 .. describe:: toggletags
 
-    flip presence of tags on this thread. A tag is considered present if at least one message contained in this thread is tagged with it. In that case this command will remove the tag from every message in the thread.
+    flip presence of tags on this thread: a tag is considered present and removed if at least one message in this thread is tagged with it
 
     argument
         comma separated list of tags
 
     optional arguments
-        :---no-flush: postpone a writeout to the index (Defaults to: 'True').
+        :---no-flush: postpone a writeout to the index (defaults to: 'True')
 
 .. _cmd.search.untag:
 
@@ -106,6 +106,6 @@ The following commands are available in search mode
         comma separated list of tags
 
     optional arguments
-        :---no-flush: postpone a writeout to the index (Defaults to: 'True').
-        :---all: retag all messages in search result.
+        :---no-flush: postpone a writeout to the index (defaults to: 'True')
+        :---all: retag all messages in search result
 

--- a/docs/source/usage/modes/thread.rst
+++ b/docs/source/usage/modes/thread.rst
@@ -19,7 +19,7 @@ The following commands are available in thread mode
     edit message in as new
 
     optional arguments
-        :---spawn: open editor in new window.
+        :---spawn: open editor in new window
 
 .. _cmd.thread.fold:
 
@@ -38,8 +38,8 @@ The following commands are available in thread mode
     forward message
 
     optional arguments
-        :---attach: attach original mail.
-        :---spawn: open editor in new window.
+        :---attach: attach original mail
+        :---spawn: open editor in new window
 
 .. _cmd.thread.indent:
 
@@ -71,14 +71,14 @@ The following commands are available in thread mode
         shellcommand to pipe to
 
     optional arguments
-        :---all: pass all messages.
-        :---format: output format. Valid choices are: \`raw\`,\`decoded\`,\`id\`,\`filepath\` (Defaults to: 'raw').
-        :---separately: call command once for each message.
-        :---background: don't stop the interface.
-        :---add_tags: add 'Tags' header to the message.
-        :---shell: let the shell interpret the command.
-        :---notify_stdout: display cmd's stdout as notification.
-        :---field_key: mailcap field key for decoding (Defaults to: 'copiousoutput').
+        :---all: pass all messages
+        :---format: output format; valid choices are: \`raw\`,\`decoded\`,\`id\`,\`filepath\` (defaults to: 'raw')
+        :---separately: call command once for each message
+        :---background: don't stop the interface
+        :---add_tags: add 'Tags' header to the message
+        :---shell: let the shell interpret the command
+        :---notify_stdout: display cmd's stdout as notification
+        :---field_key: mailcap field key for decoding (defaults to: 'copiousoutput')
 
 .. _cmd.thread.print:
 
@@ -87,10 +87,10 @@ The following commands are available in thread mode
     print message(s)
 
     optional arguments
-        :---all: print all messages.
-        :---raw: pass raw mail string.
-        :---separately: call print command once for each message.
-        :---add_tags: add 'Tags' header to the message.
+        :---all: print all messages
+        :---raw: pass raw mail string
+        :---separately: call print command once for each message
+        :---add_tags: add 'Tags' header to the message
 
 .. _cmd.thread.remove:
 
@@ -99,7 +99,7 @@ The following commands are available in thread mode
     remove message(s) from the index
 
     optional arguments
-        :---all: remove whole thread.
+        :---all: remove whole thread
 
 .. _cmd.thread.reply:
 
@@ -108,9 +108,9 @@ The following commands are available in thread mode
     reply to message
 
     optional arguments
-        :---all: reply to all.
-        :---list: reply to list.
-        :---spawn: open editor in new window.
+        :---all: reply to all
+        :---list: reply to list
+        :---spawn: open editor in new window
 
 .. _cmd.thread.retag:
 
@@ -122,8 +122,8 @@ The following commands are available in thread mode
         comma separated list of tags
 
     optional arguments
-        :---all: tag all messages in thread.
-        :---no-flush: postpone a writeout to the index (Defaults to: 'True').
+        :---all: tag all messages in thread
+        :---no-flush: postpone a writeout to the index (defaults to: 'True')
 
 .. _cmd.thread.retagprompt:
 
@@ -142,15 +142,15 @@ The following commands are available in thread mode
         path to save to
 
     optional arguments
-        :---all: save all attachments.
+        :---all: save all attachments
 
 .. _cmd.thread.select:
 
 .. describe:: select
 
-    select focussed element. The fired action depends on the focus:
-        - if message summary, this toggles visibility of the message,
-        - if attachment line, this opens the attachment
+    select focussed element:
+        - if it is a message summary, toggle visibility of the message;
+        - if it is an attachment line, open the attachment
 
 
 .. _cmd.thread.tag:
@@ -163,8 +163,8 @@ The following commands are available in thread mode
         comma separated list of tags
 
     optional arguments
-        :---all: tag all messages in thread.
-        :---no-flush: postpone a writeout to the index (Defaults to: 'True').
+        :---all: tag all messages in thread
+        :---no-flush: postpone a writeout to the index (defaults to: 'True')
 
 .. _cmd.thread.toggleheaders:
 
@@ -196,8 +196,8 @@ The following commands are available in thread mode
         comma separated list of tags
 
     optional arguments
-        :---all: tag all messages in thread.
-        :---no-flush: postpone a writeout to the index (Defaults to: 'True').
+        :---all: tag all messages in thread
+        :---no-flush: postpone a writeout to the index (defaults to: 'True')
 
 .. _cmd.thread.unfold:
 
@@ -219,6 +219,6 @@ The following commands are available in thread mode
         comma separated list of tags
 
     optional arguments
-        :---all: tag all messages in thread.
-        :---no-flush: postpone a writeout to the index (Defaults to: 'True').
+        :---all: tag all messages in thread
+        :---no-flush: postpone a writeout to the index (defaults to: 'True')
 


### PR DESCRIPTION
Applies a bit of copyediting polish to the documentation. I think you might want to pull everything in (obviously), but the branch should be cherry-pickable.

There are more typos and things to edit, but I’ll limit myself to this for now. One question: what should be done with the inconsistent usage of focused/focussed? (This PR leaves things as they are.)