### PR TITLE
Options overwrite default values for sent_tags and draft_tags

### DIFF
--- a/alot/account.py
+++ b/alot/account.py
@@ -203,15 +203,6 @@ class Account:
                  abook=None, sign_by_default=False,
                  encrypt_by_default=u"none", encrypt_to_self=None,
                  case_sensitive_username=False, **_):
-        sent_tags = sent_tags or []
-        if 'sent' not in sent_tags:
-            sent_tags.append('sent')
-        draft_tags = draft_tags or []
-        if 'draft' not in draft_tags:
-            draft_tags.append('draft')
-        replied_tags = replied_tags or []
-        passed_tags = passed_tags or []
-
         self.address = Address.from_string(
             address, case_sensitive=case_sensitive_username)
         self.aliases = [


### PR DESCRIPTION
In addition, remove hardcoded default values from account.py and use defaults from alot.rc.spec

This has multiple consequences:
- default values for `sent_tags` and `draft_tags` are solely set in alot.rc.spec
- options `sent_tags` and `draft_tags` in user config do overwrite these defaults. It is now possible to not tag sent mails and drafts at all with `sent_tags = ` and `draft_tags = `
- this is a breaking change if these options were used (though a very small one). To keep the old behaviour, the user has to add `sent` and/or `draft` manually to the options.

This fixes #1412 