### PR TITLE
expose message object to reply/forward_prefix hook

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -139,7 +139,8 @@ class ReplyCommand(Command):
         timestamp = self.message.get_date()
         qf = settings.get_hook('reply_prefix')
         if qf:
-            quotestring = qf(name, address, timestamp, ui=ui, dbm=ui.dbman)
+            quotestring = qf(name, address, timestamp,
+                             message=mail, ui=ui, dbm=ui.dbman)
         else:
             quotestring = 'Quoting %s (%s)\n' % (name or address, timestamp)
         mailcontent = quotestring
@@ -346,7 +347,8 @@ class ForwardCommand(Command):
             timestamp = self.message.get_date()
             qf = settings.get_hook('forward_prefix')
             if qf:
-                quote = qf(name, address, timestamp, ui=ui, dbm=ui.dbman)
+                quote = qf(name, address, timestamp,
+                           message=mail, ui=ui, dbm=ui.dbman)
             else:
                 quote = 'Forwarded message from %s (%s):\n' % (
                     name or address, timestamp)

--- a/docs/source/configuration/hooks.rst
+++ b/docs/source/configuration/hooks.rst
@@ -42,7 +42,7 @@ Other Hooks
 
 Apart from command pre- and posthooks, the following hooks will be interpreted:
 
-.. py:function:: reply_prefix(realname, address, timestamp[, ui= None, dbm=None])
+.. py:function:: reply_prefix(realname, address, timestamp[, message=None, ui= None, dbm=None])
 
     Is used to reformat the first indented line in a reply message.
     This defaults to 'Quoting %s (%s)\n' % (realname, timestamp)' unless this
@@ -54,9 +54,11 @@ Apart from command pre- and posthooks, the following hooks will be interpreted:
     :type address: str
     :param timestamp: value of the Date header of the replied message
     :type timestamp: :obj:`datetime.datetime`
+    :param message: message object attached to reply
+    :type message: :obj:`email.Message`
     :rtype: string
 
-.. py:function:: forward_prefix(realname, address, timestamp[, ui= None, dbm=None])
+.. py:function:: forward_prefix(realname, address, timestamp[, message=None, ui= None, dbm=None])
 
     Is used to reformat the first indented line in a inline forwarded message.
     This defaults to 'Forwarded message from %s (%s)\n' % (realname,
@@ -68,6 +70,8 @@ Apart from command pre- and posthooks, the following hooks will be interpreted:
     :type address: str
     :param timestamp: value of the Date header of the replied message
     :type timestamp: :obj:`datetime.datetime`
+    :param message: message object being forwarded
+    :type message: :obj:`email.Message`
     :rtype: string
 
 .. _pre-edit-translate:


### PR DESCRIPTION
This exposes the message object in the `reply_prefix` and `forward_prefix` hooks; now, you can mimic what Gmail does like so:

```python
def forward_prefix(*args, **kwargs):
  # ---------- Forwarded message ---------
  # From: Nick Hu <my@fake.email>
  # Date: Wed, 10 Apr 2019 at 11:03
  # Subject: Re: Cool mail
  # To: Someone Else <recipient@of.cool.mail>
  subject = alot.db.utils.decode_header(kwargs["message"].get("Subject", ""))
  to = alot.db.utils.decode_header(kwargs["message"].get("To", ""))
  return (" ---------- Forwarded message ---------\n"
             " From: {0} <{1}>\n"
             " Date: {2:%a, %-d %b %Y at %H:%M}\n"
              " Subject: {3}\n"
              " To: {4}\n\n\n"
             ).format(*args, subject, to)
```