### PR TITLE
Check whether editor_cmdstring is set before searching it.

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -337,12 +337,13 @@ class EditCommand(ExternalCommand):
         logging.debug('using editor_cmd: %s', editor_cmdstring)
 
         self.cmdlist = None
-        if '%s' in editor_cmdstring:
-            cmdstring = editor_cmdstring.replace('%s',
-                                                 helper.shell_quote(path))
-            self.cmdlist = split_commandstring(cmdstring)
-        else:
-            self.cmdlist = split_commandstring(editor_cmdstring) + [path]
+        if editor_cmdstring:
+            if '%s' in editor_cmdstring:
+                cmdstring = editor_cmdstring.replace('%s',
+                                                     helper.shell_quote(path))
+                self.cmdlist = split_commandstring(cmdstring)
+            else:
+                self.cmdlist = split_commandstring(editor_cmdstring) + [path]
 
         logging.debug({'spawn: ': self.spawn, 'in_thread': self.thread})
         ExternalCommand.__init__(self, self.cmdlist,


### PR DESCRIPTION
Bypasses the handling of editor_cmdstring if this is not set after all
attempts, which will eventually lead to EditCommand.apply erroring
with 'no editor set' instead of alot crashing.

Fixes #1438 