### PR TITLE
Fix compatibility with Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: xenial
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
 
 # We start two containers in parallel, one to check and build the docs and the
 # other to run the test suite.

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -93,6 +93,7 @@ class TestCaseClassCleanup(unittest.TestCase):
 
     @classmethod
     def doClassCleanups(cls):  # pylint: disable=invalid-name
+        cls.tearDown_exceptions = []
         while cls.__stack:
             func, args, kwargs = cls.__stack.pop()
 


### PR DESCRIPTION
The error handling code needs tearDown_exceptions in the new version of Python. Otherwise the following error appears:

```
Traceback (most recent call last):
  File "setup.py", line 7, in <module>
    setup(
  File "/usr/lib/python3.8/site-packages/setuptools/__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python3.8/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib/python3.8/distutils/dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.8/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/usr/lib/python3.8/site-packages/setuptools/command/test.py", line 229, in run
    self.run_tests()
  File "/usr/lib/python3.8/site-packages/setuptools/command/test.py", line 247, in run_tests
    test = unittest.main(
  File "/usr/lib/python3.8/unittest/main.py", line 101, in __init__
    self.runTests()
  File "/usr/lib/python3.8/unittest/main.py", line 271, in runTests
    self.result = testRunner.run(self.test)
  File "/usr/lib/python3.8/unittest/runner.py", line 176, in run
    test(result)
  File "/usr/lib/python3.8/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.8/unittest/suite.py", line 122, in run
    test(result)
  File "/usr/lib/python3.8/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.8/unittest/suite.py", line 122, in run
    test(result)
  File "/usr/lib/python3.8/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.8/unittest/suite.py", line 122, in run
    test(result)
  File "/usr/lib/python3.8/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.8/unittest/suite.py", line 122, in run
    test(result)
  File "/usr/lib/python3.8/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.8/unittest/suite.py", line 112, in run
    self._tearDownPreviousClass(test, result)
  File "/usr/lib/python3.8/unittest/suite.py", line 301, in _tearDownPreviousClass
    if len(previousClass.tearDown_exceptions) > 0:
AttributeError: type object 'TestSettingsManagerGetAccountByAddress' has no attribute 'tearDown_exceptions'
```