### PR TITLE
utils: replace unreadable characters when decode payload

### DIFF
--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -422,7 +422,7 @@ def remove_cte(part, as_string=False):
         # encodindigs. maybe those are useful?
         if not as_string:
             return raw_payload
-        return raw_payload.decode(enc)
+        return raw_payload.decode(enc, errors="replace")
     raise Exception('Unreachable')
 
 


### PR DESCRIPTION
If the encoding doesn't correspond with some characters on the payload,
instead of crashing with a 'UnicodeDecodeError', let's replace the
invalid characters so we the email is displayed.