### PR TITLE
Pipeto --as_file

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -296,10 +296,10 @@ class ExternalCommand(Command):
                 else:
                     out, err = proc.communicate(
                         stdin.read() if stdin else None)
-                if proc.returncode == 0:
-                    ret = 'success'
-                elif err:
-                    ret = err.decode(urwid.util.detected_encoding)
+                    if proc.returncode == 0:
+                        ret = 'success'
+                    elif err:
+                        ret = err.decode(urwid.util.detected_encoding)
 
         if ret == 'success':
             if self.on_success is not None:

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -249,9 +249,8 @@ class ExternalCommand(Command):
         if self.stdin is not None:
             # wrap strings in StrinIO so that they behaves like a file
             if isinstance(self.stdin, str):
-                # XXX: is utf-8 always safe to use here, or do we need to check
-                # the terminal encoding first?
-                stdin = BytesIO(self.stdin.encode('utf-8'))
+                stdin = BytesIO(
+                    self.stdin.encode(urwid.util.detected_encoding))
             else:
                 stdin = self.stdin
 
@@ -279,7 +278,8 @@ class ExternalCommand(Command):
             except OSError as e:
                 ret = str(e)
             else:
-                _, err = await proc.communicate(stdin.read() if stdin else None)
+                out, err = await proc.communicate(
+                    stdin.read() if stdin else None)
                 if proc.returncode == 0:
                     ret = 'success'
                 elif err:
@@ -294,7 +294,8 @@ class ExternalCommand(Command):
                 except OSError as e:
                     ret = str(e)
                 else:
-                    _, err = proc.communicate(stdin.read() if stdin else None)
+                    out, err = proc.communicate(
+                        stdin.read() if stdin else None)
                 if proc.returncode == 0:
                     ret = 'success'
                 elif err:
@@ -302,7 +303,7 @@ class ExternalCommand(Command):
 
         if ret == 'success':
             if self.on_success is not None:
-                self.on_success()
+                self.on_success(out)
         else:
             msg = "editor has exited with error code {} -- {}".format(
                     proc.returncode,

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -12,6 +12,7 @@ import email.policy
 from email.utils import getaddresses, parseaddr
 from email.message import Message
 
+import urwid
 from io import BytesIO
 
 from . import Command, registerCommand
@@ -634,6 +635,8 @@ class ChangeDisplaymodeCommand(Command):
                     'choices': [
                         'raw', 'decoded', 'id', 'filepath', 'mimepart',
                         'plain', 'html']}),
+    (['--as_file'], {'action': 'store_true',
+                     'help': 'pass mail as a file to the given application'}),
     (['--separately'], {'action': 'store_true',
                         'help': 'call command once for each message'}),
     (['--background'], {'action': 'store_true',
@@ -651,7 +654,7 @@ class PipeCommand(Command):
     repeatable = True
 
     def __init__(self, cmd, all=False, separately=False, background=False,
-                 shell=False, notify_stdout=False, format='raw',
+                 shell=False, notify_stdout=False, format='raw', as_file=False,
                  add_tags=False, noop_msg='no command specified',
                  confirm_msg='', done_msg=None, **kwargs):
         """
@@ -674,6 +677,8 @@ class PipeCommand(Command):
             'filepath': paths to message files on disk
             'mimepart': only pipe the currently selected mime part
         :type format: str
+        :param as_file: pass mail as a file to the given application
+        :type as_file: bool
         :param add_tags: add 'Tags' header to the message
         :type add_tags: bool
         :param noop_msg: error notification to show if `cmd` is empty
@@ -694,6 +699,7 @@ class PipeCommand(Command):
         self.shell = shell
         self.notify_stdout = notify_stdout
         self.output_format = format
+        self.as_file = as_file
         self.add_tags = add_tags
         self.noop_msg = noop_msg
         self.confirm_msg = confirm_msg
@@ -758,14 +764,29 @@ class PipeCommand(Command):
             self.cmd = [' '.join(self.cmd)]
 
         # do the monkey
-        def callback(out):
-            if self.notify_stdout:
-                ui.notify(out)
-            if self.done_msg:
-                ui.notify(self.done_msg)
-
         for mail in pipestrings:
-            await ui.apply_command(ExternalCommand(self.cmd,
+            cmd = self.cmd
+
+            # Pass mail as temporary file rather than piping through stdin.
+            if self.as_file:
+                with tempfile.NamedTemporaryFile(delete=False) as tmpfile:
+                    tmpfile.write(mail.encode(urwid.util.detected_encoding))
+                    tempfile_name = tmpfile.name
+                mail = None
+                if self.shell:
+                    cmd = [' '.join([cmd[0], tempfile_name])]
+                else:
+                    cmd.append(tempfile_name)
+
+            def callback(out):
+                if self.as_file:
+                    os.unlink(tempfile_name)
+                if self.notify_stdout:
+                    ui.notify(out)
+                if self.done_msg:
+                    ui.notify(self.done_msg)
+
+            await ui.apply_command(ExternalCommand(cmd,
                                                    stdin=mail,
                                                    shell=True,
                                                    thread=self.background,

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -514,6 +514,11 @@ class EditNewCommand(Command):
     forced={'mimetree': 'toggle'},
     arguments=[(['query'], {'help': 'query used to filter messages to affect',
                             'nargs': '*'})])
+@registerCommand(
+    MODE, 'togglemimepart', help='switch between html and plain text message',
+    forced={'mimepart': 'toggle'},
+    arguments=[(['query'], {'help': 'query used to filter messages to affect',
+                            'nargs': '*'})])
 class ChangeDisplaymodeCommand(Command):
 
     """fold or unfold messages"""
@@ -590,7 +595,14 @@ class ChangeDisplaymodeCommand(Command):
             all_headers = not mt.display_all_headers \
                 if self.all_headers == 'toggle' else self.all_headers
             if self.mimepart:
-                mt.set_mimepart(ui.get_deep_focus().mimepart)
+                if self.mimepart == 'toggle':
+                    message = mt.get_message()
+                    mimetype = {'plain': 'html', 'html': 'plain'}[
+                        message.mime_part.get_content_subtype()]
+                    mimepart = get_body_part(message.get_email(), mimetype)
+                elif self.mimepart is True:
+                    mimepart = ui.get_deep_focus().mimepart
+                mt.set_mimepart(mimepart)
             if self.mimetree == 'toggle':
                 tbuffer.focus_selected_message()
             mimetree = not mt.display_mimetree \

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -506,24 +506,31 @@ class EditNewCommand(Command):
     MODE, 'indent', help='change message/reply indentation',
     arguments=[(['indent'], {'action': cargparse.ValidatedStoreAction,
                              'validator': cargparse.is_int_or_pm})])
+@registerCommand(
+    MODE, 'togglemimetree', help='disply mime tree of the message',
+    forced={'mimetree': 'toggle'},
+    arguments=[(['query'], {'help': 'query used to filter messages to affect',
+                            'nargs': '*'})])
 class ChangeDisplaymodeCommand(Command):
 
     """fold or unfold messages"""
     repeatable = True
 
     def __init__(self, query=None, visible=None, raw=None, all_headers=None,
-                 indent=None, **kwargs):
+                 indent=None, mimetree=None, **kwargs):
         """
         :param query: notmuch query string used to filter messages to affect
         :type query: str
         :param visible: unfold if `True`, fold if `False`, ignore if `None`
         :type visible: True, False, 'toggle' or None
-        :param raw: display raw message text.
+        :param raw: display raw message text
         :type raw: True, False, 'toggle' or None
         :param all_headers: show all headers (only visible if not in raw mode)
         :type all_headers: True, False, 'toggle' or None
         :param indent: message/reply indentation
         :type indent: '+', '-', or int
+        :param mimetree: show the mime tree of the message
+        :type mimetree: True, False, 'toggle' or None
         """
         self.query = None
         if query:

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -31,6 +31,7 @@ from ..db.utils import formataddr
 from ..db.utils import extract_headers
 from ..db.utils import clear_my_address
 from ..db.utils import ensure_unique_address
+from ..db.utils import extract_body_part
 from ..db.utils import remove_cte
 from ..db.utils import string_sanitize
 from ..db.envelope import Envelope
@@ -722,18 +723,20 @@ class PipeCommand(Command):
         else:
             for msg in to_print:
                 mail = msg.get_email()
+                mimepart = getattr(
+                    ui.get_deep_focus(), 'mimepart', False) or msg.mime_part
                 if self.add_tags:
                     mail.add_header('Tags', ', '.join(msg.get_tags()))
                 if self.output_format == 'raw':
                     pipestrings.append(mail.as_string())
                 elif self.output_format == 'decoded':
                     headertext = extract_headers(mail)
-                    bodytext = msg.get_body_text()
+                    bodytext = extract_body_part(mimepart)
                     msgtext = '%s\n\n%s' % (headertext, bodytext)
                     pipestrings.append(msgtext)
                 elif self.output_format == 'mimepart':
                     pipestrings.append(string_sanitize(remove_cte(
-                        msg.mime_part, as_string=True)))
+                        mimepart, as_string=True)))
 
         if not self.separately:
             pipestrings = [separator.join(pipestrings)]

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -31,6 +31,8 @@ from ..db.utils import formataddr
 from ..db.utils import extract_headers
 from ..db.utils import clear_my_address
 from ..db.utils import ensure_unique_address
+from ..db.utils import remove_cte
+from ..db.utils import string_sanitize
 from ..db.envelope import Envelope
 from ..db.attachment import Attachment
 from ..db.errors import DatabaseROError
@@ -617,7 +619,8 @@ class ChangeDisplaymodeCommand(Command):
     (['cmd'], {'help': 'shellcommand to pipe to', 'nargs': '+'}),
     (['--all'], {'action': 'store_true', 'help': 'pass all messages'}),
     (['--format'], {'help': 'output format', 'default': 'raw',
-                    'choices': ['raw', 'decoded', 'id', 'filepath']}),
+                    'choices': [
+                        'raw', 'decoded', 'id', 'filepath', 'mimepart']}),
     (['--separately'], {'action': 'store_true',
                         'help': 'call command once for each message'}),
     (['--background'], {'action': 'store_true',
@@ -656,6 +659,7 @@ class PipeCommand(Command):
             'decoded': message content, decoded quoted printable,
             'id': message ids, separated by newlines,
             'filepath': paths to message files on disk
+            'mimepart': only pipe the currently selected mime part
         :type format: str
         :param add_tags: add 'Tags' header to the message
         :type add_tags: bool
@@ -727,6 +731,9 @@ class PipeCommand(Command):
                     bodytext = msg.get_body_text()
                     msgtext = '%s\n\n%s' % (headertext, bodytext)
                     pipestrings.append(msgtext)
+                elif self.output_format == 'mimepart':
+                    pipestrings.append(string_sanitize(remove_cte(
+                        msg.mime_part, as_string=True)))
 
         if not self.separately:
             pipestrings = [separator.join(pipestrings)]

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -6,14 +6,12 @@ import argparse
 import logging
 import mailcap
 import os
-import subprocess
 import tempfile
 import email
 import email.policy
 from email.utils import getaddresses, parseaddr
 from email.message import Message
 
-import urwid
 from io import BytesIO
 
 from . import Command, registerCommand
@@ -760,34 +758,18 @@ class PipeCommand(Command):
             self.cmd = [' '.join(self.cmd)]
 
         # do the monkey
-        for mail in pipestrings:
-            encoded_mail = mail.encode(urwid.util.detected_encoding)
-            if self.background:
-                logging.debug('call in background: %s', self.cmd)
-                proc = subprocess.Popen(self.cmd,
-                                        shell=True, stdin=subprocess.PIPE,
-                                        stdout=subprocess.PIPE,
-                                        stderr=subprocess.PIPE)
-                out, err = proc.communicate(encoded_mail)
-                if self.notify_stdout:
-                    ui.notify(out)
-            else:
-                with ui.paused():
-                    logging.debug('call: %s', self.cmd)
-                    # if proc.stdout is defined later calls to communicate
-                    # seem to be non-blocking!
-                    proc = subprocess.Popen(self.cmd, shell=True,
-                                            stdin=subprocess.PIPE,
-                                            # stdout=subprocess.PIPE,
-                                            stderr=subprocess.PIPE)
-                    out, err = proc.communicate(encoded_mail)
-            if err:
-                ui.notify(err, priority='error')
-                return
+        def callback(out):
+            if self.notify_stdout:
+                ui.notify(out)
+            if self.done_msg:
+                ui.notify(self.done_msg)
 
-        # display 'done' message
-        if self.done_msg:
-            ui.notify(self.done_msg)
+        for mail in pipestrings:
+            await ui.apply_command(ExternalCommand(self.cmd,
+                                                   stdin=mail,
+                                                   shell=True,
+                                                   thread=self.background,
+                                                   on_success=callback))
 
 
 @registerCommand(MODE, 'remove', arguments=[
@@ -991,7 +973,7 @@ class OpenAttachmentCommand(Command):
                     tempfile_name = tmpfile.name
                     self.attachment.write(tmpfile)
 
-                def afterwards():
+                def afterwards(*args):
                     os.unlink(tempfile_name)
             else:
                 handler_stdin = BytesIO()

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -769,7 +769,9 @@ class PipeCommand(Command):
 
             # Pass mail as temporary file rather than piping through stdin.
             if self.as_file:
-                with tempfile.NamedTemporaryFile(delete=False) as tmpfile:
+                suffix = {'html': '.html'}.get(mimepart.get_content_subtype())
+                with tempfile.NamedTemporaryFile(
+                        delete=False, suffix=suffix) as tmpfile:
                     tmpfile.write(mail.encode(urwid.util.detected_encoding))
                     tempfile_name = tmpfile.name
                 mail = None

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -32,6 +32,7 @@ from ..db.utils import extract_headers
 from ..db.utils import clear_my_address
 from ..db.utils import ensure_unique_address
 from ..db.utils import extract_body_part
+from ..db.utils import get_body_part
 from ..db.utils import remove_cte
 from ..db.utils import string_sanitize
 from ..db.envelope import Envelope
@@ -621,7 +622,8 @@ class ChangeDisplaymodeCommand(Command):
     (['--all'], {'action': 'store_true', 'help': 'pass all messages'}),
     (['--format'], {'help': 'output format', 'default': 'raw',
                     'choices': [
-                        'raw', 'decoded', 'id', 'filepath', 'mimepart']}),
+                        'raw', 'decoded', 'id', 'filepath', 'mimepart',
+                        'plain', 'html']}),
     (['--separately'], {'action': 'store_true',
                         'help': 'call command once for each message'}),
     (['--background'], {'action': 'store_true',
@@ -734,7 +736,9 @@ class PipeCommand(Command):
                     bodytext = extract_body_part(mimepart)
                     msgtext = '%s\n\n%s' % (headertext, bodytext)
                     pipestrings.append(msgtext)
-                elif self.output_format == 'mimepart':
+                elif self.output_format in ['mimepart', 'plain', 'html']:
+                    if self.output_format in ['plain', 'html']:
+                        mimepart = get_body_part(mail, self.output_format)
                     pipestrings.append(string_sanitize(remove_cte(
                         mimepart, as_string=True)))
 

--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -539,6 +539,7 @@ class ChangeDisplaymodeCommand(Command):
         self.raw = raw
         self.all_headers = all_headers
         self.indent = indent
+        self.mimetree = mimetree
         Command.__init__(self, **kwargs)
 
     def apply(self, ui):
@@ -584,6 +585,11 @@ class ChangeDisplaymodeCommand(Command):
             raw = not mt.display_source if self.raw == 'toggle' else self.raw
             all_headers = not mt.display_all_headers \
                 if self.all_headers == 'toggle' else self.all_headers
+            if self.mimetree == 'toggle':
+                tbuffer.focus_selected_message()
+            mimetree = not mt.display_mimetree \
+                if self.mimetree == 'toggle' else self.mimetree
+
 
             # collapse/expand depending on new 'visible' value
             if visible is False:
@@ -596,6 +602,8 @@ class ChangeDisplaymodeCommand(Command):
                 mt.display_source = raw
             if all_headers is not None:
                 mt.display_all_headers = all_headers
+            if mimetree is not None:
+                mt.display_mimetree = mimetree
             mt.debug()
             # let the messagetree reassemble itself
             mt.reassemble()

--- a/alot/completion/command.py
+++ b/alot/completion/command.py
@@ -193,7 +193,8 @@ class CommandCompleter(Completer):
                     res = self._pathcompleter.complete(params, localpos)
                 elif self.mode == 'thread' and cmd in ['fold', 'unfold',
                                                        'togglesource',
-                                                       'toggleheaders']:
+                                                       'toggleheaders',
+                                                       'togglemimetree']:
                     res = self._querycompleter.complete(params, localpos)
                 elif self.mode == 'thread' and cmd in ['tag', 'retag', 'untag',
                                                        'toggletags']:

--- a/alot/completion/command.py
+++ b/alot/completion/command.py
@@ -194,7 +194,8 @@ class CommandCompleter(Completer):
                 elif self.mode == 'thread' and cmd in ['fold', 'unfold',
                                                        'togglesource',
                                                        'toggleheaders',
-                                                       'togglemimetree']:
+                                                       'togglemimetree',
+                                                       'togglemimepart']:
                     res = self._querycompleter.complete(params, localpos)
                 elif self.mode == 'thread' and cmd in ['tag', 'retag', 'untag',
                                                        'toggletags']:

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -286,5 +286,8 @@ class Message:
 
     @staticmethod
     def _get_mime_part_info(mime_part):
-        return '{}: {}'.format(mime_part.get_content_type(), 
-                               mime_part.get_filename() or '(no filename)')
+        contenttype = mime_part.get_content_type()
+        filename = mime_part.get_filename() or '(no filename)'
+        charset = mime_part.get_content_charset() or ''
+        size = helper.humanize_size(len(mime_part.as_string()))
+        return ' '.join((contenttype, filename, charset, size))

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from notmuch import NullPointerError
 
 from . import utils
-from .utils import extract_body
+from .utils import get_body_part, extract_body_part
 from .utils import decode_header
 from .attachment import Attachment
 from .. import helper
@@ -67,6 +67,8 @@ class Message:
             self._from = '"{}" <{}>'.format(acc.realname, str(acc.address))
         else:
             self._from = '"Unknown" <>'
+
+        self.mime_part = get_body_part(self.get_email())
 
     def __str__(self):
         """prettyprint the message"""
@@ -263,8 +265,7 @@ class Message:
 
     def get_body_text(self):
         """ returns bodystring extracted from this mail """
-        # TODO: allow toggle commands to decide which part is considered body
-        return extract_body(self.get_email())
+        return extract_body_part(self.mime_part)
 
     def matches(self, querystring):
         """tests if this messages is in the resultset for `querystring`"""
@@ -282,7 +283,7 @@ class Message:
         if message.is_multipart():
             return label, [cls._get_mimetree(m) for m in message.get_payload()]
         else:
-            return label, None
+            return label, message
 
     @staticmethod
     def _get_mime_part_info(mime_part):

--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -463,8 +463,8 @@ MISSING_HTML_MSG = ("This message contains a text/html part that was not "
                     "http://alot.rtfd.io/en/latest/faq.html")
 
 
-def extract_body(mail):
-    """Returns a string view of a Message.
+def get_body_part(mail):
+    """Returns an EmailMessage.
 
     This consults :ref:`prefer_plaintext <prefer-plaintext>`
     to determine if a "text/plain" alternative is preferred over a "text/html"
@@ -485,6 +485,11 @@ def extract_body(mail):
     if body_part is None:  # if no part matching preferredlist was found
         return ""
 
+    return body_part
+
+
+def extract_body_part(body_part):
+    """Returns a string view of a Message."""
     displaystring = ""
 
     if body_part.get_content_type() == 'text/plain':

--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -463,7 +463,7 @@ MISSING_HTML_MSG = ("This message contains a text/html part that was not "
                     "http://alot.rtfd.io/en/latest/faq.html")
 
 
-def get_body_part(mail):
+def get_body_part(mail, mimetype=None):
     """Returns an EmailMessage.
 
     This consults :ref:`prefer_plaintext <prefer-plaintext>`
@@ -476,10 +476,10 @@ def get_body_part(mail):
     :rtype: str
     """
 
-    if settings.get('prefer_plaintext'):
-        preferencelist = ('plain', 'html')
-    else:
-        preferencelist = ('html', 'plain')
+    if not mimetype:
+        mimetype = 'plain' if settings.get('prefer_plaintext') else 'html'
+    preferencelist = {
+        'plain': ('plain', 'html'), 'html': ('html', 'plain')}[mimetype]
 
     body_part = mail.get_body(preferencelist)
     if body_part is None:  # if no part matching preferredlist was found

--- a/alot/widgets/ansi.py
+++ b/alot/widgets/ansi.py
@@ -12,7 +12,10 @@ class ANSIText(urwid.WidgetWrap):
     def __init__(self, txt,
                  default_attr=None,
                  default_attr_focus=None,
-                 ansi_background=True, **kwds):
+                 ansi_background=True,
+                 mimepart=False,
+                 **kwds):
+        self.mimepart = mimepart
         ct, focus_map = parse_escapes_to_urwid(txt, default_attr,
                                                default_attr_focus,
                                                ansi_background)

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -324,9 +324,20 @@ class MessageTree(CollapsibleTree):
 
     def _get_mimetree(self):
         if self._mimetree is None:
-            mime_tree = self._message.get_mime_tree()
-            self._mimetree = SimpleTree([mime_tree])
+            mime_tree_txt = self._message.get_mime_tree()
+            mime_tree_widgets = self._text_tree_to_widget_tree(mime_tree_txt)
+            self._mimetree = SimpleTree([mime_tree_widgets])
         return self._mimetree
+
+    def _text_tree_to_widget_tree(self, tree):
+        att = settings.get_theming_attribute('thread', 'body')
+        att_focus = settings.get_theming_attribute('thread', 'body_focus')
+        label, subtrees = tree
+        label = FocusableText(label, att, att_focus)
+        if subtrees is None:
+            return label, None
+        else:
+            return label, [self._text_tree_to_widget_tree(s) for s in subtrees]
 
 
 class ThreadTree(Tree):

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -16,6 +16,8 @@ from ..settings.const import settings
 from ..db.utils import decode_header, X_SIGNATURE_MESSAGE_HEADER
 from ..helper import string_sanitize
 
+ANSI_BACKGROUND = settings.get("interpret_ansi_background")
+
 
 class MessageSummaryWidget(urwid.WidgetWrap):
     """
@@ -80,17 +82,16 @@ class TextlinesList(SimpleTree):
         for each line in content.
         """
         structure = []
-        ansi_background = settings.get("interpret_ansi_background")
 
         # depending on this config setting, we either add individual lines
         # or the complete context as focusable objects.
         if settings.get('thread_focus_linewise'):
             for line in content.splitlines():
                 structure.append((ANSIText(line, attr, attr_focus,
-                                           ansi_background), None))
+                                           ANSI_BACKGROUND), None))
         else:
             structure.append((ANSIText(content, attr, attr_focus,
-                                       ansi_background), None))
+                                       ANSI_BACKGROUND), None))
         SimpleTree.__init__(self, structure)
 
 
@@ -334,7 +335,7 @@ class MessageTree(CollapsibleTree):
         att = settings.get_theming_attribute('thread', 'body')
         att_focus = settings.get_theming_attribute('thread', 'body_focus')
         label, subtrees = tree
-        label = FocusableText(label, att, att_focus)
+        label = ANSIText(label, att, att_focus, ANSI_BACKGROUND)
         if subtrees is None:
             return label, None
         else:

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -7,7 +7,7 @@ Widgets specific to thread mode
 import logging
 import urwid
 
-from urwidtrees import Tree, SimpleTree, CollapsibleTree
+from urwidtrees import Tree, SimpleTree, CollapsibleTree, ArrowTree
 
 from .ansi import ANSIText
 from .globals import TagWidget
@@ -324,9 +324,10 @@ class MessageTree(CollapsibleTree):
 
     def _get_mimetree(self):
         if self._mimetree is None:
-            mime_tree_txt = self._message.get_mime_tree()
-            mime_tree_widgets = self._text_tree_to_widget_tree(mime_tree_txt)
-            self._mimetree = SimpleTree([mime_tree_widgets])
+            tree = self._message.get_mime_tree()
+            tree = self._text_tree_to_widget_tree(tree)
+            tree = SimpleTree([tree])
+            self._mimetree = ArrowTree(tree)
         return self._mimetree
 
     def _text_tree_to_widget_tree(self, tree):

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -160,8 +160,10 @@ class MessageTree(CollapsibleTree):
         self._all_headers_tree = None
         self._default_headers_tree = None
         self.display_attachments = True
+        self._mimetree = None
         self._attachments = None
         self._maintree = SimpleTree(self._assemble_structure(True))
+        self.display_mimetree = False
         CollapsibleTree.__init__(self, self._maintree)
 
     def get_message(self):
@@ -179,6 +181,7 @@ class MessageTree(CollapsibleTree):
         logging.debug('display_source %s', self.display_source)
         logging.debug('display_all_headers %s', self.display_all_headers)
         logging.debug('display_attachements %s', self.display_attachments)
+        logging.debug('display_mimetree %s', self.display_mimetree)
         logging.debug('AHT %s', str(self._all_headers_tree))
         logging.debug('DHT %s', str(self._default_headers_tree))
         logging.debug('MAINTREE %s', str(self._maintree._treelist))
@@ -203,6 +206,9 @@ class MessageTree(CollapsibleTree):
         mainstruct = []
         if self.display_source:
             mainstruct.append((self._get_source(), None))
+        elif self.display_mimetree:
+            mainstruct.append((self._get_headers(), None))
+            mainstruct.append((self._get_mimetree(), None))
         else:
             mainstruct.append((self._get_headers(), None))
 
@@ -315,6 +321,12 @@ class MessageTree(CollapsibleTree):
         value_att = settings.get_theming_attribute('thread', 'header_value')
         gaps_att = settings.get_theming_attribute('thread', 'header')
         return DictList(lines, key_att, value_att, gaps_att)
+
+    def _get_mimetree(self):
+        if self._mimetree is None:
+            mime_tree = self._message.get_mime_tree()
+            self._mimetree = SimpleTree([mime_tree])
+        return self._mimetree
 
 
 class ThreadTree(Tree):

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -4,6 +4,7 @@
 """
 Widgets specific to thread mode
 """
+import email
 import logging
 import urwid
 
@@ -334,12 +335,20 @@ class MessageTree(CollapsibleTree):
     def _text_tree_to_widget_tree(self, tree):
         att = settings.get_theming_attribute('thread', 'body')
         att_focus = settings.get_theming_attribute('thread', 'body_focus')
+        mimepart = tree[1] if isinstance(
+            tree[1], email.message.EmailMessage) else None
         label, subtrees = tree
-        label = ANSIText(label, att, att_focus, ANSI_BACKGROUND)
-        if subtrees is None:
+        label = ANSIText(
+            label, att, att_focus, ANSI_BACKGROUND, mimepart=mimepart)
+        if subtrees is None or mimepart:
             return label, None
         else:
             return label, [self._text_tree_to_widget_tree(s) for s in subtrees]
+
+    def set_mimepart(self, mimepart):
+        """ Set message widget mime part and invalidate body tree."""
+        self.get_message().mime_part = mimepart
+        self._bodytree = None
 
 
 class ThreadTree(Tree):

--- a/docs/source/usage/modes/thread.rst
+++ b/docs/source/usage/modes/thread.rst
@@ -72,7 +72,7 @@ The following commands are available in thread mode:
 
     optional arguments
         :---all: pass all messages
-        :---format: output format; valid choices are: 'raw','decoded','id','filepath' (defaults to: 'raw')
+        :---format: output format; valid choices are: 'raw','decoded','id','filepath','mimepart','plain','html' (defaults to: 'raw')
         :---separately: call command once for each message
         :---background: don't stop the interface
         :---add_tags: add 'Tags' header to the message
@@ -150,6 +150,7 @@ The following commands are available in thread mode:
     select focussed element:
         - if it is a message summary, toggle visibility of the message;
         - if it is an attachment line, open the attachment
+        - if it is a mimepart, toggle visibility of the mimepart
 
 
 .. _cmd.thread.tag:
@@ -170,6 +171,26 @@ The following commands are available in thread mode:
 .. describe:: toggleheaders
 
     display all headers
+
+    argument
+        query used to filter messages to affect
+
+
+.. _cmd.thread.togglemimepart:
+
+.. describe:: togglemimepart
+
+    switch between html and plain text message
+
+    argument
+        query used to filter messages to affect
+
+
+.. _cmd.thread.togglemimetree:
+
+.. describe:: togglemimetree
+
+    disply mime tree of the message
 
     argument
         query used to filter messages to affect

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -665,6 +665,22 @@ class TestGetBodyPart(unittest.TestCase):
 
         self.assertEqual(actual, expected)
 
+    @mock.patch('alot.db.utils.settings.get', mock.Mock(return_value=False))
+    def test_prefer_html_set_mimetype_plain(self):
+        expected = "text/plain"
+        mail = self._make_mixed_plain_html()
+        actual = utils.get_body_part(mail, 'plain').get_content_type()
+
+        self.assertEqual(actual, expected)
+
+    @mock.patch('alot.db.utils.settings.get', mock.Mock(return_value=True))
+    def test_prefer_plaintext_set_mimetype_html(self):
+        expected = 'text/html'
+        mail = self._make_mixed_plain_html()
+        actual = utils.get_body_part(mail, 'html').get_content_type()
+
+        self.assertEqual(actual, expected)
+
 
 class TestExtractBodyPart(unittest.TestCase):
 


### PR DESCRIPTION
This branch is based on #1475 so I wouldn't recommend a thorough review yet.

Rather than literally piping mail into a command, this option writes to a temporary file which is passed to the command. For some applications this is the only feasible option.

Only the tiny final commit adding browser support actually depends on mime support but I don't think the overhead of this feature can be justified without the use case of piping to a browser.