### PR TITLE
Fix 'SyntaxWarning: "is" with a literal.' from Python 3.8

### DIFF
--- a/alot/commands/envelope.py
+++ b/alot/commands/envelope.py
@@ -759,13 +759,13 @@ class BodyConvertCommand(Command):
         ebuffer = ui.current_buffer
         envelope = ebuffer.envelope
 
-        if self.action is "txt2html":
+        if self.action == "txt2html":
             fallbackcmd = settings.get('envelope_txt2html')
             cmd = self.cmd or split_commandstring(fallbackcmd)
             if cmd:
                 envelope.body_html = self.convert(cmd, envelope.body_txt)
 
-        elif self.action is "html2txt":
+        elif self.action == "html2txt":
             fallbackcmd = settings.get('envelope_html2txt')
             cmd = self.cmd or split_commandstring(fallbackcmd)
             if cmd:

--- a/alot/widgets/ansi.py
+++ b/alot/widgets/ansi.py
@@ -81,7 +81,7 @@ def parse_escapes_to_urwid(text, default_attr=None, default_attr_focus=None,
             i = 0
             while i < len(esc_code):
                 code = esc_code[i]
-                if code is 0:
+                if code == 0:
                     attr.update({'bold': default_attr.bold,
                                  'underline': default_attr.underline,
                                  'standout': default_attr.standout})


### PR DESCRIPTION
```
alot/alot/widgets/ansi.py:84: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if code is 0:
alot/alot/commands/envelope.py:762: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if self.action is "txt2html":
alot/alot/commands/envelope.py:768: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif self.action is "html2txt":
```

Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=955193
Signed-off-by: Jordan Justen <jordan.l.justen@intel.com>