### PR TITLE
Enable zsh completion of email addresses

### DIFF
--- a/extra/completion/alot-completion.zsh
+++ b/extra/completion/alot-completion.zsh
@@ -24,6 +24,18 @@ _alot_search()
     '--sort=[sort results]:sorting:((newest_first\:"reverse chronological order" oldest_first\:"chronological order" message_id\:"lexicographically by Message Id"))'
 }
 
+_alot_account_emails()
+{
+  python3 - ${XDG_CONFIG_HOME:-~/.config}/alot/config <<-'EOF'
+	import configobj, sys
+	config = configobj.ConfigObj(infile=sys.argv[1], encoding="UTF8")
+	accounts = config.get("accounts", {})
+	addresses = [accounts[k].get('address') for k in accounts
+							 if type(accounts[k]) is configobj.Section]
+	print(" ".join(addresses), end="")
+	EOF
+}
+
 _alot_compose()
 {
   _arguments -s : \
@@ -31,7 +43,7 @@ _alot_compose()
     '--bcc=[Blind Carbon Copy header]:Recipient (Bcc header):_email_addresses' \
     '--cc=[Carbon Copy header]:Recipient (Cc header):_email_addresses' \
     '--omit_signature[do not add signature]' \
-    '--sender=[From header]' \
+    "--sender=[From header]:Sender account:($(_alot_account_emails))" \
     '--subject=[Subject header]' \
     '--template=[template file to use]' \
     '--to=[To header]:Recipient (To header):_email_addresses' \

--- a/extra/completion/alot-completion.zsh
+++ b/extra/completion/alot-completion.zsh
@@ -27,13 +27,14 @@ _alot_search()
 _alot_compose()
 {
   _arguments -s : \
+    '--attach=[Attach files]:attach:_files -/' \
+    '--bcc=[Blind Carbon Copy header]:Recipient (Bcc header):_email_addresses' \
+    '--cc=[Carbon Copy header]:Recipient (Cc header):_email_addresses' \
     '--omit_signature[do not add signature]' \
     '--sender=[From header]' \
     '--subject=[Subject header]' \
-    '--cc=[Carbon Copy header]' \
-    '--bcc=[Blind Carbon Copy header]' \
     '--template=[template file to use]' \
-    '--attach=[Attach files]:attach:_files -/'\
+    '--to=[To header]:Recipient (To header):_email_addresses' \
 }
 
 _alot()


### PR DESCRIPTION
Currently only the recipient addresses are completed.  It does not make
sense to add the same completion for the sender option as this should
only be used with addresses that are defined in the alot config file.

I have this code ready which we can put in a zsh function to complete the
sender account addresses.
```python
import configobj, sys
config = configobj.ConfigObj(infile=sys.argv[1], encoding="UTF8")
accounts = config.get("accounts", {})
addresses = [accounts[k].get('address') for k in accounts
	     if type(accounts[k]) is configobj.Section]
print(" ".join(addresses))
```
It can be defined inline in the zsh function like this:
```zsh
_alot_account_emails()
{
  python3 - ${XDG_CONFIG_HOME:-~/.config}/alot/config <<-'EOF'
	...
	EOF
}
```
My problem currently is that I don't know enough zsh completion logic to turn
`_alot_account_emails` into a proper completion function that could be used
like the `_email_addresses` function in this patch.

Does anyone of you know how to do it?  Otherwise we can also merge just this
one commit.