### PR TITLE
Add test case for new encoding problems

### DIFF
--- a/tests/db/utils_test.py
+++ b/tests/db/utils_test.py
@@ -711,6 +711,13 @@ class TestExtractBody(unittest.TestCase):
 
         self.assertEqual(actual, expected)
 
+    @unittest.expectedFailure
+    def test_simple_utf8_file(self):
+        mail = email.message_from_binary_file(
+                open('tests/static/mail/utf8.eml', 'rb'))
+        actual = utils.extract_body(mail)
+        expected = "Liebe Grüße!\n"
+        self.assertEqual(actual, expected)
 
 class TestMessageFromString(unittest.TestCase):
 

--- a/tests/static/mail/utf8.eml
+++ b/tests/static/mail/utf8.eml
@@ -1,0 +1,8 @@
+From: lucc@github
+To: tests@alot
+Subject: plain utf8 8bit message
+MIME-Version: 1.0
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: 8bit
+
+Liebe Grüße!


### PR DESCRIPTION
Mentioned in #1291 (sorry it took me so long).

This is just one simple test. We might need to add some more basic test for 8bit or utf8 or so before we can finally fix this.

Maybe the test case can also be formulated without an external file, I did not try that yet.