### PR TITLE
Don't try to add Content-Disposition header to mime that already has one

### DIFF
--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -470,8 +470,11 @@ def extract_body(mail, types=None, field_key='copiousoutput'):
             rendered_payload = render_part(part)
             if rendered_payload:  # handler had output
                 body_parts.append(string_sanitize(rendered_payload))
-            else:  # mark as attachment
-                part.add_header('Content-Disposition', 'attachment; ' + cd)
+            # mark as attachment
+            elif cd:
+                part.replace_header('Content-Disposition', 'attachment; ' + cd)
+            else:
+                part.add_header('Content-Disposition', 'attachment;')
     return u'\n\n'.join(body_parts)
 
 


### PR DESCRIPTION
… one

Currently in db.utils.extract_body we try to add a Content-Disposition
header, regardless of whether an email already has one. This isn't
actually legal, and individual mime message may only have one C-D. The
correction is to replace the header with the modified header if it
already exists, and to add a new one only if the message doesn't have
one.

Note that I haven't actually seen a message that hits the path that
would need "add_header", only "replace_header". I have however included
it because it would be a behavioral change to not handle that case.

Fixes #1297