### PR TITLE
ignore quoted separators when splitting command lines

### DIFF
--- a/alot/helper.py
+++ b/alot/helper.py
@@ -23,20 +23,12 @@ import urwid
 import magic
 
 
-def split_commandline(s, comments=False, posix=True):
+def split_commandline(s):
     """
-    splits semi-colon separated commandlines
+    splits semi-colon separated commandlines, ignoring quoted separators
     """
-    # shlex seems to remove unescaped quotes and backslashes
-    s = s.replace('\\', '\\\\')
-    s = s.replace('\'', '\\\'')
-    s = s.replace('\"', '\\\"')
-    lex = shlex.shlex(s, posix=posix)
-    lex.whitespace_split = True
-    lex.whitespace = ';'
-    if not comments:
-        lex.commenters = ''
-    return list(lex)
+    splitter = r'''((?:[^;"']|"(\\\\|\\"|[^"])*"|'(\\\\|\\'|[^'])*')+)'''
+    return re.split(splitter, s)[1::4]
 
 
 def split_commandstring(cmdstring):

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -124,9 +124,20 @@ class TestSplitCommandline(unittest.TestCase):
         expected = [base]
         self._test(base, expected)
 
-    def test_unicode(self):
-        base = 'echo "foo";sleep 1'
-        expected = ['echo "foo"', 'sleep 1']
+    def test_quoted_separator(self):
+        base = '''echo "foo; bar";sleep 1 ; echo "foo; \\"bar; baz";''' \
+               ''' echo "foo; bar \\\\" "baz"; test 'hi' 'hi';''' \
+               ''' word; two words; empty '' '''
+        expected = [
+            'echo "foo; bar"',
+            'sleep 1 ',
+            ' echo "foo; \\"bar; baz"',
+            ' echo "foo; bar \\\\" "baz"',
+            " test 'hi' 'hi'",
+            ' word',
+            ' two words',
+            " empty '' "
+        ]
         self._test(base, expected)
 
 


### PR DESCRIPTION
Fixes https://github.com/pazz/alot/issues/1454:
Can't attach a file if filename contains a semicolon