### PR TITLE
Add test case for encoding problems

### DIFF
--- a/tests/db/utils_test.py
+++ b/tests/db/utils_test.py
@@ -719,6 +719,19 @@ class TestExtractBody(unittest.TestCase):
         expected = "Liebe Grüße!\n"
         self.assertEqual(actual, expected)
 
+    @unittest.expectedFailure
+    def test_simple_japanese_file(self):
+        mail = email.message_from_binary_file(
+                open('tests/static/mail/japanese.eml', 'rb'))
+        actual = utils.extract_body(mail)
+        expected = """
+            MA-EYESご利用者各位
+
+            BIRD-BOの河和です。お疲れ様です。
+        """
+        self.assertEqual(actual, expected)
+
+
 class TestMessageFromString(unittest.TestCase):
 
     """Tests for decrypted_message_from_string.

--- a/tests/static/mail/japanese.eml
+++ b/tests/static/mail/japanese.eml
@@ -1,0 +1,10 @@
+From: teto@github
+To: tests@alot
+Subject: Japanese email
+MIME-Version: 1.0
+Content-Type: text/plain; charset="ISO-2022-JP"
+Content-Transfer-Encoding: 7bit
+
+MA-EYESご利用者各位
+
+BIRD-BOの河和です。お疲れ様です。


### PR DESCRIPTION
Some of my Japanese mails are not displayed correctly
https://github.com/pazz/alot/issues/1314

For instance the text from tests/static/mail/japanese.eml appear on my terminal as:
```
MA-EYES?$B$4MxMQ<T3F0L?(B

BIRD-BO?$B$N2OOB$G$9!#$*Hh$lMM$G$9!#?(B
```
my terminal is perfectly capable of displaying kanjis, alot even shows the subject correctly, just the body is messed up.

It would be great if someone could pick this up. When I launched the tests, it failed on some other test (using python3.7) 
```
======================================================================
FAIL: test_env_set (tests.helper_test.TestCallCmdAsync)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/teto/alot/tests/utilities.py", line 188, in _actual
    return loop.run_until_complete(coro(*args, **kwargs))
  File "/nix/store/ydk0mfpvn9smcmn72wc9i20slv1d2b79-python3-3.7.2/lib/python3.7/asyncio/base_events.py", line 584, in run_until_complete
    return future.result()
  File "/home/teto/alot/tests/helper_test.py", line 424, in test_env_set
    self.assertEqual(ret[0], 'bar')
AssertionError: '' != 'bar'
+ bar

```