### PR TITLE
Compare lowercase recipient and encryption key addresses

### DIFF
--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -174,13 +174,13 @@ class SendCommand(Command):
         addresses = set()
         for key in self.envelope.encrypt_keys.values():
             for uid in key.uids:
-                addresses.add(uid.email)
+                addresses.add(uid.email.lower())
         return addresses
 
     def _get_recipients_addresses(self):
         tos = self.envelope.headers.get('To', [])
         ccs = self.envelope.headers.get('Cc', [])
-        return {a for (_, a) in email.utils.getaddresses(tos + ccs)}
+        return {a.lower() for (_, a) in email.utils.getaddresses(tos + ccs)}
 
     def _is_encrypted_to_all_recipients(self):
         recipients_addresses = self._get_recipients_addresses()


### PR DESCRIPTION
Alot will check if a certain encrypted message is actually being
encrypted to all its recipients before sending it. Currently, comparison
is taking upper/down-case into account, which leads to malfunction when
recipient is "someOne@example.org" but the key id is actually
"someone@example.org" (or the opposite).

This commit just converts everything to downcase before comparing
addresses.

Closes: #1363