### PR TITLE
Fix async idle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ install:
   - |
     set -e
     if [[ $JOB = docs ]]; then
-      pip install configobj python-magic urwidtrees
+      pip install configobj twisted python-magic urwidtrees
       # Mock all "difficult" dependencies of alot in order to be able to import
       # alot when rebuilding the documentation.  Notmuch would have to be
       # installed by hand in order to get a recent enough version on travis.

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,6 @@
 0.8:
 * Port to python 3. Python 2.x no longer supported
 * feature: Add a new 'namedqueries' buffer type for displaying named queries.
-* feature: Replace twisted with asyncio
 * bug fix: correct handling of subparts with different encodings
 
 0.7:

--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -16,6 +16,9 @@ from alot.commands import *
 from alot.commands import CommandParseError, COMMANDS
 from alot.utils import argparse as cargparse
 
+from twisted.internet import asyncioreactor
+asyncioreactor.install()
+
 
 _SUBCOMMANDS = ['search', 'compose', 'bufferlist', 'taglist', 'namedqueries',
                 'pyshell']

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -310,7 +310,7 @@ class UI(object):
         """
         history = history or []
 
-        fut = asyncio.Future()
+        fut = asyncio.get_event_loop().create_future()
         oldroot = self.mainloop.widget
 
         def select_or_cancel(text):
@@ -539,7 +539,7 @@ class UI(object):
         assert cancel is None or cancel in choices.values()
         assert msg_position in ['left', 'above']
 
-        fut = asyncio.Future()  # Create a returned future
+        fut = asyncio.get_event_loop().create_future()  # Create a returned future
         oldroot = self.mainloop.widget
 
         def select_or_cancel(text):

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -115,7 +115,7 @@ class UI(object):
         self.mainloop = urwid.MainLoop(
             self.root_widget,
             handle_mouse=settings.get('handle_mouse'),
-            event_loop=urwid.AsyncioEventLoop(),
+            event_loop=urwid.TwistedEventLoop(),
             unhandled_input=self._unhandled_input,
             input_filter=self._input_filter)
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'notmuch>=0.26',
         'urwid>=1.3.0',
         'urwidtrees>=1.0',
+        'twisted>=10.2.0',
         'python-magic',
         'configobj>=4.7.0',
         'gpg'


### PR DESCRIPTION
It turns out that urwid just doesn't work very will with asyncio. I simply don't have time or motivation to try to fix urwid, so instead I'm proposing trying to get the nice syntax of asyncio, but without the overhead by continuing to use urwid's `TwistedEventLoop`. Since we've installed the twisted reactor as the asyncio loop, starting Twisted's loop starts processing asyncio calls.