### PR TITLE
Implement command for confirming command sequences.

### DIFF
--- a/alot/commands/__init__.py
+++ b/alot/commands/__init__.py
@@ -33,6 +33,13 @@ class CommandCanceled(Exception):
     pass
 
 
+class SequenceCanceled(Exception):
+    """ Exception triggered when a command sequence has been cancelled by the
+    confirmsequence command
+    """
+    pass
+
+
 COMMANDS = {
     'search': {},
     'envelope': {},

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -17,7 +17,7 @@ import shlex
 import urwid
 
 from . import Command, registerCommand
-from . import CommandCanceled
+from . import CommandCanceled, SequenceCanceled
 from .utils import update_keys
 from .. import commands
 
@@ -1174,3 +1174,30 @@ class RemoveQueryCommand(Command):
         # flush index
         if self.flush:
             ui.apply_command(commands.globals.FlushCommand())
+
+
+@registerCommand(
+    MODE, 'confirmsequence',
+    arguments=[
+        (['msg'], {'help': 'Additional message to prompt',
+                   'nargs': '*'})
+    ],
+    help="prompt to confirm a sequence of commands")
+class ConfirmCommand(Command):
+    """Prompt user to confirm a sequence of commands."""
+
+    def __init__(self, msg=None, **kwargs):
+        """
+        :param msg: Additional message to prompt the user with
+        :type msg: List[str]
+        """
+        super(ConfirmCommand, self).__init__(**kwargs)
+        if not msg:
+            self.msg = "Confirm sequence?"
+        else:
+            self.msg = "Confirm sequence: {}?".format(" ".join(msg))
+
+    async def apply(self, ui):
+        if (await ui.choice(self.msg, select='yes', cancel='no',
+                            msg_position='left')) == 'no':
+            raise SequenceCanceled()

--- a/docs/source/usage/modes/global.rst
+++ b/docs/source/usage/modes/global.rst
@@ -77,6 +77,16 @@ The following commands are available globally:
         :---omit_signature: do not add signature
         :---spawn: spawn editor in new terminal
 
+.. _cmd.global.confirmsequence:
+
+.. describe:: confirmsequence
+
+    prompt to confirm a sequence of commands
+
+    argument
+        Additional message to prompt
+
+
 .. _cmd.global.exit:
 
 .. describe:: exit


### PR DESCRIPTION
First attempt at implementing a confirmation command intended for use in
command sequences, as discussed in #1368.

When called (optionally with a free-form string message), prompts the
user for confirmation. If the user declines, a SequenceCanceled
exception is raised, which trickles up the error handling into
apply_commandline where it is explicitly caught outside the common error
handler. This aborts the execution of subsequent commands in the
commandline, but does not show up as an error in the log.

Closes #1368