### PR TITLE
Add new hook 'thread_message_text_translate'

### DIFF
--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -99,7 +99,12 @@ class TextlinesList(SimpleTree):
                 structure.append((FocusableText(line, attr, attr_focus), None))
         else:
             structure.append((FocusableText(content, attr, attr_focus), None))
+
+        if len(structure) == 0:
+                structure.append((FocusableText("", attr, attr_focus), None))
+
         SimpleTree.__init__(self, structure)
+
 
 
 class DictList(SimpleTree):

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -169,6 +169,7 @@ class MessageTree(CollapsibleTree):
         self._default_headers_tree = None
         self.display_attachments = True
         self._attachments = None
+        self.thread_message_text_translate = settings.get_hook('thread_message_text_translate')
         self._maintree = SimpleTree(self._assemble_structure(True))
         CollapsibleTree.__init__(self, self._maintree)
 
@@ -253,6 +254,8 @@ class MessageTree(CollapsibleTree):
         if self._bodytree is None:
             bodytxt = self._message.accumulate_body()
             if bodytxt:
+                if self.thread_message_text_translate:
+                    bodytxt = self.thread_message_text_translate(bodytxt, self._message)
                 att = settings.get_theming_attribute('thread', 'body')
                 att_focus = settings.get_theming_attribute(
                     'thread', 'body_focus')

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -106,7 +106,6 @@ class TextlinesList(SimpleTree):
         SimpleTree.__init__(self, structure)
 
 
-
 class DictList(SimpleTree):
     """
     :class:`SimpleTree` that displays key-value pairs.
@@ -174,7 +173,10 @@ class MessageTree(CollapsibleTree):
         self._default_headers_tree = None
         self.display_attachments = True
         self._attachments = None
-        self.thread_message_text_translate = settings.get_hook('thread_message_text_translate')
+        self.thread_message_text_translate = settings.get_hook(
+            'thread_message_text_translate')
+        if not self.thread_message_text_translate:
+            self.thread_message_text_translate = lambda s, m: s
         self._maintree = SimpleTree(self._assemble_structure(True))
         CollapsibleTree.__init__(self, self._maintree)
 
@@ -259,8 +261,8 @@ class MessageTree(CollapsibleTree):
         if self._bodytree is None:
             bodytxt = self._message.accumulate_body()
             if bodytxt:
-                if self.thread_message_text_translate:
-                    bodytxt = self.thread_message_text_translate(bodytxt, self._message)
+                bodytxt = self.thread_message_text_translate(bodytxt,
+                                                             self._message)
                 att = settings.get_theming_attribute('thread', 'body')
                 att_focus = settings.get_theming_attribute(
                     'thread', 'body_focus')


### PR DESCRIPTION
This adds a hook which can translate the text of each message before it is displayed in thread mode. I personally have found it very useful to strip out the original messages from replies; this makes thread view much more compact and useful, since this way each message widget only has the corresponding message text and not all of the older messages in the thread.