### PR TITLE
fix #1402

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -10,7 +10,7 @@ import subprocess
 import tempfile
 import email
 import email.policy
-from email.utils import getaddresses, parseaddr, formataddr
+from email.utils import getaddresses, parseaddr
 from email.message import Message
 
 import urwid
@@ -28,6 +28,9 @@ from ..completion import ContactsCompleter, PathCompleter
 from ..db.utils import decode_header
 from ..db.utils import extract_headers
 from ..db.utils import extract_body
+from ..db.utils import formataddr
+from ..db.utils import clear_my_address
+from ..db.utils import ensure_unique_address
 from ..db.envelope import Envelope
 from ..db.attachment import Attachment
 from ..db.errors import DatabaseROError
@@ -203,7 +206,7 @@ class ReplyCommand(Command):
             # make sure that our own address is not included
             # if the message was self-sent, then our address is not included
             MFT = mail.get_all('Mail-Followup-To', [])
-            followupto = self.clear_my_address(account, MFT)
+            followupto = clear_my_address(account, MFT)
             if followupto and settings.get('honor_followup_to'):
                 logging.debug('honor followup to: %s', ', '.join(followupto))
                 recipients = followupto
@@ -214,17 +217,16 @@ class ReplyCommand(Command):
 
                 # append To addresses if not replying to self sent message
                 if not account.matches_address(sender_address):
-                    cleared = self.clear_my_address(
-                        account, mail.get_all('To', []))
+                    cleared = clear_my_address(account,
+                                               mail.get_all('To', []))
                     recipients.extend(cleared)
 
                 # copy cc for group-replies
                 if 'Cc' in mail:
-                    cc = self.clear_my_address(
-                        account, mail.get_all('Cc', []))
+                    cc = clear_my_address(account, mail.get_all('Cc', []))
                     envelope.add('Cc', decode_header(', '.join(cc)))
 
-        to = ', '.join(self.ensure_unique_address(recipients))
+        to = ', '.join(ensure_unique_address(recipients))
         logging.debug('reply to: %s', to)
 
         if self.listreply:
@@ -278,36 +280,6 @@ class ReplyCommand(Command):
         await ui.apply_command(ComposeCommand(envelope=envelope,
                                               spawn=self.force_spawn,
                                               encrypt=encrypt))
-
-    @staticmethod
-    def clear_my_address(my_account, value):
-        """return recipient header without the addresses in my_account
-
-        :param my_account: my account
-        :type my_account: :class:`Account`
-        :param value: a list of recipient or sender strings (with or without
-            real names as taken from email headers)
-        :type value: list(str)
-        :returns: a new, potentially shortend list
-        :rtype: list(str)
-        """
-        new_value = []
-        for name, address in getaddresses(value):
-            if not my_account.matches_address(address):
-                new_value.append(formataddr((name, str(address))))
-        return new_value
-
-    @staticmethod
-    def ensure_unique_address(recipients):
-        """
-        clean up a list of name,address pairs so that
-        no address appears multiple times.
-        """
-        res = dict()
-        for name, address in getaddresses(recipients):
-            res[address] = name
-        urecipients = [formataddr((n, str(a))) for a, n in res.items()]
-        return sorted(urecipients)
 
 
 @registerCommand(MODE, 'forward', arguments=[

--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -526,15 +526,9 @@ def decode_header(header, normalize=False):
     :type normalize: bool
     :rtype: str
     """
-    # some mailers send out incorrectly escaped headers
-    # and double quote the escaped realname part again. remove those
-    # RFC: 2047
-    regex = r'"(=\?.+?\?.+?\?[^ ?]+\?=)"'
-    value = re.sub(regex, r'\1', header)
-    logging.debug("unquoted header: |%s|", value)
+    logging.debug("unquoted header: |%s|", header)
 
-    # otherwise we interpret RFC2822 encoding escape sequences
-    valuelist = email.header.decode_header(value)
+    valuelist = email.header.decode_header(header)
     decoded_list = []
     for v, enc in valuelist:
         v = string_decode(v, enc)

--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -547,3 +547,45 @@ def is_subdir_of(subpath, superpath):
     # return true, if the common prefix of both is equal to directory
     # e.g. /a/b/c/d.rst and directory is /a/b, the common prefix is /a/b
     return os.path.commonprefix([subpath, superpath]) == superpath
+
+
+def formataddr(pair, **kwargs):
+    """wraps around email.utils.formataddr and adds a more digestable error
+    message in case the address contains non-ascii chars"""
+    try:
+        return email.utils.formataddr(pair, **kwargs)
+    except UnicodeEncodeError as e:
+        msg = "address \"%s\" contains non-ascii characters! " \
+              "This violates RFC 2047" % pair[1]
+        raise Exception(msg)
+
+
+def clear_my_address(my_account, value):
+    """return recipient header without the addresses in my_account
+
+    :param my_account: my account
+    :type my_account: :class:`Account`
+    :param value: a list of recipient or sender strings (with or without
+        real names as taken from email headers)
+    :type value: list(str)
+    :returns: a new, potentially shortend list
+    :rtype: list(str)
+    """
+    new_value = []
+    for name, address in email.utils.getaddresses(value):
+        if not my_account.matches_address(address):
+            new_value.append(formataddr((name, address)))
+    return new_value
+
+
+def ensure_unique_address(recipients):
+    """
+    clean up a list of name,address pairs so that
+    no address appears multiple times.
+    """
+    res = dict()
+    for name, address in email.utils.getaddresses(recipients):
+        res[address] = name
+    logging.debug(res)
+    urecipients = [formataddr((n, a)) for a, n in res.items()]
+    return sorted(urecipients)


### PR DESCRIPTION
When decoding headers containing email addresses;
Some MUAs (exchange) will add headers in the form:

  To: "Last, First" <x@y.z>

Prior to this commit, alot would remove the quotes (apparently they
violate RFC 2047). However, this then would lead to problems where the
additional comma is interpreted as separator between several recipients.

This commit causes alot to not remove the quotes.
#1402 