### PR TITLE
Travis: "use notices instead of regular messages"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -157,3 +157,4 @@ after_success: |
 notifications:
   irc: "chat.freenode.net#alot"
   on_success: change
+  use_notice: true


### PR DESCRIPTION
> It's suggested by the standard to use for automated messages
> And it easily avoids cycles if every bot uses notices
> i.e. only listens to privmsgs and only emits notices