### PR TITLE
Faster Thread loading

### DIFF
--- a/alot/commands/search.py
+++ b/alot/commands/search.py
@@ -38,9 +38,9 @@ class OpenThreadCommand(Command):
             query = ui.current_buffer.querystring
             logging.info('open thread view for %s', self.thread)
 
-            sb = buffers.ThreadBuffer(ui, self.thread)
-            ui.buffer_open(sb)
-            sb.unfold_matching(query)
+            tb = buffers.ThreadBuffer(ui, self.thread)
+            ui.buffer_open(tb)
+            tb.unfold_matching(query)
 
 
 @registerCommand(MODE, 'refine', help='refine query', arguments=[

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -191,6 +191,19 @@ class MessageTree(CollapsibleTree):
         logging.debug('DHT %s', str(self._default_headers_tree))
         logging.debug('MAINTREE %s', str(self._maintree._treelist))
 
+    def expand(self, pos):
+        """
+        overload CollapsibleTree.expand method to ensure all parts are present.
+        Initially, only the summary widget is created to avoid reading the
+        messafe file and thus speed up the creation of this object. Once we
+        expand = unfold the message, we need to make sure that body/attachments
+        exist.
+        """
+        logging.debug("MT expand")
+        if not self._bodytree:
+            self.reassemble()
+        CollapsibleTree.expand(self, pos)
+
     def _assemble_structure(self, summary_only=False):
         if summary_only:
             return [(self._get_summary(), None)]

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -169,7 +169,7 @@ class MessageTree(CollapsibleTree):
         self._default_headers_tree = None
         self.display_attachments = True
         self._attachments = None
-        self._maintree = SimpleTree(self._assemble_structure())
+        self._maintree = SimpleTree(self._assemble_structure(True))
         CollapsibleTree.__init__(self, self._maintree)
 
     def get_message(self):
@@ -191,7 +191,10 @@ class MessageTree(CollapsibleTree):
         logging.debug('DHT %s', str(self._default_headers_tree))
         logging.debug('MAINTREE %s', str(self._maintree._treelist))
 
-    def _assemble_structure(self):
+    def _assemble_structure(self, summary_only=False):
+        if summary_only:
+            return [(self._get_summary(), None)]
+
         mainstruct = []
         if self.display_source:
             mainstruct.append((self._get_source(), None))


### PR DESCRIPTION
This will prevent the whole message from being read and interpreted
at the time we instantiate a MessageTree for display and instead only
create the (cheap!) summary widget.

When a user manually interacts with the Message widgets (for example by
unfolding/toggling source) then the content parts will anyway be
reassembled. The consequence of this patch is that loading large threads
should be much faster.