### PR TITLE
db/message: accept attachments of type pgp-encrypted

### DIFF
--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -252,10 +252,13 @@ class Message(object):
                 if ct in ['octet/stream', 'application/octet-stream']:
                     content = part.get_payload(decode=True)
                     ct = helper.guess_mimetype(content)
+                    if (self._attachments and
+                            self._attachments[-1].get_content_type() ==
+                            'application/pgp-encrypted'):
+                        self._attachments.pop()
 
                 if cd.lower().startswith('attachment'):
-                    if ct.lower() not in ['application/pgp-encrypted',
-                                          'application/pgp-signature']:
+                    if ct.lower() not in ['application/pgp-signature']:
                         self._attachments.append(Attachment(part))
                 elif cd.lower().startswith('inline'):
                     if (filename is not None and


### PR DESCRIPTION
Some email clients (like thunderbird) if you attach a .gpg file it will
say the attachment content type is 'application/pgp-encrypted'. We need
to discard only the attachments with content type
'application/pgp-encrypted' if they are followed by an
'application/octet-stream', beacuse this case is a PGP/MIME message:
https://tools.ietf.org/html/rfc3156#section-6.1