### PR TITLE
Option to delete old drafts when sending or saving.

### DIFF
--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -133,23 +133,59 @@ class SaveCommand(Command):
         path = account.store_draft_mail(
             mail.as_string(policy=email.policy.SMTP))
 
-        msg = 'draft saved successfully'
-
         # add mail to index if maildir path available
         if path is not None:
-            ui.notify(msg + ' to %s' % path)
+            ui.notify('draft saved successfully to %s' % path)
             logging.debug('adding new mail to index')
             try:
                 ui.dbman.add_message(path, account.draft_tags + envelope.tags)
                 await ui.apply_command(globals.FlushCommand())
-                await ui.apply_command(commands.globals.BufferCloseCommand())
             except DatabaseError as e:
                 logging.error(str(e))
                 ui.notify('could not index message:\n%s' % str(e),
                           priority='error',
                           block=True)
-        else:
-            await ui.apply_command(commands.globals.BufferCloseCommand())
+                return
+
+        # if provided, delete the old draft
+        if envelope.previous_draft is not None:
+            if settings.get('envelope_always_delete_old_drafts'):
+                del_old_draft = True
+            else:
+                msg = 'Do you want to delete the old draft?'
+                del_old_draft = (await ui.choice(msg, cancel='no',
+                                                 msg_position='left'))
+                del_old_draft = (del_old_draft == 'yes')
+            if del_old_draft:
+                try:
+                    message_path = envelope.previous_draft.get_filename()
+                except Exception as e:
+                    logging.error(e)
+                    ui.notify('could not get draft path:\n%s' % e,
+                              priority='error', block=True)
+                    return
+
+                try:
+                    ui.dbman.remove_message(envelope.previous_draft)
+                    await ui.apply_command(globals.FlushCommand())
+                except DatabaseError as e:
+                    logging.error(e)
+                    ui.notify('could not remove draft from db:\n%s' % e,
+                              priority='error', block=True)
+                    return
+
+                try:
+                    os.unlink(message_path)
+                except OSError as e:
+                    logging.error(e)
+                    ui.notify('could not delete draft file:\n%s' % e,
+                              priority='error', block=True)
+                    return
+
+        # strip the outside '<' and '>' characters from the id
+        mid = mail['Message-ID'][1:-1]
+        envelope.previous_draft = ui.dbman.get_message(mid)
+        await ui.apply_command(commands.globals.BufferCloseCommand())
 
 
 @registerCommand(MODE, 'send')
@@ -279,6 +315,47 @@ class SendCommand(Command):
                 logging.debug('adding new mail to index')
                 ui.dbman.add_message(path, account.sent_tags + initial_tags)
                 await ui.apply_command(globals.FlushCommand())
+
+            # if provided, delete the old draft
+            try:
+                p_draft = self.envelope.previous_draft
+            except AttributeError:
+                pass
+            else:
+                if settings.get('envelope_always_delete_old_drafts'):
+                    del_old_draft = True
+                else:
+                    msg = 'Do you want to delete the old draft?'
+                    del_old_draft = (await ui.choice(msg, cancel='no',
+                                                     msg_position='left'))
+                    del_old_draft = (del_old_draft == 'yes')
+                if del_old_draft:
+                    try:
+                        message_path = p_draft.get_filename()
+                    except Exception as e:
+                        logging.error(e)
+                        ui.notify('could not get draft path:\n%s' % e,
+                                  priority='error', block=True)
+                        return
+
+                    try:
+                        ui.dbman.remove_message(p_draft)
+                        await ui.apply_command(globals.FlushCommand())
+                    except DatabaseError as e:
+                        logging.error(e)
+                        ui.notify('could not remove draft from db:\n%s' % e,
+                                  priority='error', block=True)
+                        return
+
+                    try:
+                        os.unlink(message_path)
+                    except OSError as e:
+                        logging.error(e)
+                        ui.notify('could not delete draft file:\n%s' % e,
+                                  priority='error', block=True)
+                        return
+
+                    self.envelope.previous_draft = None
 
 
 @registerCommand(MODE, 'edit', arguments=[

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -500,9 +500,15 @@ class EditNewCommand(Command):
         tags.difference_update({'inbox', 'sent', 'draft', 'killed', 'replied',
                                 'signed', 'encrypted', 'unread', 'attachment'})
         tags = list(tags)
+
+        draft = None
+        if 'draft' in self.message.get_tags():
+            draft = self.message
+
         # set body text
         mailcontent = self.message.accumulate_body()
-        envelope = Envelope(bodytext=mailcontent, tags=tags)
+        envelope = Envelope(bodytext=mailcontent, tags=tags,
+                            previous_draft=draft)
 
         # copy selected headers
         to_copy = ['Subject', 'From', 'To', 'Cc', 'Bcc', 'In-Reply-To',

--- a/alot/db/envelope.py
+++ b/alot/db/envelope.py
@@ -49,7 +49,7 @@ class Envelope(object):
     def __init__(
             self, template=None, bodytext=None, headers=None, attachments=None,
             sign=False, sign_key=None, encrypt=False, tags=None, replied=None,
-            passed=None):
+            passed=None, previous_draft=None):
         """
         :param template: if not None, the envelope will be initialised by
                          :meth:`parsing <parse_template>` this string before
@@ -85,6 +85,7 @@ class Envelope(object):
         self.tags = tags or []  # tags to add after successful sendout
         self.replied = replied  # message being replied to
         self.passed = passed  # message being passed on
+        self.previous_draft = previous_draft
         self.sent_time = None
         self.modified_since_sent = False
         self.sending = False  # semaphore to avoid accidental double sendout

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -274,6 +274,9 @@ periodic_hook_frequency = integer(default=300)
 # for the whole message body.
 thread_focus_linewise = boolean(default=True)
 
+# When sending an email or saving a new draft, always delete the old draft.
+# If set to False, the user will be prompted every time.
+envelope_always_delete_old_drafts = boolean(default=False)
 
 # Key bindings
 [bindings]

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -209,6 +209,17 @@
     :default: "UTF-8"
 
 
+.. _envelope-always-delete-old-drafts:
+
+.. describe:: envelope_always_delete_old_drafts
+
+     When sending an email or saving a new draft, always delete the old draft.
+     If set to False, the user will be prompted every time.
+
+    :type: boolean
+    :default: False
+
+
 .. _envelope-headers-blacklist:
 
 .. describe:: envelope_headers_blacklist


### PR DESCRIPTION
When you run the 'editnew' command in a thread view, if the email you are copying has the 'draft' flag, it will pass this message on to the envelope object. When the user saves or sends a draft, they will be prompted to delete the old draft.

I do not currently have alot set up to send emails, so someone would need to test that process. But I believe it should work, it's not really any different from the process when saving new drafts.

Let me know if you'd like me to change anything.