### PR TITLE
Fix html only mails

### DIFF
--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -477,7 +477,7 @@ def extract_body(mail):
     """
 
     if settings.get('prefer_plaintext'):
-        preferencelist = ('plain',)
+        preferencelist = ('plain', 'html')
     else:
         preferencelist = ('html', 'plain')
 

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -677,7 +677,6 @@ class TestExtractBody(unittest.TestCase):
             subtype='html')
         return mail
 
-    @unittest.expectedFailure
     @mock.patch('alot.db.utils.settings.get', mock.Mock(return_value=True))
     @mock.patch('alot.db.utils.settings.mailcap_find_match',
                 mock.Mock(return_value=(None, {'view': 'cat'})))


### PR DESCRIPTION
Make HTML-only mails display again.
(No, they'll never be "great".)