### PR TITLE
restore lenient libmagic decoding

### DIFF
--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -446,9 +446,9 @@ def remove_cte(part, as_string=False):
             sp = helper.try_decode(bp)
         except UnicodeDecodeError as emsg:
             # the mail contains chars that are not enc-encoded.
-            # try again and just ignore those
+            # libmagic works better than just ignoring those
             logging.debug('Decoding failure: {}'.format(emsg))
-            sp = bp.decode(enc, errors='ignore')
+            sp = helper.try_decode(bp)
         return sp
     return bp
 

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -711,7 +711,6 @@ class TestExtractBody(unittest.TestCase):
 
         self.assertEqual(actual, expected)
 
-    @unittest.expectedFailure
     def test_simple_utf8_file(self):
         mail = email.message_from_binary_file(
                 open('tests/static/mail/utf8.eml', 'rb'))


### PR DESCRIPTION
176cffcd ("refactor alot.db.utils.remove_cte", 2018-12-04) created a few
problems with 8bit quoted-printable e-mails, see #1291 #1360.

This commit restores the old libmagic fallback which did not cause this
problem.

(Maybe just goood as a 0.8 hotfix.)