### PR TITLE
Be more informative if editor exits with error.

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -304,7 +304,10 @@ class ExternalCommand(Command):
             if self.on_success is not None:
                 self.on_success()
         else:
-            ui.notify(ret, priority='error')
+            msg = "editor has exited with error code {} -- {}".format(
+                    proc.returncode,
+                    ret or "No stderr output")
+            ui.notify(msg, priority='error')
         if self.refocus and callerbuffer in ui.buffers:
             logging.info('refocussing')
             ui.buffer_focus(callerbuffer)

--- a/tests/commands/test_global.py
+++ b/tests/commands/test_global.py
@@ -134,14 +134,18 @@ class TestExternalCommand(unittest.TestCase):
         cmd = g_commands.ExternalCommand(
             u"test -t 0", stdin=u'0', refocus=False)
         await cmd.apply(ui)
-        ui.notify.assert_called_once_with('', priority='error')
+        ui.notify.assert_called_once_with(
+                'editor has exited with error code 1 -- No stderr output',
+                priority='error')
 
     @utilities.async_test
     async def test_no_spawn_failure(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(u'false', refocus=False)
         await cmd.apply(ui)
-        ui.notify.assert_called_once_with('', priority='error')
+        ui.notify.assert_called_once_with(
+                'editor has exited with error code 1 -- No stderr output',
+                priority='error')
 
     @utilities.async_test
     @mock.patch(
@@ -173,7 +177,9 @@ class TestExternalCommand(unittest.TestCase):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(u'false', refocus=False, spawn=True)
         await cmd.apply(ui)
-        ui.notify.assert_called_once_with('', priority='error')
+        ui.notify.assert_called_once_with(
+                'editor has exited with error code 1 -- No stderr output',
+                priority='error')
 
 
 class TestCallCommand(unittest.TestCase):


### PR DESCRIPTION
Implements the suggestion in #1427 to display the actual error code, and
substitutes an empty stderr with "No stderr output".

I figured, while I'm rooting around in that file, might as well implement that
<15mins suggestion.