### PR TITLE
commands/envelope: keep editable headers order

### DIFF
--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -27,6 +27,7 @@ from ..helper import string_decode
 from ..settings.const import settings
 from ..settings.errors import NoMatchingAccount
 from ..utils import argparse as cargparse
+from ..utils.collections import OrderedSet
 
 
 MODE = 'envelope'
@@ -341,9 +342,9 @@ class EditCommand(Command):
             self.envelope = ui.current_buffer.envelope
 
         # determine editable headers
-        edit_headers = set(settings.get('edit_headers_whitelist'))
+        edit_headers = OrderedSet(settings.get('edit_headers_whitelist'))
         if '*' in edit_headers:
-            edit_headers = set(self.envelope.headers)
+            edit_headers = OrderedSet(self.envelope.headers)
         blacklist = set(settings.get('edit_headers_blacklist'))
         if '*' in blacklist:
             blacklist = set(self.envelope.headers)

--- a/alot/utils/collections.py
+++ b/alot/utils/collections.py
@@ -1,0 +1,29 @@
+# This file is released under the GNU GPL, version 3 or a later revision.
+# For further details see the COPYING file
+
+from collections.abc import Set
+
+# for backward compatibility with Python <3.7
+from collections import OrderedDict
+
+
+class OrderedSet(Set):
+    """
+    Ordered collection of distinct hashable objects.
+    Taken from https://stackoverflow.com/a/10006674
+    """
+
+    def __init__(self, iterable=()):
+        self.d = OrderedDict.fromkeys(iterable)
+
+    def __len__(self):
+        return len(self.d)
+
+    def __contains__(self, element):
+        return element in self.d
+
+    def __iter__(self):
+        return iter(self.d)
+
+    def __repr__(self):
+        return str(list(self))


### PR DESCRIPTION
This should mitigate issue #898 by keeping the order of editable headers from either the configuration or the current envelope.

__This change set hasn't been tested.__