### PR TITLE
Fix double width characters in search view

### DIFF
--- a/alot/widgets/search.py
+++ b/alot/widgets/search.py
@@ -156,7 +156,7 @@ def build_text_part(name, thread, struct):
 
     # define width and part_w
     text = urwid.Text(content, wrap='clip')
-    width = text.pack()[0]
+    width = text.pack((maxw or minw,))[0]
     part_w = AttrFlipWidget(text, struct)
 
     return width, part_w


### PR DESCRIPTION
Hotfix for double width characters causing columns misalign in search
view (closes https://github.com/pazz/alot/issues/1393)