### PR TITLE
Show decrypted subject in search results.

### DIFF
--- a/alot/db/thread.py
+++ b/alot/db/thread.py
@@ -49,6 +49,22 @@ class Thread(object):
                 subject = ''
         self._subject = subject
 
+        # maybe decrypt subject in protected headers
+        # (see: https://github.com/autocrypt/memoryhole)
+        msgs = [m for m in thread.get_messages()]
+        last = msgs[-1]
+        first_part = last.get_message_parts()[0]
+        if first_part.get_content_type() == 'application/pgp-encrypted':
+            second_part = last.get_message_parts()[1]
+            encrypted = second_part.get_payload()
+            from email.parser import Parser
+            from alot.crypto import decrypt_verify
+            _, plaintext = decrypt_verify(encrypted)
+            parser = Parser()
+            decrypted = parser.parsestr(plaintext)
+            if decrypted.get_param('protected-headers') == 'v1':
+                self._subject = decrypted.get('subject')
+
         self._authors = None
         ts = thread.get_oldest_date()
 


### PR DESCRIPTION
Memory hole is currently implemented in Enigmail and message headers can
be protected in the encrypted payload of a message. This commit modifies
the update of a thread's subject by extracting the subject from the
encrypted headers when the most recent message contains protected
headers (v1). This results in the decrypted header being shown in the
search results.

See:

  https://github.com/autocrypt/memoryhole
  https://wiki.gnupg.org/OpenPGPEmailSummit201607/MemoryHole
  https://www.enigmail.net/index.php/en/user-manual/advanced-operations

This is part of #1233. Another part is missing to show decrypted headers
in the message tree.