### PR TITLE
Implement `toggleset` to allow easy set/unset of header

### DIFF
--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -428,26 +428,19 @@ class SetCommand(Command):
         envelope = ui.current_buffer.envelope
 
         if self.action == 'set':
-            do_set = True
+            # add a new header
+            envelope.add(self.key, self.value, self.reset)
         elif self.action == 'unset':
-            do_set = False
-        elif self.action == 'toggleset':
-            # in case we toggle we only `set` a new header if it didn't exist
-            # already before, in case it exists we will simply remove it hence
-            # `do_set = False`
-            do_set = False if self.key in envelope else True
-
-        if self.reset or not do_set:
-            # remove the existing header if
-            #  - we don't append
-            #  - we are in a toggle scenario and it exists already
-            #  - we are in the unset scenario
-
+            # we want to unset the header if it already exists
             if self.key in envelope:
                 del envelope[self.key]
-
-        if do_set:
-            envelope.add(self.key, self.value)
+        elif self.action == 'toggleset':
+            # in case we toggle we only add a new header if it didn't exist
+            # already before, in case it exists we will simply remove it
+            if self.key in envelope:
+                del envelope[self.key]
+            else:
+                envelope.add(self.key, self.value)
 
         # FIXME: handle BCC as well
         # Currently we don't handle bcc because it creates a side channel leak,

--- a/alot/db/envelope.py
+++ b/alot/db/envelope.py
@@ -96,12 +96,7 @@ class Envelope(object):
         """setter for header values. This allows adding header like so:
         envelope['Subject'] = u'sm\xf8rebr\xf8d'
         """
-        if name not in self.headers:
-            self.headers[name] = []
-        self.headers[name].append(val)
-
-        if self.sent_time:
-            self.modified_since_sent = True
+        self.add(name, val, True)
 
     def __getitem__(self, name):
         """getter for header values.
@@ -136,9 +131,9 @@ class Envelope(object):
             value = fallback or []
         return value
 
-    def add(self, key, value):
+    def add(self, key, value, reset=False):
         """add header value"""
-        if key not in self.headers:
+        if key not in self.headers or reset:
             self.headers[key] = []
         self.headers[key].append(value)
 

--- a/docs/source/usage/modes/envelope.rst
+++ b/docs/source/usage/modes/envelope.rst
@@ -85,7 +85,7 @@ The following commands are available in envelope mode:
 
 .. describe:: set
 
-    set header value
+    set/unset/toggle a header value
 
     positional arguments
         0: header to refine
@@ -134,6 +134,18 @@ The following commands are available in envelope mode:
     toggle display of all headers
 
 
+.. _cmd.envelope.toggleset:
+
+.. describe:: toggleset
+
+    set/unset/toggle a header value
+
+    positional arguments
+        0: header to refine
+        1: value
+
+
+
 .. _cmd.envelope.togglesign:
 
 .. describe:: togglesign
@@ -175,7 +187,7 @@ The following commands are available in envelope mode:
 
 .. describe:: unset
 
-    remove header field
+    set/unset/toggle a header value
 
     argument
         header to refine


### PR DESCRIPTION
There is currently no toggletags equivalent for a header field.
To easily switch certain predefined header fields in the config
file on or off it is useful to have the option of binding
```
toggleset key value
```
to a certain key, making it for the user easy to switch between
different scenarios in which specific headers are wanted or
unwanted.

Suggestions for implementation or naming are of course very
welcome.

This addresses a small thing I noticed in an earlier comment of
mine: https://github.com/pazz/alot/issues/1299#issuecomment-423550190.