### PR TITLE
restore support for regex in section names

### DIFF
--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -354,7 +354,7 @@ class SettingsManager(object):
         fallback_focus = resolve_att(onebelow_focus, default_focus)
 
         for sec in cfg['tags'].sections:
-            if re.match('^{}$'.format(re.escape(sec)), tag):
+            if re.match('^{}$'.format(sec), tag):
                 normal = resolve_att(colourpick(cfg['tags'][sec]['normal']),
                                      fallback_normal)
                 focus = resolve_att(colourpick(cfg['tags'][sec]['focus']),


### PR DESCRIPTION
As mentioned in documentation (as I recall),
but wasn't working for some time.

Makes it possible to do things like:

```
[tags]
  [[lists/.*]]
    translation = 'lists/(.*)', 'ʟ\1'
```

To replace lists/foo with ʟfoo (or whatever) :).