### PR TITLE
Add a mail corpus for the test suite

### DIFF
--- a/tests/db/utils_test.py
+++ b/tests/db/utils_test.py
@@ -741,3 +741,13 @@ class TestRemoveCte(unittest.TestCase):
         # This should not raise an UnicodeDecodeError.
         utils.remove_cte(mail, as_string=True)
         self.assertTrue(True)
+
+    @unittest.expectedFailure
+    def test_issue_1301(self):
+        fp = open('tests/static/mail/latin-1.eml')
+        mail = email.message_from_file(fp)
+        # This should not raise an Exception("Unknown Content-Transfer-Encoding")
+        # Currently it even throws another Exception.
+        utils.remove_cte(mail, as_string=True)
+        self.assertTrue(True)
+

--- a/tests/db/utils_test.py
+++ b/tests/db/utils_test.py
@@ -736,16 +736,16 @@ class TestRemoveCte(unittest.TestCase):
 
     @unittest.expectedFailure
     def test_issue_1291(self):
-        fp = open('tests/static/mail/broken-utf8.eml')
-        mail = email.message_from_file(fp)
+        with open('tests/static/mail/broken-utf8.eml') as fp:
+            mail = email.message_from_file(fp)
         # This should not raise an UnicodeDecodeError.
         utils.remove_cte(mail, as_string=True)
         self.assertTrue(True)
 
     @unittest.expectedFailure
     def test_issue_1301(self):
-        fp = open('tests/static/mail/latin-1.eml')
-        mail = email.message_from_file(fp)
+        with open('tests/static/mail/latin-1.eml') as fp:
+            mail = email.message_from_file(fp)
         # This should not raise an Exception("Unknown Content-Transfer-Encoding")
         # Currently it even throws another Exception.
         utils.remove_cte(mail, as_string=True)

--- a/tests/db/utils_test.py
+++ b/tests/db/utils_test.py
@@ -730,3 +730,14 @@ class TestMessageFromString(unittest.TestCase):
         m['To'] = 'Nobody'
         message = utils.decrypted_message_from_string(m.as_string())
         self.assertEqual(message.get_payload(), 'This is some text')
+
+
+class TestRemoveCte(unittest.TestCase):
+
+    @unittest.expectedFailure
+    def test_issue_1291(self):
+        fp = open('tests/static/mail/broken-utf8.eml')
+        mail = email.message_from_file(fp)
+        # This should not raise an UnicodeDecodeError.
+        utils.remove_cte(mail, as_string=True)
+        self.assertTrue(True)

--- a/tests/static/mail/broken-utf8.eml
+++ b/tests/static/mail/broken-utf8.eml
@@ -1,0 +1,9 @@
+Subject: Broken UTF8 byte in quoted printable
+From: josh@github
+To: test@alot
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+=C2=A1This works!
+=A1This doesn't!

--- a/tests/static/mail/latin-1.eml
+++ b/tests/static/mail/latin-1.eml
@@ -1,0 +1,8 @@
+Subject: 7bit Tränsfer Encöding with lätin1 in bödy and sübject
+To: lucc@github
+From: test@alot
+MIME-Version: 1.0;
+Content-Type: text/plain; charset=iso-8859-1;
+Content-Transfer-Encoding: 7bit;
+
+Föö Bär Bäz

--- a/tests/static/mail/sender-with-wide-chars.eml
+++ b/tests/static/mail/sender-with-wide-chars.eml
@@ -1,0 +1,5 @@
+Subject: wide chars in From: header
+From: =?utf-8?b?5ZC06bmP?= <pazz@github>
+To: test@alot
+
+testing issue #1262.


### PR DESCRIPTION
This was discussed before (#1268) and there is a wiki entry for this [here](https://github.com/pazz/alot/wiki/Future-Tests). **Currently this is just a WIP branch to get the discussion going.**

I was looking at the open issues for the [0.8 milestone](https://github.com/pazz/alot/milestone/13) and both remaining issues are about mail decoding which looks like a topic best covered by a corpus of some example mails. So I took the liberty to start this.

Questions: Should we keep a notmuch index in git?
1. Pro: maybe faster when running the tests as it doesn't have to be created on the fly
2. Pro: Less setup code for a test that needs it.
3. Con:  Not all tests that need a mail from the corpus might need the index
4. Con: Maybe it will create problems if the tests are run with a different version than the version with which the index was created.
5. Con: Binary files in git. (but it is rather small when `notmuch compact` is called)