### PR TITLE
Clear the screen before initial paint

### DIFF
--- a/alot/ui.py
+++ b/alot/ui.py
@@ -134,6 +134,9 @@ class UI:
         logging.info('setup gui in %d colours', colourmode)
         self.mainloop.screen.set_terminal_properties(colors=colourmode)
 
+        # clear the screen before the initial frame
+        self.mainloop.screen.clear()
+
         logging.debug('fire first command')
         loop.create_task(self.apply_commandline(initialcmdline))
 


### PR DESCRIPTION
If the terminal previously did show another curses application (e.g.
VIM) that content might be shown upon starting alot until the first
command has been executed and the result printed. By simply clearing the
screen before entering the mainloop we can work around that.