### PR TITLE
envelope: set policy when constructing email

### DIFF
--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -14,6 +14,7 @@ import re
 import tempfile
 import textwrap
 import traceback
+import sys
 
 from . import Command, registerCommand
 from . import globals
@@ -135,7 +136,7 @@ class SaveCommand(Command):
         mail = envelope.construct_mail()
         # store mail locally
         path = account.store_draft_mail(
-            mail.as_string(policy=email.policy.SMTP))
+            mail.as_string(policy=email.policy.SMTP, maxheaderlen=sys.maxsize))
 
         msg = 'draft saved successfully'
 
@@ -243,7 +244,8 @@ class SendCommand(Command):
 
             try:
                 self.mail = self.envelope.construct_mail()
-                self.mail = self.mail.as_string(policy=email.policy.SMTP)
+                self.mail = self.mail.as_string(policy=email.policy.SMTP,
+                                                maxheaderlen=sys.maxsize)
             except GPGProblem as e:
                 ui.clear_notify([clearme])
                 ui.notify(str(e), priority='error')

--- a/alot/db/envelope.py
+++ b/alot/db/envelope.py
@@ -298,6 +298,8 @@ class Envelope:
         if uastring:
             headers['User-Agent'] = [uastring]
 
+        # set policy on outer_msg to ease encoding headers
+        outer_msg.policy = email.policy.default
         # copy headers from envelope to mail
         for k, vlist in headers.items():
             for v in vlist:

--- a/tests/db/test_envelope.py
+++ b/tests/db/test_envelope.py
@@ -112,3 +112,19 @@ class TestEnvelope(unittest.TestCase):
         })
         self.assertEqual(envlp.body_txt,
                          'Some body content: which is not a header.')
+
+    @mock.patch('alot.db.envelope.settings', SETTINGS)
+    def test_construct_encoding(self):
+        headers = {
+            'From': 'foo@example.com',
+            'To': 'bar@example.com',
+            'Subject': 'Test email héhé',
+        }
+        e = envelope.Envelope(account=test_account,
+                              headers={k: [v] for k, v in headers.items()},
+                              bodytext='Test')
+        mail = e.construct_mail()
+        raw = mail.as_string(policy=email.policy.SMTP)
+        actual = email.parser.Parser().parsestr(raw)
+        self.assertEqual('Test email =?utf-8?b?aMOpaMOp?=', actual['Subject'])
+

--- a/tests/db/test_envelope.py
+++ b/tests/db/test_envelope.py
@@ -20,6 +20,7 @@ import os
 import tempfile
 import unittest
 from unittest import mock
+import sys
 
 from alot.db import envelope
 from alot.account import Account
@@ -124,7 +125,6 @@ class TestEnvelope(unittest.TestCase):
                               headers={k: [v] for k, v in headers.items()},
                               bodytext='Test')
         mail = e.construct_mail()
-        raw = mail.as_string(policy=email.policy.SMTP)
+        raw = mail.as_string(policy=email.policy.SMTP, maxheaderlen=sys.maxsize)
         actual = email.parser.Parser().parsestr(raw)
         self.assertEqual('Test email =?utf-8?b?aMOpaMOp?=', actual['Subject'])
-


### PR DESCRIPTION
`default` policy ensure headers are correctly encoded (i.e. will not
leak non-ascii char in headers)

(related to #1482)