### PR TITLE
envelope: add setting for custom Message-ID domain

### DIFF
--- a/alot/db/envelope.py
+++ b/alot/db/envelope.py
@@ -274,7 +274,8 @@ class Envelope:
         headers = self.headers.copy()
         # add Message-ID
         if 'Message-ID' not in headers:
-            headers['Message-ID'] = [email.utils.make_msgid()]
+            domain = settings.get('message_id_domain')
+            headers['Message-ID'] = [email.utils.make_msgid(domain=domain)]
 
         if 'User-Agent' in headers:
             uastring_format = headers['User-Agent'][0]

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -197,6 +197,10 @@ quit_on_last_bclose = boolean(default=False)
 # The string '{version}' will be replaced by the version string of the running instance.
 user_agent = string(default='alot/{version}')
 
+# Domain to use in automatically generated Message-ID headers.
+# The default is the local hostname.
+message_id_domain = string(default=None)
+
 # Suffix of the prompt used when waiting for user input
 prompt_suffix = string(default=':')
 

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -380,6 +380,17 @@
     :default: ,
 
 
+.. _message-id-domain:
+
+.. describe:: message_id_domain
+
+     Domain to use in automatically generated Message-ID headers.
+     The default is the local hostname.
+
+    :type: string
+    :default: None
+
+
 .. _msg-summary-hides-threadwide-tags:
 
 .. describe:: msg_summary_hides_threadwide_tags


### PR DESCRIPTION
This allows users to use a custom domain in automatically generated
Message-ID headers instead of the local hostname.