### PR TITLE
sanitize message body text for display in envelope

### DIFF
--- a/alot/buffers/envelope.py
+++ b/alot/buffers/envelope.py
@@ -9,6 +9,7 @@ from ..settings.const import settings
 from ..widgets.globals import HeadersList
 from ..widgets.globals import AttachmentWidget
 from ..helper import shorten_author_string
+from ..helper import string_sanitize
 
 
 class EnvelopeBuffer(Buffer):
@@ -88,7 +89,7 @@ class EnvelopeBuffer(Buffer):
             self.attachment_wgt = urwid.Pile(lines)
             displayed_widgets.append(self.attachment_wgt)
 
-        self.body_wgt = urwid.Text(self.envelope.body)
+        self.body_wgt = urwid.Text(string_sanitize(self.envelope.body))
         displayed_widgets.append(self.body_wgt)
         self.body = urwid.ListBox(displayed_widgets)
 

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -12,6 +12,7 @@ from .globals import TagWidget
 from .globals import AttachmentWidget
 from ..settings.const import settings
 from ..db.utils import decode_header, X_SIGNATURE_MESSAGE_HEADER
+from ..helper import string_sanitize
 
 
 class MessageSummaryWidget(urwid.WidgetWrap):
@@ -244,6 +245,7 @@ class MessageTree(CollapsibleTree):
     def _get_source(self):
         if self._sourcetree is None:
             sourcetxt = self._message.get_email().as_string()
+            sourcetxt = string_sanitize(sourcetxt)
             att = settings.get_theming_attribute('thread', 'body')
             att_focus = settings.get_theming_attribute('thread', 'body_focus')
             self._sourcetree = TextlinesList(sourcetxt, att, att_focus)


### PR DESCRIPTION
this simply calls helper.string_sanitize on the (real) email "body" text
before handing it to the urwid Text widget.
The original message may contain tabs, which are untouched when sending
the message. The sanitization is only for displaying this string, and
should replace tabs by whitespaces as expected.

fix #1439