### PR TITLE
commands/thread: Don't refresh after moving

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -1058,7 +1058,6 @@ class MoveFocusCommand(MoveCommand):
             MoveCommand.apply(self, ui)
         # TODO add 'next matching' if threadbuffer stores the original query
         # TODO: add next by date..
-        tbuffer.body.refresh()
 
 
 @registerCommand(MODE, 'select')


### PR DESCRIPTION
For large threads (I can reproduce on threads with ~50 messages),
changing messages can become quite slow, especially if there are a
significant number of folded messages. Removing the call to refresh the
body after moving seems to fix this.

There may be side effects of this change, and it may be required in some
cases, just not all of them.