### PR TITLE
reply: use `email.utils.formataddr` as in compose command

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -88,7 +88,7 @@ def determine_sender(mail, action='reply'):
                     logging.debug('using realname: "%s"', realname)
                     logging.debug('using address: %s', address)
 
-                    from_value = formataddr((realname, address))
+                    from_value = email.utils.formataddr((realname, address))
                     return from_value, account
 
     # revert to default account if nothing found
@@ -98,7 +98,7 @@ def determine_sender(mail, action='reply'):
     logging.debug('using realname: "%s"', realname)
     logging.debug('using address: %s', address)
 
-    from_value = formataddr((realname, str(address)))
+    from_value = email.utils.formataddr((realname, str(address)))
     return from_value, account
 
 

--- a/tests/commands/test_thread.py
+++ b/tests/commands/test_thread.py
@@ -151,3 +151,8 @@ class TestDetermineSender(unittest.TestCase):
         expected = ('to+some_tag@example.com', account2)
         self._test(accounts=[account1, account2, account3], expected=expected,
                    mail=mail)
+
+    def test_determine_sender_correctly_encode_non_ascii(self):
+        account = _AccountTestClass(address='foo@example.com', realname='Foo Hé')
+        self._test(accounts=[account], header_priority=(),
+                   expected=('=?utf-8?q?Foo_H=C3=A9?= <foo@example.com>', account))


### PR DESCRIPTION
to format address used in `From` header we should use `formataddr` from
stdlib, this will handle encoding properly (we shouldn't leak non-ascii
characters in headers).
Actually this is same behaviour in `compose` command

(closes #1482)