### PR TITLE
Remove unicode literals syntax from python2

### DIFF
--- a/alot/account.py
+++ b/alot/account.py
@@ -201,7 +201,7 @@ class Account:
                  sent_box=None, sent_tags=None, draft_box=None,
                  draft_tags=None, replied_tags=None, passed_tags=None,
                  abook=None, sign_by_default=False,
-                 encrypt_by_default=u"none", encrypt_to_self=None,
+                 encrypt_by_default="none", encrypt_to_self=None,
                  case_sensitive_username=False, **_):
         self.address = Address.from_string(
             address, case_sensitive=case_sensitive_username)
@@ -228,17 +228,17 @@ class Account:
         encrypt_by_default = encrypt_by_default.lower()
         msg = "Deprecation warning: The format for the encrypt_by_default " \
               "option changed.  Please use 'none', 'all' or 'trusted'."
-        if encrypt_by_default in (u"true", u"yes", u"1"):
-            encrypt_by_default = u"all"
+        if encrypt_by_default in ("true", "yes", "1"):
+            encrypt_by_default = "all"
             logging.info(msg)
-        elif encrypt_by_default in (u"false", u"no", u"0"):
-            encrypt_by_default = u"none"
+        elif encrypt_by_default in ("false", "no", "0"):
+            encrypt_by_default = "none"
             logging.info(msg)
         self.encrypt_by_default = encrypt_by_default
         # cache alias_regexp regexes
         if self.alias_regexp != "":
             self._alias_regexp = re.compile(
-                u'^' + str(self.alias_regexp) + u'$',
+                '^' + str(self.alias_regexp) + '$',
                 flags=0 if case_sensitive_username else re.IGNORECASE)
 
     def matches_address(self, address):

--- a/alot/buffers/thread.py
+++ b/alot/buffers/thread.py
@@ -84,7 +84,7 @@ class ThreadBuffer(Buffer):
             heads_char = None
             heads_att = None
             if self._indent_width > 1:
-                heads_char = '\u27a4'
+                heads_char = '➤'
                 heads_att = settings.get_theming_attribute('thread',
                                                            'arrow_heads')
             A = ArrowTree(

--- a/alot/buffers/thread.py
+++ b/alot/buffers/thread.py
@@ -84,7 +84,7 @@ class ThreadBuffer(Buffer):
             heads_char = None
             heads_att = None
             if self._indent_width > 1:
-                heads_char = u'\u27a4'
+                heads_char = '\u27a4'
                 heads_att = settings.get_theming_attribute('thread',
                                                            'arrow_heads')
             A = ArrowTree(

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -236,7 +236,7 @@ class SendCommand(Command):
                                     msg_position='left')) == 'no':
                     return
 
-            clearme = ui.notify(u'constructing mail (GPG, attachments)\u2026',
+            clearme = ui.notify('constructing mail (GPG, attachments)\u2026',
                                 timeout=-1)
 
             try:
@@ -375,7 +375,7 @@ class EditCommand(Command):
                 ebuffer.rebuild()
 
         # decode header
-        headertext = u''
+        headertext = ''
         for key in edit_headers:
             vlist = self.envelope.get_all(key)
             if not vlist:
@@ -664,7 +664,7 @@ class TagCommand(Command):
     """manipulate message tags"""
     repeatable = True
 
-    def __init__(self, tags=u'', action='add', **kwargs):
+    def __init__(self, tags='', action='add', **kwargs):
         """
         :param tags: comma separated list of tagstrings to set
         :type tags: str

--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -236,7 +236,7 @@ class SendCommand(Command):
                                     msg_position='left')) == 'no':
                     return
 
-            clearme = ui.notify('constructing mail (GPG, attachments)\u2026',
+            clearme = ui.notify('constructing mail (GPG, attachments)…',
                                 timeout=-1)
 
             try:

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -723,8 +723,8 @@ class ComposeCommand(Command):
     """compose a new email"""
     def __init__(
             self,
-            envelope=None, headers=None, template=None, sender=u'',
-            tags=None, subject=u'', to=None, cc=None, bcc=None, attach=None,
+            envelope=None, headers=None, template=None, sender='',
+            tags=None, subject='', to=None, cc=None, bcc=None, attach=None,
             omit_signature=False, spawn=None, rest=None, encrypt=False,
             **kwargs):
         """
@@ -943,12 +943,12 @@ class ComposeCommand(Command):
 
     async def _set_gpg_encrypt(self, ui):
         account = self.envelope.account
-        if self.encrypt or account.encrypt_by_default == u"all":
+        if self.encrypt or account.encrypt_by_default == "all":
             logging.debug("Trying to encrypt message because encrypt=%s and "
                           "encrypt_by_default=%s", self.encrypt,
                           account.encrypt_by_default)
             await update_keys(ui, self.envelope, block_error=self.encrypt)
-        elif account.encrypt_by_default == u"trusted":
+        elif account.encrypt_by_default == "trusted":
             logging.debug("Trying to encrypt message because "
                           "account.encrypt_by_default=%s",
                           account.encrypt_by_default)

--- a/alot/commands/search.py
+++ b/alot/commands/search.py
@@ -148,7 +148,7 @@ class TagCommand(Command):
     """manipulate message tags"""
     repeatable = True
 
-    def __init__(self, tags=u'', action='add', allmessages=False, flush=True,
+    def __init__(self, tags='', action='add', allmessages=False, flush=True,
                  **kwargs):
         """
         :param tags: comma separated list of tagstrings to set

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -1080,7 +1080,7 @@ class TagCommand(Command):
     """manipulate message tags"""
     repeatable = True
 
-    def __init__(self, tags=u'', action='add', all=False, flush=True,
+    def __init__(self, tags='', action='add', all=False, flush=True,
                  **kwargs):
         """
         :param tags: comma separated list of tagstrings to set

--- a/alot/db/envelope.py
+++ b/alot/db/envelope.py
@@ -78,7 +78,7 @@ class Envelope:
             self.parse_template(template)
             logging.debug('PARSED TEMPLATE: %s', template)
             logging.debug('BODY: %s', self.body)
-        self.body = bodytext or u''
+        self.body = bodytext or ''
         # TODO: if this was as collections.defaultdict a number of methods
         # could be simplified.
         self.headers = headers or {}
@@ -100,7 +100,7 @@ class Envelope:
 
     def __setitem__(self, name, val):
         """setter for header values. This allows adding header like so:
-        envelope['Subject'] = u'sm\xf8rebr\xf8d'
+        envelope['Subject'] = 'sm\xf8rebr\xf8d'
         """
         if name not in self.headers:
             self.headers[name] = []

--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -50,7 +50,7 @@ def add_signature_headers(mail, sigs, error_msg):
     assert error_msg is None or isinstance(error_msg, str)
 
     if not sigs:
-        error_msg = error_msg or u'no signature found'
+        error_msg = error_msg or 'no signature found'
     elif not error_msg:
         try:
             key = crypto.get_key(sigs[0].fpr)
@@ -112,19 +112,19 @@ def _handle_signatures(original, message, params):
     """
     malformed = None
     if len(message.get_payload()) != 2:
-        malformed = u'expected exactly two messages, got {0}'.format(
+        malformed = 'expected exactly two messages, got {0}'.format(
             len(message.get_payload()))
     else:
         ct = message.get_payload(1).get_content_type()
         if ct != _APP_PGP_SIG:
-            malformed = u'expected Content-Type: {0}, got: {1}'.format(
+            malformed = 'expected Content-Type: {0}, got: {1}'.format(
                 _APP_PGP_SIG, ct)
 
     # TODO: RFC 3156 says the alg has to be lower case, but I've seen a message
     # with 'PGP-'. maybe we should be more permissive here, or maybe not, this
     # is crypto stuff...
     if not params.get('micalg', 'nothing').startswith('pgp-'):
-        malformed = u'expected micalg=pgp-..., got: {0}'.format(
+        malformed = 'expected micalg=pgp-..., got: {0}'.format(
             params.get('micalg', 'nothing'))
 
     sigs = []
@@ -161,13 +161,13 @@ def _handle_encrypted(original, message, session_keys=None):
 
     ct = message.get_payload(0).get_content_type()
     if ct != _APP_PGP_ENC:
-        malformed = u'expected Content-Type: {0}, got: {1}'.format(
+        malformed = 'expected Content-Type: {0}, got: {1}'.format(
             _APP_PGP_ENC, ct)
 
     want = 'application/octet-stream'
     ct = message.get_payload(1).get_content_type()
     if ct != want:
-        malformed = u'expected Content-Type: {0}, got: {1}'.format(want, ct)
+        malformed = 'expected Content-Type: {0}, got: {1}'.format(want, ct)
 
     if not malformed:
         # This should be safe because PGP uses US-ASCII characters only
@@ -209,7 +209,7 @@ def _handle_encrypted(original, message, session_keys=None):
                 add_signature_headers(original, sigs, '')
 
     if malformed:
-        msg = u'Malformed OpenPGP message: {0}'.format(malformed)
+        msg = 'Malformed OpenPGP message: {0}'.format(malformed)
         content = email.message_from_string(msg,
                                             _class=email.message.EmailMessage,
                                             policy=email.policy.SMTP)
@@ -317,11 +317,11 @@ def extract_headers(mail, headers=None):
     :param headers: headers to extract
     :type headers: list of str
     """
-    headertext = u''
+    headertext = ''
     if headers is None:
         headers = mail.keys()
     for key in headers:
-        value = u''
+        value = ''
         if key in mail:
             value = decode_header(mail.get(key, ''))
         headertext += '%s: %s\n' % (key, value)

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -116,7 +116,7 @@ def string_decode(string, enc='ascii'):
 def shorten(string, maxlen):
     """shortens string if longer than maxlen, appending ellipsis"""
     if 1 < maxlen < len(string):
-        string = string[:maxlen - 1] + u'…'
+        string = string[:maxlen - 1] + '…'
     return string[:maxlen]
 
 
@@ -162,7 +162,7 @@ def shorten_author_string(authors_string, maxlength):
     authors_chain = deque()
 
     if len(authors) == 0:
-        return u''
+        return ''
 
     # reserve space for first author
     first_au = shorten(authors.popleft(), maxlength)
@@ -179,7 +179,7 @@ def shorten_author_string(authors_string, maxlength):
         au = authors.pop()
         if len(au) > 1 and (remaining_length == 3 or (authors and
                                                       remaining_length < 7)):
-            authors_chain.appendleft(u'\u2026')
+            authors_chain.appendleft('\u2026')
             break
         else:
             if authors:
@@ -205,21 +205,21 @@ def pretty_datetime(d):
     >>> now.strftime('%c')
     'Sat 31 Mar 2012 14:47:26 '
     >>> pretty_datetime(now)
-    u'just now'
+    'just now'
     >>> pretty_datetime(now - timedelta(minutes=1))
-    u'1min ago'
+    '1min ago'
     >>> pretty_datetime(now - timedelta(hours=5))
-    u'5h ago'
+    '5h ago'
     >>> pretty_datetime(now - timedelta(hours=12))
-    u'02:54am'
+    '02:54am'
     >>> pretty_datetime(now - timedelta(days=1))
-    u'yest 02pm'
+    'yest 02pm'
     >>> pretty_datetime(now - timedelta(days=2))
-    u'Thu 02pm'
+    'Thu 02pm'
     >>> pretty_datetime(now - timedelta(days=7))
-    u'Mar 24'
+    'Mar 24'
     >>> pretty_datetime(now - timedelta(days=356))
-    u'Apr 2011'
+    'Apr 2011'
     """
     ampm = d.strftime('%p').lower()
     if len(ampm):
@@ -551,7 +551,7 @@ def parse_mailto(mailto_str):
         import urllib.parse
         to_str, parms_str = mailto_str[7:].partition('?')[::2]
         headers = {}
-        body = u''
+        body = ''
 
         to = urllib.parse.unquote(to_str)
         if to:

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -179,7 +179,7 @@ def shorten_author_string(authors_string, maxlength):
         au = authors.pop()
         if len(au) > 1 and (remaining_length == 3 or (authors and
                                                       remaining_length < 7)):
-            authors_chain.appendleft('\u2026')
+            authors_chain.appendleft('…')
             break
         else:
             if authors:

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -381,7 +381,7 @@ class SettingsManager:
             return getattr(self.hooks, key, None)
         return None
 
-    def get_mapped_input_keysequences(self, mode='global', prefix=u''):
+    def get_mapped_input_keysequences(self, mode='global', prefix=''):
         # get all bindings in this mode
         globalmaps, modemaps = self.get_keybindings(mode)
         candidates = list(globalmaps.keys()) + list(modemaps.keys())

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -290,7 +290,7 @@ class UI:
         self._unlock_callback = afterwards
         self._locked = True
 
-    def prompt(self, prefix, text=u'', completer=None, tab=0, history=None):
+    def prompt(self, prefix, text='', completer=None, tab=0, history=None):
         """
         prompt for text input.
         This returns a :class:`asyncio.Future`, which will have a string value
@@ -669,9 +669,9 @@ class UI:
         info['pending_writes'] = len(self.dbman.writequeue)
         info['input_queue'] = ' '.join(self.input_queue)
 
-        lefttxt = righttxt = u''
+        lefttxt = righttxt = ''
         if cb is not None:
-            lefttxt, righttxt = settings.get(btype + '_statusbar', (u'', u''))
+            lefttxt, righttxt = settings.get(btype + '_statusbar', ('', ''))
             lefttxt = string_decode(lefttxt, 'UTF-8')
             lefttxt = lefttxt.format(**info)
             righttxt = string_decode(righttxt, 'UTF-8')

--- a/alot/widgets/globals.py
+++ b/alot/widgets/globals.py
@@ -107,7 +107,7 @@ class CompleteEdit(urwid.Edit):
 
     def __init__(self, completer, on_exit,
                  on_error=None,
-                 edit_text=u'',
+                 edit_text='',
                  history=None,
                  **kwargs):
         """

--- a/docs/source/api/conf.py
+++ b/docs/source/api/conf.py
@@ -71,8 +71,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'alot'
-copyright = u'2011 ' + __author__
+project = 'alot'
+copyright = '2011 ' + __author__
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -243,8 +243,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'alot', u'alot Documentation',
-     [u'Patrick Totzke'], 1)
+    ('index', 'alot', 'alot Documentation',
+     ['Patrick Totzke'], 1)
 ]
 
 autodoc_member_order = 'bysource'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,7 +47,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'alot'
+project = 'alot'
 copyright = alot.__copyright__
 
 # The version info for the project you're documenting, acts as replacement for
@@ -186,8 +186,8 @@ htmlhelp_basename = 'alotdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual])
 latex_documents = [
-  ('index', 'alot.tex', u'alot Documentation',
-   u'Patrick Totzke', 'manual'),
+  ('index', 'alot.tex', 'alot Documentation',
+   'Patrick Totzke', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/tests/addressbook/test_external.py
+++ b/tests/addressbook/test_external.py
@@ -24,7 +24,7 @@ class TestExternalAddressbookGetContacts(unittest.TestCase):
         with self._patch_call_cmd(('', '', 42)):
             with self.assertRaises(external.AddressbookError) as contextmgr:
                 abook.get_contacts()
-        expected = u'abook command "foobar" returned with return code 42'
+        expected = 'abook command "foobar" returned with return code 42'
         self.assertEqual(contextmgr.exception.args[0], expected)
 
     def test_stderr_of_failing_command_is_part_of_exception_message(self):

--- a/tests/commands/test_envelope.py
+++ b/tests/commands/test_envelope.py
@@ -120,28 +120,28 @@ class TestTagCommands(unittest.TestCase):
         self.assertListEqual(sorted(actual), sorted(expected))
 
     def test_add_new_tags(self):
-        self._test(u'four', 'add', ['one', 'two', 'three', 'four'])
+        self._test('four', 'add', ['one', 'two', 'three', 'four'])
 
     def test_adding_existing_tags_has_no_effect(self):
-        self._test(u'one', 'add', ['one', 'two', 'three'])
+        self._test('one', 'add', ['one', 'two', 'three'])
 
     def test_remove_existing_tags(self):
-        self._test(u'one', 'remove', ['two', 'three'])
+        self._test('one', 'remove', ['two', 'three'])
 
     def test_remove_non_existing_tags_has_no_effect(self):
-        self._test(u'four', 'remove', ['one', 'two', 'three'])
+        self._test('four', 'remove', ['one', 'two', 'three'])
 
     def test_set_tags(self):
-        self._test(u'a,b,c', 'set', ['a', 'b', 'c'])
+        self._test('a,b,c', 'set', ['a', 'b', 'c'])
 
     def test_toggle_will_remove_existing_tags(self):
-        self._test(u'one', 'toggle', ['two', 'three'])
+        self._test('one', 'toggle', ['two', 'three'])
 
     def test_toggle_will_add_new_tags(self):
-        self._test(u'four', 'toggle', ['one', 'two', 'three', 'four'])
+        self._test('four', 'toggle', ['one', 'two', 'three', 'four'])
 
     def test_toggle_can_remove_and_add_in_one_run(self):
-        self._test(u'one,four', 'toggle', ['two', 'three', 'four'])
+        self._test('one,four', 'toggle', ['two', 'three', 'four'])
 
 
 class TestSignCommand(unittest.TestCase):

--- a/tests/commands/test_global.py
+++ b/tests/commands/test_global.py
@@ -84,12 +84,12 @@ class TestComposeCommand(unittest.TestCase):
         self.assertIs(envelope.sign_key, None)
 
     def test_get_template_decode(self):
-        subject = u'This is a täßϑ subject.'
-        to = u'recipient@mail.com'
-        _from = u'foo.bar@mail.fr'
-        body = u'Body\n地初店会継思識棋御招告外児山望掲領環。\n€mail body €nd.'
+        subject = 'This is a täßϑ subject.'
+        to = 'recipient@mail.com'
+        _from = 'foo.bar@mail.fr'
+        body = 'Body\n地初店会継思識棋御招告外児山望掲領環。\n€mail body €nd.'
         with tempfile.NamedTemporaryFile('wb', delete=False) as f:
-            txt = u'Subject: {}\nTo: {}\nFrom: {}\n{}'.format(subject, to,
+            txt = 'Subject: {}\nTo: {}\nFrom: {}\n{}'.format(subject, to,
                                                               _from, body)
             f.write(txt.encode('utf-8'))
         self.addCleanup(os.unlink, f.name)
@@ -109,14 +109,14 @@ class TestExternalCommand(unittest.TestCase):
     @utilities.async_test
     async def test_no_spawn_no_stdin_success(self):
         ui = utilities.make_ui()
-        cmd = g_commands.ExternalCommand(u'true', refocus=False)
+        cmd = g_commands.ExternalCommand('true', refocus=False)
         await cmd.apply(ui)
         ui.notify.assert_not_called()
 
     @utilities.async_test
     async def test_no_spawn_stdin_success(self):
         ui = utilities.make_ui()
-        cmd = g_commands.ExternalCommand(u"awk '{ exit $0 }'", stdin=u'0',
+        cmd = g_commands.ExternalCommand("awk '{ exit $0 }'", stdin='0',
                                          refocus=False)
         await cmd.apply(ui)
         ui.notify.assert_not_called()
@@ -124,7 +124,7 @@ class TestExternalCommand(unittest.TestCase):
     @utilities.async_test
     async def test_no_spawn_no_stdin_attached(self):
         ui = utilities.make_ui()
-        cmd = g_commands.ExternalCommand(u'test -t 0', refocus=False)
+        cmd = g_commands.ExternalCommand('test -t 0', refocus=False)
         await cmd.apply(ui)
         ui.notify.assert_not_called()
 
@@ -132,14 +132,14 @@ class TestExternalCommand(unittest.TestCase):
     async def test_no_spawn_stdin_attached(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(
-            u"test -t 0", stdin=u'0', refocus=False)
+            "test -t 0", stdin='0', refocus=False)
         await cmd.apply(ui)
         ui.notify.assert_called_once_with('', priority='error')
 
     @utilities.async_test
     async def test_no_spawn_failure(self):
         ui = utilities.make_ui()
-        cmd = g_commands.ExternalCommand(u'false', refocus=False)
+        cmd = g_commands.ExternalCommand('false', refocus=False)
         await cmd.apply(ui)
         ui.notify.assert_called_once_with('', priority='error')
 
@@ -149,7 +149,7 @@ class TestExternalCommand(unittest.TestCase):
     @mock.patch.dict(os.environ, {'DISPLAY': ':0'})
     async def test_spawn_no_stdin_success(self):
         ui = utilities.make_ui()
-        cmd = g_commands.ExternalCommand(u'true', refocus=False, spawn=True)
+        cmd = g_commands.ExternalCommand('true', refocus=False, spawn=True)
         await cmd.apply(ui)
         ui.notify.assert_not_called()
 
@@ -160,8 +160,8 @@ class TestExternalCommand(unittest.TestCase):
     async def test_spawn_stdin_success(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(
-            u"awk '{ exit $0 }'",
-            stdin=u'0', refocus=False, spawn=True)
+            "awk '{ exit $0 }'",
+            stdin='0', refocus=False, spawn=True)
         await cmd.apply(ui)
         ui.notify.assert_not_called()
 
@@ -171,7 +171,7 @@ class TestExternalCommand(unittest.TestCase):
     @mock.patch.dict(os.environ, {'DISPLAY': ':0'})
     async def test_spawn_failure(self):
         ui = utilities.make_ui()
-        cmd = g_commands.ExternalCommand(u'false', refocus=False, spawn=True)
+        cmd = g_commands.ExternalCommand('false', refocus=False, spawn=True)
         await cmd.apply(ui)
         ui.notify.assert_called_once_with('', priority='error')
 

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -33,7 +33,7 @@ class TestCommandFactory(unittest.TestCase):
         cmd = commands.commandfactory('save --all /foo', mode='thread')
         self.assertIsInstance(cmd, thread.SaveAttachmentCommand)
         self.assertTrue(cmd.all)
-        self.assertEqual(cmd.path, u'/foo')
+        self.assertEqual(cmd.path, '/foo')
 
 
 class TestRegisterCommand(unittest.TestCase):

--- a/tests/commands/test_thread.py
+++ b/tests/commands/test_thread.py
@@ -77,77 +77,77 @@ class TestDetermineSender(unittest.TestCase):
         self.assertTupleEqual(cm2.exception.args, expected)
 
     def test_default_account_is_used_if_no_match_is_found(self):
-        account1 = _AccountTestClass(address=u'foo@example.com')
-        account2 = _AccountTestClass(address=u'bar@example.com')
-        expected = (u'foo@example.com', account1)
+        account1 = _AccountTestClass(address='foo@example.com')
+        account2 = _AccountTestClass(address='bar@example.com')
+        expected = ('foo@example.com', account1)
         self._test(accounts=[account1, account2], expected=expected)
 
     def test_matching_address_and_account_are_returned(self):
-        account1 = _AccountTestClass(address=u'foo@example.com')
-        account2 = _AccountTestClass(address=u'to@example.com')
-        account3 = _AccountTestClass(address=u'bar@example.com')
-        expected = (u'to@example.com', account2)
+        account1 = _AccountTestClass(address='foo@example.com')
+        account2 = _AccountTestClass(address='to@example.com')
+        account3 = _AccountTestClass(address='bar@example.com')
+        expected = ('to@example.com', account2)
         self._test(accounts=[account1, account2, account3], expected=expected)
 
     def test_force_realname_has_real_name_in_returned_address_if_defined(self):
-        account1 = _AccountTestClass(address=u'foo@example.com')
-        account2 = _AccountTestClass(address=u'to@example.com', realname='Bar')
-        account3 = _AccountTestClass(address=u'baz@example.com')
-        expected = (u'Bar <to@example.com>', account2)
+        account1 = _AccountTestClass(address='foo@example.com')
+        account2 = _AccountTestClass(address='to@example.com', realname='Bar')
+        account3 = _AccountTestClass(address='baz@example.com')
+        expected = ('Bar <to@example.com>', account2)
         self._test(accounts=[account1, account2, account3], expected=expected,
                    force_realname=True)
 
     def test_doesnt_fail_with_force_realname_if_real_name_not_defined(self):
-        account1 = _AccountTestClass(address=u'foo@example.com')
-        account2 = _AccountTestClass(address=u'to@example.com')
-        account3 = _AccountTestClass(address=u'bar@example.com')
-        expected = (u'to@example.com', account2)
+        account1 = _AccountTestClass(address='foo@example.com')
+        account2 = _AccountTestClass(address='to@example.com')
+        account3 = _AccountTestClass(address='bar@example.com')
+        expected = ('to@example.com', account2)
         self._test(accounts=[account1, account2, account3], expected=expected,
                    force_realname=True)
 
     def test_with_force_address_main_address_is_always_used(self):
         # In python 3.4 this and the next test could be written as subtests.
-        account1 = _AccountTestClass(address=u'foo@example.com')
-        account2 = _AccountTestClass(address=u'bar@example.com',
-                                     aliases=[u'to@example.com'])
-        account3 = _AccountTestClass(address=u'bar@example.com')
-        expected = (u'bar@example.com', account2)
+        account1 = _AccountTestClass(address='foo@example.com')
+        account2 = _AccountTestClass(address='bar@example.com',
+                                     aliases=['to@example.com'])
+        account3 = _AccountTestClass(address='bar@example.com')
+        expected = ('bar@example.com', account2)
         self._test(accounts=[account1, account2, account3], expected=expected,
                    force_address=True)
 
     def test_without_force_address_matching_address_is_used(self):
         # In python 3.4 this and the previous test could be written as
         # subtests.
-        account1 = _AccountTestClass(address=u'foo@example.com')
-        account2 = _AccountTestClass(address=u'bar@example.com',
-                                     aliases=[u'to@example.com'])
-        account3 = _AccountTestClass(address=u'baz@example.com')
-        expected = (u'to@example.com', account2)
+        account1 = _AccountTestClass(address='foo@example.com')
+        account2 = _AccountTestClass(address='bar@example.com',
+                                     aliases=['to@example.com'])
+        account3 = _AccountTestClass(address='baz@example.com')
+        expected = ('to@example.com', account2)
         self._test(accounts=[account1, account2, account3], expected=expected,
                    force_address=False)
 
     def test_uses_to_header_if_present(self):
-        account1 = _AccountTestClass(address=u'foo@example.com')
-        account2 = _AccountTestClass(address=u'to@example.com')
-        account3 = _AccountTestClass(address=u'bar@example.com')
-        expected = (u'to@example.com', account2)
+        account1 = _AccountTestClass(address='foo@example.com')
+        account2 = _AccountTestClass(address='to@example.com')
+        account3 = _AccountTestClass(address='bar@example.com')
+        expected = ('to@example.com', account2)
         self._test(accounts=[account1, account2, account3], expected=expected)
 
     def test_header_order_is_more_important_than_accounts_order(self):
-        account1 = _AccountTestClass(address=u'cc@example.com')
-        account2 = _AccountTestClass(address=u'to@example.com')
-        account3 = _AccountTestClass(address=u'bcc@example.com')
-        expected = (u'to@example.com', account2)
+        account1 = _AccountTestClass(address='cc@example.com')
+        account2 = _AccountTestClass(address='to@example.com')
+        account3 = _AccountTestClass(address='bcc@example.com')
+        expected = ('to@example.com', account2)
         self._test(accounts=[account1, account2, account3], expected=expected)
 
     def test_accounts_can_be_found_by_alias_regex_setting(self):
-        account1 = _AccountTestClass(address=u'foo@example.com')
-        account2 = _AccountTestClass(address=u'to@example.com',
+        account1 = _AccountTestClass(address='foo@example.com')
+        account2 = _AccountTestClass(address='to@example.com',
                                      alias_regexp=r'to\+.*@example.com')
-        account3 = _AccountTestClass(address=u'bar@example.com')
-        mailstring = self.mailstring.replace(u'to@example.com',
-                                             u'to+some_tag@example.com')
+        account3 = _AccountTestClass(address='bar@example.com')
+        mailstring = self.mailstring.replace('to@example.com',
+                                             'to+some_tag@example.com')
         mail = email.message_from_string(mailstring)
-        expected = (u'to+some_tag@example.com', account2)
+        expected = ('to+some_tag@example.com', account2)
         self._test(accounts=[account1, account2, account3], expected=expected,
                    mail=mail)

--- a/tests/db/test_envelope.py
+++ b/tests/db/test_envelope.py
@@ -62,8 +62,8 @@ class TestEnvelope(unittest.TestCase):
     def test_setitem_stores_text_unchanged(self):
         "Just ensure that the value is set and unchanged"
         e = envelope.Envelope()
-        e['Subject'] = u'sm\xf8rebr\xf8d'
-        self.assertEqual(e['Subject'], u'sm\xf8rebr\xf8d')
+        e['Subject'] = 'sm\xf8rebr\xf8d'
+        self.assertEqual(e['Subject'], 'sm\xf8rebr\xf8d')
 
     def _test_mail(self, envelope):
         mail = envelope.construct_mail()

--- a/tests/db/test_message.py
+++ b/tests/db/test_message.py
@@ -91,8 +91,8 @@ class TestMessage(unittest.TestCase):
         is present.
         """
         acc = mock.Mock()
-        acc.address = account.Address(u'user', u'example.com')
-        acc.realname = u'User Name'
+        acc.address = account.Address('user', 'example.com')
+        acc.realname = 'User Name'
         with mock.patch('alot.db.message.settings.get_accounts',
                         mock.Mock(return_value=[acc])):
             msg = message.Message(
@@ -104,8 +104,8 @@ class TestMessage(unittest.TestCase):
         the message is not a draft.
         """
         acc = mock.Mock()
-        acc.address = account.Address(u'user', u'example.com')
-        acc.realname = u'User Name'
+        acc.address = account.Address('user', 'example.com')
+        acc.realname = 'User Name'
         with mock.patch('alot.db.message.settings.get_accounts',
                         mock.Mock(return_value=[acc])):
             msg = message.Message(mock.Mock(), MockNotmuchMessage())

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -132,37 +132,37 @@ class TestExtractHeader(unittest.TestCase):
             if not line:
                 break
             expected.append(line)
-        expected = u'\n'.join(expected) + u'\n'
+        expected = '\n'.join(expected) + '\n'
         self.assertEqual(actual, expected)
 
     def test_single_headers_can_be_retrieved(self):
         actual = utils.extract_headers(self.mail, ['from'])
-        expected = u'from: me\n'
+        expected = 'from: me\n'
         self.assertEqual(actual, expected)
 
     def test_multible_headers_can_be_retrieved_in_predevined_order(self):
         headers = ['x-header', 'to', 'x-uppercase']
         actual = utils.extract_headers(self.mail, headers)
-        expected = u'x-header: param=one; and=two; or=three\nto: you\n' \
-            u'x-uppercase: PARAM1=ONE; PARAM2=TWO\n'
+        expected = 'x-header: param=one; and=two; or=three\nto: you\n' \
+            'x-uppercase: PARAM1=ONE; PARAM2=TWO\n'
         self.assertEqual(actual, expected)
 
     def test_headers_can_be_retrieved_multible_times(self):
         headers = ['from', 'from']
         actual = utils.extract_headers(self.mail, headers)
-        expected = u'from: me\nfrom: me\n'
+        expected = 'from: me\nfrom: me\n'
         self.assertEqual(actual, expected)
 
     def test_case_is_prserved_in_header_keys_but_irelevant(self):
         headers = ['FROM', 'from']
         actual = utils.extract_headers(self.mail, headers)
-        expected = u'FROM: me\nfrom: me\n'
+        expected = 'FROM: me\nfrom: me\n'
         self.assertEqual(actual, expected)
 
     @unittest.expectedFailure
     def test_header_values_are_not_decoded(self):
         actual = utils.extract_headers(self.mail, ['x-quoted'])
-        expected = u"x-quoted: param=utf-8''%C3%9Cmlaut; second=plain%C3%9C\n",
+        expected = "x-quoted: param=utf-8''%C3%9Cmlaut; second=plain%C3%9C\n",
         self.assertEqual(actual, expected)
 
 
@@ -207,78 +207,78 @@ class TestDecodeHeader(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_non_ascii_strings_are_returned_as_unicode_directly(self):
-        text = u'Nön ÄSCII string¡'
+        text = 'Nön ÄSCII string¡'
         self._test(text, text)
 
     def test_basic_utf_8_quoted(self):
-        expected = u'ÄÖÜäöü'
+        expected = 'ÄÖÜäöü'
         text = self._quote(expected, 'utf-8')
         self._test(text, expected)
 
     def test_basic_iso_8859_1_quoted(self):
-        expected = u'ÄÖÜäöü'
+        expected = 'ÄÖÜäöü'
         text = self._quote(expected, 'iso-8859-1')
         self._test(text, expected)
 
     def test_basic_windows_1252_quoted(self):
-        expected = u'ÄÖÜäöü'
+        expected = 'ÄÖÜäöü'
         text = self._quote(expected, 'windows-1252')
         self._test(text, expected)
 
     def test_basic_utf_8_base64(self):
-        expected = u'ÄÖÜäöü'
+        expected = 'ÄÖÜäöü'
         text = self._base64(expected, 'utf-8')
         self._test(text, expected)
 
     def test_basic_iso_8859_1_base64(self):
-        expected = u'ÄÖÜäöü'
+        expected = 'ÄÖÜäöü'
         text = self._base64(expected, 'iso-8859-1')
         self._test(text, expected)
 
     def test_basic_iso_1252_base64(self):
-        expected = u'ÄÖÜäöü'
+        expected = 'ÄÖÜäöü'
         text = self._base64(expected, 'windows-1252')
         self._test(text, expected)
 
     def test_quoted_words_can_be_interrupted(self):
-        part = u'ÄÖÜäöü'
+        part = 'ÄÖÜäöü'
         text = self._base64(part, 'utf-8') + ' and ' + \
             self._quote(part, 'utf-8')
-        expected = u'ÄÖÜäöü and ÄÖÜäöü'
+        expected = 'ÄÖÜäöü and ÄÖÜäöü'
         self._test(text, expected)
 
     def test_different_encodings_can_be_mixed(self):
-        part = u'ÄÖÜäöü'
+        part = 'ÄÖÜäöü'
         text = 'utf-8: ' + self._base64(part, 'utf-8') + \
             ' again: ' + self._quote(part, 'utf-8') + \
             ' latin1: ' + self._base64(part, 'iso-8859-1') + \
             ' and ' + self._quote(part, 'iso-8859-1')
         expected = (
-            u'utf-8: ÄÖÜäöü '
-            u'again: ÄÖÜäöü '
-            u'latin1: ÄÖÜäöü and ÄÖÜäöü'
+            'utf-8: ÄÖÜäöü '
+            'again: ÄÖÜäöü '
+            'latin1: ÄÖÜäöü and ÄÖÜäöü'
         )
         self._test(text, expected)
 
     def test_tabs_are_expanded_to_align_with_eigth_spaces(self):
         text = 'tab: \t'
-        expected = u'tab:    '
+        expected = 'tab:    '
         self._test(text, expected)
 
     def test_newlines_are_not_touched_by_default(self):
         text = 'first\nsecond\n third\n  fourth'
-        expected = u'first\nsecond\n third\n  fourth'
+        expected = 'first\nsecond\n third\n  fourth'
         self._test(text, expected)
 
     def test_continuation_newlines_can_be_normalized(self):
         text = 'first\nsecond\n third\n\tfourth\n \t  fifth'
-        expected = u'first\nsecond third fourth fifth'
+        expected = 'first\nsecond third fourth fifth'
         actual = utils.decode_header(text, normalize=True)
         self.assertEqual(actual, expected)
 
     def test_exchange_quotes_remain(self):
         # issue #1347
-        expected = u'"Mouse, Michaël" <x@y.z>'
+        expected = '"Mouse, Michaël" <x@y.z>'
         text = self._quote(expected, 'utf-8')
         self._test(text, expected)
 
@@ -292,7 +292,7 @@ class TestAddSignatureHeaders(unittest.TestCase):
         def add_header(self, header, value):
             self.headers.append((header, value))
 
-    def check(self, key, valid, error_msg=u''):
+    def check(self, key, valid, error_msg=''):
         mail = self.FakeMail()
 
         with mock.patch('alot.db.utils.crypto.get_key',
@@ -305,55 +305,55 @@ class TestAddSignatureHeaders(unittest.TestCase):
 
     def test_length_0(self):
         mail = self.FakeMail()
-        utils.add_signature_headers(mail, [], u'')
-        self.assertIn((utils.X_SIGNATURE_VALID_HEADER, u'False'), mail.headers)
+        utils.add_signature_headers(mail, [], '')
+        self.assertIn((utils.X_SIGNATURE_VALID_HEADER, 'False'), mail.headers)
         self.assertIn(
-            (utils.X_SIGNATURE_MESSAGE_HEADER, u'Invalid: no signature found'),
+            (utils.X_SIGNATURE_MESSAGE_HEADER, 'Invalid: no signature found'),
             mail.headers)
 
     def test_valid(self):
         key = make_key()
         mail = self.check(key, True)
 
-        self.assertIn((utils.X_SIGNATURE_VALID_HEADER, u'True'), mail.headers)
+        self.assertIn((utils.X_SIGNATURE_VALID_HEADER, 'True'), mail.headers)
         self.assertIn(
-            (utils.X_SIGNATURE_MESSAGE_HEADER, u'Valid: mocked'), mail.headers)
+            (utils.X_SIGNATURE_MESSAGE_HEADER, 'Valid: mocked'), mail.headers)
 
     def test_untrusted(self):
         key = make_key()
         mail = self.check(key, False)
 
-        self.assertIn((utils.X_SIGNATURE_VALID_HEADER, u'True'), mail.headers)
+        self.assertIn((utils.X_SIGNATURE_VALID_HEADER, 'True'), mail.headers)
         self.assertIn(
-            (utils.X_SIGNATURE_MESSAGE_HEADER, u'Untrusted: mocked'),
+            (utils.X_SIGNATURE_MESSAGE_HEADER, 'Untrusted: mocked'),
             mail.headers)
 
     def test_unicode_as_bytes(self):
         mail = self.FakeMail()
         key = make_key()
-        key.uids = [make_uid('andreá@example.com', uid=u'Andreá')]
+        key.uids = [make_uid('andreá@example.com', uid='Andreá')]
         mail = self.check(key, True)
 
-        self.assertIn((utils.X_SIGNATURE_VALID_HEADER, u'True'), mail.headers)
+        self.assertIn((utils.X_SIGNATURE_VALID_HEADER, 'True'), mail.headers)
         self.assertIn(
-            (utils.X_SIGNATURE_MESSAGE_HEADER, u'Valid: Andreá'),
+            (utils.X_SIGNATURE_MESSAGE_HEADER, 'Valid: Andreá'),
             mail.headers)
 
     def test_error_message_unicode(self):
-        mail = self.check(mock.Mock(), mock.Mock(), u'error message')
-        self.assertIn((utils.X_SIGNATURE_VALID_HEADER, u'False'), mail.headers)
+        mail = self.check(mock.Mock(), mock.Mock(), 'error message')
+        self.assertIn((utils.X_SIGNATURE_VALID_HEADER, 'False'), mail.headers)
         self.assertIn(
-            (utils.X_SIGNATURE_MESSAGE_HEADER, u'Invalid: error message'),
+            (utils.X_SIGNATURE_MESSAGE_HEADER, 'Invalid: error message'),
             mail.headers)
 
     def test_get_key_fails(self):
         mail = self.FakeMail()
         with mock.patch('alot.db.utils.crypto.get_key',
-                        mock.Mock(side_effect=GPGProblem(u'', 0))):
-            utils.add_signature_headers(mail, [mock.Mock(fpr='')], u'')
-        self.assertIn((utils.X_SIGNATURE_VALID_HEADER, u'False'), mail.headers)
+                        mock.Mock(side_effect=GPGProblem('', 0))):
+            utils.add_signature_headers(mail, [mock.Mock(fpr='')], '')
+        self.assertIn((utils.X_SIGNATURE_VALID_HEADER, 'False'), mail.headers)
         self.assertIn(
-            (utils.X_SIGNATURE_MESSAGE_HEADER, u'Untrusted: '),
+            (utils.X_SIGNATURE_MESSAGE_HEADER, 'Untrusted: '),
             mail.headers)
 
 
@@ -395,7 +395,7 @@ class TestMessageFromFile(TestCaseClassCleanup):
         self.assertIs(message.get(utils.X_SIGNATURE_MESSAGE_HEADER), None)
 
     def test_plain_mail(self):
-        m = email.mime.text.MIMEText(u'This is some text', 'plain', 'utf-8')
+        m = email.mime.text.MIMEText('This is some text', 'plain', 'utf-8')
         m['Subject'] = 'test'
         m['From'] = 'me'
         m['To'] = 'Nobody'
@@ -688,7 +688,7 @@ class TestMessageFromString(unittest.TestCase):
     """
 
     def test(self):
-        m = email.mime.text.MIMEText(u'This is some text', 'plain', 'utf-8')
+        m = email.mime.text.MIMEText('This is some text', 'plain', 'utf-8')
         m['Subject'] = 'test'
         m['From'] = 'me'
         m['To'] = 'Nobody'
@@ -767,15 +767,15 @@ class _AccountTestClass(Account):
 
 class TestClearMyAddress(unittest.TestCase):
 
-    me1 = u'me@example.com'
-    me2 = u'ME@example.com'
-    me3 = u'me+label@example.com'
-    me4 = u'ME+label@example.com'
+    me1 = 'me@example.com'
+    me2 = 'ME@example.com'
+    me3 = 'me+label@example.com'
+    me4 = 'ME+label@example.com'
     me_regex = r'me\+.*@example.com'
-    me_named = u'alot team <me@example.com>'
-    you = u'you@example.com'
-    named = u'somebody you know <somebody@example.com>'
-    imposter = u'alot team <imposter@example.com>'
+    me_named = 'alot team <me@example.com>'
+    you = 'you@example.com'
+    named = 'somebody you know <somebody@example.com>'
+    imposter = 'alot team <imposter@example.com>'
     mine = _AccountTestClass(
         address=me1, aliases=[], alias_regexp=me_regex, case_sensitive_username=True)
 
@@ -811,7 +811,7 @@ class TestClearMyAddress(unittest.TestCase):
 
 class TestFormataddr(unittest.TestCase):
 
-    address = u'me@example.com'
+    address = 'me@example.com'
     umlauts_and_comma = '"Ö, Ä" <a@b.c>'
 
     def test_is_inverse(self):

--- a/tests/settings/test_manager.py
+++ b/tests/settings/test_manager.py
@@ -272,17 +272,17 @@ class TestSettingsManagerGetAccountByAddress(utilities.TestCaseClassCleanup):
         cls.manager.read_config(f.name)
 
     def test_exists_addr(self):
-        acc = self.manager.account_matching_address(u'that_guy@example.com')
+        acc = self.manager.account_matching_address('that_guy@example.com')
         self.assertEqual(acc.realname, 'That Guy')
 
     def test_doesnt_exist_return_default(self):
-        acc = self.manager.account_matching_address(u'doesntexist@example.com',
+        acc = self.manager.account_matching_address('doesntexist@example.com',
                                                     return_default=True)
         self.assertEqual(acc.realname, 'That Guy')
 
     def test_doesnt_exist_raise(self):
         with self.assertRaises(NoMatchingAccount):
-            self.manager.account_matching_address(u'doesntexist@example.com')
+            self.manager.account_matching_address('doesntexist@example.com')
 
     def test_doesnt_exist_no_default(self):
         with tempfile.NamedTemporaryFile() as f:

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -35,23 +35,23 @@ class TestAccount(unittest.TestCase):
     def test_matches_address(self):
         """Tests address without aliases."""
         acct = _AccountTestClass(address="foo@example.com")
-        self.assertTrue(acct.matches_address(u"foo@example.com"))
-        self.assertFalse(acct.matches_address(u"bar@example.com"))
+        self.assertTrue(acct.matches_address("foo@example.com"))
+        self.assertFalse(acct.matches_address("bar@example.com"))
 
     def test_matches_address_with_aliases(self):
         """Tests address with aliases."""
         acct = _AccountTestClass(address="foo@example.com",
                                  aliases=['bar@example.com'])
-        self.assertTrue(acct.matches_address(u"foo@example.com"))
-        self.assertTrue(acct.matches_address(u"bar@example.com"))
-        self.assertFalse(acct.matches_address(u"baz@example.com"))
+        self.assertTrue(acct.matches_address("foo@example.com"))
+        self.assertTrue(acct.matches_address("bar@example.com"))
+        self.assertFalse(acct.matches_address("baz@example.com"))
 
     def test_matches_address_with_regex_aliases(self):
         """Tests address with regex aliases."""
-        acct = _AccountTestClass(address=u"foo@example.com",
+        acct = _AccountTestClass(address="foo@example.com",
                                  alias_regexp=r'to\+.*@example.com')
-        self.assertTrue(acct.matches_address(u"to+foo@example.com"))
-        self.assertFalse(acct.matches_address(u"to@example.com"))
+        self.assertTrue(acct.matches_address("to+foo@example.com"))
+        self.assertFalse(acct.matches_address("to@example.com"))
 
 
     def test_deprecated_encrypt_by_default(self):

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -70,7 +70,7 @@ def make_key(revoked=False, expired=False, invalid=False, can_encrypt=True,
              can_sign=True):
     # This is ugly
     mock_key = mock.create_autospec(gpg._gpgme._gpgme_key)
-    mock_key.uids = [mock.Mock(uid=u'mocked')]
+    mock_key.uids = [mock.Mock(uid='mocked')]
     mock_key.revoked = revoked
     mock_key.expired = expired
     mock_key.invalid = invalid
@@ -267,12 +267,12 @@ class TestListKeys(unittest.TestCase):
 
     def test_list_keys_pub(self):
         values = list(crypto.list_keys(hint="ambigu"))[0]
-        self.assertEqual(values.uids[0].email, u'amigbu@example.com')
+        self.assertEqual(values.uids[0].email, 'amigbu@example.com')
         self.assertFalse(values.secret)
 
     def test_list_keys_private(self):
         values = list(crypto.list_keys(hint="ambigu", private=True))[0]
-        self.assertEqual(values.uids[0].email, u'amigbu@example.com')
+        self.assertEqual(values.uids[0].email, 'amigbu@example.com')
         self.assertTrue(values.secret)
 
 

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -38,7 +38,7 @@ from . import utilities
 
 class TestHelperShortenAuthorString(unittest.TestCase):
 
-    authors = u'King Kong, Mucho Muchacho, Jaime Huerta, Flash Gordon'
+    authors = 'King Kong, Mucho Muchacho, Jaime Huerta, Flash Gordon'
 
     def test_high_maxlength_keeps_string_intact(self):
         short = helper.shorten_author_string(self.authors, 60)
@@ -46,23 +46,23 @@ class TestHelperShortenAuthorString(unittest.TestCase):
 
     def test_shows_only_first_names_if_they_fit(self):
         short = helper.shorten_author_string(self.authors, 40)
-        self.assertEqual(short, u"King, Mucho, Jaime, Flash")
+        self.assertEqual(short, "King, Mucho, Jaime, Flash")
 
     def test_adds_ellipses_to_long_first_names(self):
         short = helper.shorten_author_string(self.authors, 20)
-        self.assertEqual(short, u"King, …, Jai…, Flash")
+        self.assertEqual(short, "King, …, Jai…, Flash")
 
     def test_replace_all_but_first_name_with_ellipses(self):
         short = helper.shorten_author_string(self.authors, 10)
-        self.assertEqual(short, u"King, …")
+        self.assertEqual(short, "King, …")
 
     def test_shorten_first_name_with_ellipses(self):
         short = helper.shorten_author_string(self.authors, 2)
-        self.assertEqual(short, u"K…")
+        self.assertEqual(short, "K…")
 
     def test_only_display_initial_letter_for_maxlength_1(self):
         short = helper.shorten_author_string(self.authors, 1)
-        self.assertEqual(short, u"K")
+        self.assertEqual(short, "K")
 
 
 class TestShellQuote(unittest.TestCase):
@@ -125,7 +125,7 @@ class TestSplitCommandline(unittest.TestCase):
         self._test(base, expected)
 
     def test_unicode(self):
-        base = u'echo "foo";sleep 1'
+        base = 'echo "foo";sleep 1'
         expected = ['echo "foo"', 'sleep 1']
         self._test(base, expected)
 
@@ -164,18 +164,18 @@ class TestStringDecode(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_ascii_bytes(self):
-        base = u'test'.encode('ascii')
-        expected = u'test'
+        base = 'test'.encode('ascii')
+        expected = 'test'
         self._test(base, expected)
 
     def test_utf8_bytes(self):
-        base = u'test'.encode('utf-8')
-        expected = u'test'
+        base = 'test'.encode('utf-8')
+        expected = 'test'
         self._test(base, expected, 'utf-8')
 
     def test_unicode(self):
-        base = u'test'
-        expected = u'test'
+        base = 'test'
+        expected = 'test'
         self._test(base, expected)
 
 
@@ -219,21 +219,21 @@ class TestPrettyDatetime(unittest.TestCase):
         for i in (self.random.randint(0, 60) for _ in range(5)):
             test = self.now - datetime.timedelta(seconds=i)
             actual = helper.pretty_datetime(test)
-            self.assertEqual(actual, u'just now')
+            self.assertEqual(actual, 'just now')
 
     def test_x_minutes_ago(self):
         for i in (self.random.randint(60, 3600) for _ in range(10)):
             test = self.now - datetime.timedelta(seconds=i)
             actual = helper.pretty_datetime(test)
             self.assertEqual(
-                actual, u'{}min ago'.format((self.now - test).seconds // 60))
+                actual, '{}min ago'.format((self.now - test).seconds // 60))
 
     def test_x_hours_ago(self):
         for i in (self.random.randint(3600, 3600 * 6) for _ in range(10)):
             test = self.now - datetime.timedelta(seconds=i)
             actual = helper.pretty_datetime(test)
             self.assertEqual(
-                actual, u'{}h ago'.format((self.now - test).seconds // 3600))
+                actual, '{}h ago'.format((self.now - test).seconds // 3600))
 
     # TODO: yesterday
     # TODO: yesterday > now > a year
@@ -318,45 +318,45 @@ class TestCallCmd(unittest.TestCase):
 
     def test_no_stdin(self):
         out, err, code = helper.call_cmd(['echo', '-n', 'foo'])
-        self.assertEqual(out, u'foo')
-        self.assertEqual(err, u'')
+        self.assertEqual(out, 'foo')
+        self.assertEqual(err, '')
         self.assertEqual(code, 0)
 
     def test_no_stdin_unicode(self):
         out, err, code = helper.call_cmd(['echo', '-n', '�'])
-        self.assertEqual(out, u'�')
-        self.assertEqual(err, u'')
+        self.assertEqual(out, '�')
+        self.assertEqual(err, '')
         self.assertEqual(code, 0)
 
     def test_stdin(self):
         out, err, code = helper.call_cmd(['cat'], stdin='�')
-        self.assertEqual(out, u'�')
-        self.assertEqual(err, u'')
+        self.assertEqual(out, '�')
+        self.assertEqual(err, '')
         self.assertEqual(code, 0)
 
     def test_no_such_command(self):
         out, err, code = helper.call_cmd(['thiscommandabsolutelydoesntexist'])
-        self.assertEqual(out, u'')
+        self.assertEqual(out, '')
 
         # We don't control the output of err, the shell does. Therefore simply
         # assert that the shell said *something*
-        self.assertNotEqual(err, u'')
+        self.assertNotEqual(err, '')
         self.assertEqual(code, errno.ENOENT)
 
     def test_no_such_command_stdin(self):
         out, err, code = helper.call_cmd(['thiscommandabsolutelydoesntexist'],
                                          stdin='foo')
-        self.assertEqual(out, u'')
+        self.assertEqual(out, '')
 
         # We don't control the output of err, the shell does. Therefore simply
         # assert that the shell said *something*
-        self.assertNotEqual(err, u'')
+        self.assertNotEqual(err, '')
         self.assertEqual(code, errno.ENOENT)
 
     def test_bad_argument_stdin(self):
         out, err, code = helper.call_cmd(['cat', '-Y'], stdin='�')
-        self.assertEqual(out, u'')
-        self.assertNotEqual(err, u'')
+        self.assertEqual(out, '')
+        self.assertNotEqual(err, '')
 
         # We don't control this, although 1 might be a fairly safe guess, we
         # know for certain it should *not* return 0
@@ -364,8 +364,8 @@ class TestCallCmd(unittest.TestCase):
 
     def test_bad_argument(self):
         out, err, code = helper.call_cmd(['cat', '-Y'])
-        self.assertEqual(out, u'')
-        self.assertNotEqual(err, u'')
+        self.assertEqual(out, '')
+        self.assertNotEqual(err, '')
 
         # We don't control this, although 1 might be a fairly safe guess, we
         # know for certain it should *not* return 0
@@ -373,18 +373,18 @@ class TestCallCmd(unittest.TestCase):
 
     def test_os_errors_from_popen_are_caught(self):
         with mock.patch('subprocess.Popen',
-                        mock.Mock(side_effect=OSError(42, u'foobar'))):
+                        mock.Mock(side_effect=OSError(42, 'foobar'))):
             out, err, code = helper.call_cmd(
                 ['does_not_matter_as_subprocess_popen_is_mocked'])
-        self.assertEqual(out, u'')
-        self.assertEqual(err, u'foobar')
+        self.assertEqual(out, '')
+        self.assertEqual(err, 'foobar')
         self.assertEqual(code, 42)
 
 
 class TestShorten(unittest.TestCase):
 
     def test_lt_maxlen(self):
-        expected = u'a string'
+        expected = 'a string'
         actual = helper.shorten(expected, 25)
         self.assertEqual(expected, actual)
 
@@ -394,7 +394,7 @@ class TestShorten(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_gt_maxlen(self):
-        expected = u'a long string…'
+        expected = 'a long string…'
         actual = helper.shorten('a long string that is full of text', 14)
         self.assertEqual(expected, actual)
 

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -147,7 +147,7 @@ class ModuleCleanup(object):
         return wrapper
 
 
-def make_uid(email, uid=u'mocked', revoked=False, invalid=False,
+def make_uid(email, uid='mocked', revoked=False, invalid=False,
              validity=gpg.constants.validity.FULL):
     uid_ = mock.Mock()
     uid_.email = email
@@ -162,7 +162,7 @@ def make_uid(email, uid=u'mocked', revoked=False, invalid=False,
 def make_key(revoked=False, expired=False, invalid=False, can_encrypt=True,
              can_sign=True):
     mock_key = mock.Mock()
-    mock_key.uids = [make_uid(u'foo@example.com')]
+    mock_key.uids = [make_uid('foo@example.com')]
     mock_key.revoked = revoked
     mock_key.expired = expired
     mock_key.invalid = invalid

--- a/tests/widgets/test_globals.py
+++ b/tests/widgets/test_globals.py
@@ -40,7 +40,7 @@ class TestTagWidget(unittest.TestCase):
     def test_hash_for_unicode_representation(self):
         with mock.patch(
                 'alot.widgets.globals.settings.get_tagstring_representation',
-                lambda _, __, ___: {'translated': u'✉', 'normal': None,
+                lambda _, __, ___: {'translated': '✉', 'normal': None,
                                     'focussed': None}):
             # We don't have to assert anything, we just want the hash to be
             # computed without an exception.  The implementation currently


### PR DESCRIPTION
In order to confuse new developers less.