### PR TITLE
Don't lose the focus when refreshing a thread

### DIFF
--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -189,6 +189,10 @@ initial_command = string(default='search tag:inbox AND NOT tag:killed')
 # default sort order of results in a search
 search_threads_sort_order = option('oldest_first', 'newest_first', 'message_id', 'unsorted', default='newest_first')
 
+# maximum amount of threads that will be consumed to try to restore the focus, upon triggering a search buffer rebuild
+# when set to 0, no limit is set (can be very slow in searches that yield thousands of results)
+search_threads_rebuild_limit = integer(default=0)
+
 # in case more than one account has an address book:
 # Set this to True to make tab completion for recipients during compose only
 # look in the abook of the account matching the sender address

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -588,6 +588,17 @@
     :default: [{buffer_no}: search] for "{querystring}", {input_queue} {result_count} of {total_messages} messages
 
 
+.. _search-threads-rebuild-limit:
+
+.. describe:: search_threads_rebuild_limit
+
+     maximum amount of threads that will be consumed to try to restore the focus, upon triggering a search buffer rebuild
+     when set to 0, no limit is set (can be very slow in searches that yield thousands of results)
+
+    :type: integer
+    :default: 0
+
+
 .. _search-threads-sort-order:
 
 .. describe:: search_threads_sort_order


### PR DESCRIPTION
This commit allows keeping the currently focused message selected
across thread refreshes.

Since this operation can take a long time in large threads, a
`search_threads_rebuild_limit` option is introduced. When defined,
it sets the maximum amount of messages that will be iterated upon
when trying to find the previously focused message.