### PR TITLE
envelope: fix header key:value parsing regression

### DIFF
--- a/alot/db/envelope.py
+++ b/alot/db/envelope.py
@@ -315,7 +315,7 @@ class Envelope:
             # locally, lines are separated by a simple LF, not CRLF
             # we decode the edited text ourselves here as
             # email.message_from_file can't deal with raw utf8 header values
-            headerRe = re.compile(r'^(?P<k>.+):(?P<v>(.|\n[ \t\r\f\v])+)$',
+            headerRe = re.compile(r'^(?P<k>.+?):(?P<v>(.|\n[ \t\r\f\v])+)$',
                                   re.MULTILINE)
             for header in headerRe.finditer(raw):
                 if header.start() > headerEndPos + 1:

--- a/tests/db/test_envelope.py
+++ b/tests/db/test_envelope.py
@@ -94,7 +94,7 @@ class TestEnvelope(unittest.TestCase):
             'From: foo@example.com\n'
             'To: bar@example.com,\n'
             ' baz@example.com\n'
-            'Subject: Test email\n'
+            'Subject: Fwd: Test email\n'
             '\n'
             'Some body content: which is not a header.\n'
         )
@@ -103,7 +103,7 @@ class TestEnvelope(unittest.TestCase):
         self.assertDictEqual(envlp.headers, {
             'From': ['foo@example.com'],
             'To': ['bar@example.com, baz@example.com'],
-            'Subject': ['Test email']
+            'Subject': ['Fwd: Test email']
         })
         self.assertEqual(envlp.body,
                          'Some body content: which is not a header.')


### PR DESCRIPTION
Fixes an issue introduced in 45829f7956716638fe77989a50eb87d3ea34cace
which made header values containing ':' break the parser.