### PR TITLE
make bounce command use the correct sender account

### DIFF
--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -253,7 +253,7 @@ class SendCommand(Command):
         if not isinstance(msg, email.message.Message):
             msg = email.message_from_string(
                 self.mail, policy=email.policy.SMTP)
-        address = msg.get('From', '')
+        address = msg.get('Resent-From', False) or msg.get('From', '')
         logging.debug("FROM: \"%s\"" % address)
         try:
             account = settings.get_account_by_address(address,


### PR DESCRIPTION
Bounce correctly determines the address and account to send the bounce
from. It uses the account to choose an address book for "to:" completion
and passes the sender address as "Resent-From:" to SendCommand(). The
latter uses the "From:" header, though, to determine the sending account
again and (in the case of a bounce) wrongly.

Make SendCommand() use "Resent-From:" if present and "From:" else.

Code remark: specifying "False" as the default return value for get()
ist not necessary; it is meant to make this short form clearer to read,
and to safeguard for times when '' or None do not evaluate to False
here.

Fixes #1331 :)