### PR TITLE
commands/globals: Convert Address to string for email.utils

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -818,7 +818,8 @@ class ComposeCommand(Command):
             accounts = settings.get_accounts()
             if len(accounts) == 1:
                 a = accounts[0]
-                fromstring = email.utils.formataddr((a.realname, a.address))
+                fromstring = email.utils.formataddr(
+                    (a.realname, str(a.address)))
                 self.envelope.add('From', fromstring)
             else:
                 cmpl = AccountCompleter()


### PR DESCRIPTION
Email.utils apparently assumes it's getting a string, and calls encode
without converting first. This can only be hit if you have a single
account configured, not with multiple accounts.

Fixes #1277