### PR TITLE
Bump twisted to >= 18.4.0 fix #1420

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -28,7 +28,7 @@ A full list of dependencies is below:
 * `urwid <http://excess.org/urwid/>`_ toolkit, ≥ `1.3.0`
 * `urwidtrees <https://github.com/pazz/urwidtrees>`_, ≥ `1.0`
 * `gpg <http://www.gnupg.org/related_software/gpgme>`_ and it's python bindings, ≥ `1.9.0`
-* `twisted <https://twistedmatrix.com>`_, ≥ `10.2.0`
+* `twisted <https://twistedmatrix.com>`_, ≥ `18.4.0`
 
 
 On Debian/Ubuntu these are packaged as::

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'notmuch>=0.27',
         'urwid>=1.3.0',
         'urwidtrees>=1.0',
-        'twisted>=10.2.0',
+        'twisted>=18.4.0',
         'python-magic',
         'configobj>=4.7.0',
         'gpg'


### PR DESCRIPTION
Hey,
Following the issue #1420 I have bump twisted to be at least 18.4.0,
this patch need some checking to be sure everyone can have this version.