### PR TITLE
ContactsCompletion: use db.utils.formataddr

### DIFF
--- a/alot/completion.py
+++ b/alot/completion.py
@@ -14,6 +14,7 @@ from . import commands
 from .buffers import EnvelopeBuffer
 from .settings.const import settings
 from .utils import argparse as cargparse
+from .db.utils import formataddr
 from .helper import split_commandline
 from .addressbook import AddressbookError
 from .errors import CompletionError
@@ -248,7 +249,7 @@ class AbooksCompleter(Completer):
         else:
             returnlist = []
             for name, addr in res:
-                newtext = email.utils.formataddr((name, addr))
+                newtext = formataddr((name, addr))
                 returnlist.append((newtext, len(newtext)))
         return returnlist
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -20,6 +20,7 @@ def _mock_lookup(query):
     abook = [
         ("", "no-real-name@example.com"),
         ("foo", "foo@example.com"),
+        ("Ümläut", "umlaut@example.com"),
         ("comma, person", "comma@example.com"),
         ("single 'quote' person", "squote@example.com"),
         ('double "quote" person', "dquote@example.com"),
@@ -65,6 +66,11 @@ class AbooksCompleterTest(unittest.TestCase):
         expected = [("foo <foo@example.com>", 21)]
         self.assertListEqual(actual, expected)
 
+    def test_simple_address_with_umlaut_real_name(self):
+        actual = self.__class__.example_abook_completer.complete("umlaut", 6)
+        expected = [("Ümläut <umlaut@example.com>", 27)]
+        self.assertListEqual(actual, expected)
+
     def test_real_name_with_comma(self):
         actual = self.__class__.example_abook_completer.complete("comma", 5)
         expected = [('"comma, person" <comma@example.com>', 35)]
@@ -79,13 +85,13 @@ class AbooksCompleterTest(unittest.TestCase):
         actual = self.__class__.example_abook_completer.complete("dquote", 6)
         expected = [("", 0)]
         expected = [
-            (r""""double \"quote\" person" <dquote@example.com>""", 46)]
+            (r"""double "quote" person <dquote@example.com>""", 42)]
         self._assert_only_one_list_entry(actual, expected)
 
     def test_real_name_with_quotes_and_comma(self):
         actual = self.__class__.example_abook_completer.complete("all", 3)
-        expected = [(r""""all 'fanzy' \"stuff\" at, once" <all@example.com>""",
-                     50)]
+        expected = [(r""""all 'fanzy' "stuff" at, once" <all@example.com>""",
+                     48)]
         self._assert_only_one_list_entry(actual, expected)
 
 


### PR DESCRIPTION
email.utils.formataddr does more encoding than we need at this point -
headers will be encoded when they get inserted anyway.

Use db.utils.formataddr instead. Fixes #1378