### PR TITLE
Check the return code from sendmail

### DIFF
--- a/alot/account.py
+++ b/alot/account.py
@@ -348,7 +348,9 @@ class SendmailAccount(Account):
 
         try:
             # make sure self.mail is a string
-            out, *_ = await call_cmd_async(cmdlist, stdin=str(mail))
+            out, err, code = await call_cmd_async(cmdlist, stdin=str(mail))
+            if code != 0:
+                raise Exception
         except Exception as e:
             logging.error(str(e))
             raise SendingMailFailed(str(e))

--- a/alot/account.py
+++ b/alot/account.py
@@ -350,7 +350,9 @@ class SendmailAccount(Account):
             # make sure self.mail is a string
             out, err, code = await call_cmd_async(cmdlist, stdin=str(mail))
             if code != 0:
-                raise Exception
+                msg = 'The sendmail command {} returned with code {}{}'.format(
+                    self.cmd, code, ':\n' + err.strip() if err else '.')
+                raise Exception(msg)
         except Exception as e:
             logging.error(str(e))
             raise SendingMailFailed(str(e))

--- a/tests/account_test.py
+++ b/tests/account_test.py
@@ -168,7 +168,6 @@ class TestSend(unittest.TestCase):
         #self.assertIn(cm.output, "sent mail successfullya")
         self.assertIn("INFO:root:sent mail successfully", cm.output)
 
-    @unittest.expectedFailure
     @utilities.async_test
     async def test_failing_sendmail_command_is_noticed(self):
         a = account.SendmailAccount(address="test@alot.dev", cmd="false")


### PR DESCRIPTION
I took the simple route, so maybe there is a better way to get the exception for the failing command than the simple assert. But this should fix #1303 which was quite annoying.