### PR TITLE
Allow optional text/plain mailcap entry.

### DIFF
--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -486,16 +486,17 @@ def extract_body(mail):
         return ""
 
     displaystring = ""
-
-    if body_part.get_content_type() == 'text/plain':
+    rendered_payload = render_part(
+        body_part,
+        **{'field_key': 'view'} if body_part.get_content_type() == 'text/plain'
+        else {})
+    if rendered_payload:  # handler had output
+        displaystring = string_sanitize(rendered_payload)
+    elif body_part.get_content_type() == 'text/plain':
         displaystring = string_sanitize(remove_cte(body_part, as_string=True))
     else:
-        rendered_payload = render_part(body_part)
-        if rendered_payload:  # handler had output
-            displaystring = string_sanitize(rendered_payload)
-        else:
-            if body_part.get_content_type() == 'text/html':
-                displaystring = MISSING_HTML_MSG
+        if body_part.get_content_type() == 'text/html':
+            displaystring = MISSING_HTML_MSG
     return displaystring
 
 

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -699,6 +699,8 @@ class TestExtractBody(unittest.TestCase):
 
         self.assertEqual(actual, expected)
 
+    @mock.patch('alot.db.utils.settings.mailcap_find_match',
+                mock.Mock(return_value=(None, None)))
     def test_simple_utf8_file(self):
         mail = email.message_from_binary_file(
                 open('tests/static/mail/utf8.eml', 'rb'),
@@ -707,6 +709,18 @@ class TestExtractBody(unittest.TestCase):
         expected = "Liebe Grüße!\n"
 
         self.assertEqual(actual, expected)
+
+    @mock.patch('alot.db.utils.settings.get', mock.Mock(return_value=True))
+    @mock.patch('alot.db.utils.settings.mailcap_find_match',
+                mock.Mock(return_value=(
+                    None, {'view': 'sed "s/ is/ was/"'})))
+    def test_plaintext_mailcap(self):
+        expected = 'This was an email\n'
+        mail = self._make_mixed_plain_html()
+        actual = utils.extract_body(mail)
+
+        self.assertEqual(actual, expected)
+
 
 class TestMessageFromString(unittest.TestCase):
 


### PR DESCRIPTION
My use case is limiting width:

    text/plain; fmt -w 80 -s %s