### PR TITLE
Ignore non-ascii email-addresses in completion

### DIFF
--- a/alot/completion.py
+++ b/alot/completion.py
@@ -248,8 +248,11 @@ class AbooksCompleter(Completer):
         else:
             returnlist = []
             for name, addr in res:
-                newtext = email.utils.formataddr((name, addr))
-                returnlist.append((newtext, len(newtext)))
+                try:
+                    newtext = email.utils.formataddr((name, addr))
+                    returnlist.append((newtext, len(newtext)))
+                except UnicodeEncodeError:
+                    pass
         return returnlist
 
 


### PR DESCRIPTION
Both a bug report and a fix.

**Describe the bug**
I'm using `notmuch` as addressbook, however I have received a mail from the address `André@DigitalOcean` (note the non-ascii character in the address).
This causes alot to crash when trying to complete. 

**Software Versions**
- Python version: 3.7.2
- Notmuch version: 0.28.3
- Alot version: master

**To Reproduce**
Steps to reproduce the behaviour:
1. Create the file `/tmp/custom_abook` with the contents:
```
#!/bin/bash
echo '{"name": "", "address": "André@DigitalOcean", "name-addr": "André@DigitalOcean"},'
```
2. Use the following abook config:
```
		[[[abook]]]
			type = shellcommand
			command = /tmp/custom_abook
			regexp = '\[?{"name": "(?P<name>.*)", "address": "(?P<email>.+)", "name-addr": ".*"}[,\]]?'
			shellcommand_external_filtering = False
```
3. Open alot, write a mail and try to auto-complete the recipient.

**Error Log**
Backtrace:
```
Traceback (most recent call last): 0x7f57c08954c8>)
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/tyilo/repos/alot/alot/__main__.py", line 146, in <module>
    main()
  File "/home/tyilo/repos/alot/alot/__main__.py", line 137, in main
    UI(dbman, cmdstring)
  File "/home/tyilo/repos/alot/alot/ui.py", line 141, in __init__
    self.mainloop.run()
  File "/usr/lib/python3.7/site-packages/urwid/main_loop.py", line 286, in run
    self._run()
  File "/usr/lib/python3.7/site-packages/urwid/main_loop.py", line 384, in _run
    self.event_loop.run()
  File "/usr/lib/python3.7/site-packages/urwid/main_loop.py", line 1340, in run
    reraise(*exc_info)
  File "/usr/lib/python3.7/site-packages/urwid/compat.py", line 58, in reraise
    raise value
  File "/usr/lib/python3.7/site-packages/urwid/main_loop.py", line 1354, in wrapper
    rval = f(*args,**kargs)
  File "/usr/lib/python3.7/site-packages/urwid/raw_display.py", line 404, in <lambda>
    event_loop, callback, self.get_available_raw_input())
  File "/usr/lib/python3.7/site-packages/urwid/raw_display.py", line 502, in parse_input
    callback(processed, processed_codes)
  File "/usr/lib/python3.7/site-packages/urwid/main_loop.py", line 411, in _update
    self.process_input(keys)
  File "/usr/lib/python3.7/site-packages/urwid/main_loop.py", line 511, in process_input
    k = self._topmost_widget.keypress(self.screen_size, k)
  File "/usr/lib/python3.7/site-packages/urwid/container.py", line 595, in keypress
    *self.calculate_padding_filler(size, True)), key)
  File "/usr/lib/python3.7/site-packages/urwid/container.py", line 2271, in keypress
    key = w.keypress((mc,) + size[1:], key)
  File "/home/tyilo/repos/alot/alot/widgets/globals.py", line 145, in keypress
    self.edit_pos)
  File "/home/tyilo/repos/alot/alot/completion.py", line 118, in complete
    for c, _ in self._completer.complete(mypart, mypos):
  File "/home/tyilo/repos/alot/alot/completion.py", line 251, in complete
    newtext = email.utils.formataddr((name, addr))
  File "/usr/lib/python3.7/email/utils.py", line 91, in formataddr
    address.encode('ascii')
UnicodeEncodeError: 'ascii' codec can't encode character '\xe9' in position 4: ordinal not in range(128)
```
