### PR TITLE
Fix mailcap rendering for e-mails without `Content-Type` header

### DIFF
--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -365,7 +365,7 @@ def render_part(part, field_key='copiousoutput'):
             stdin = raw_payload
 
         # read parameter, create handler command
-        parms = tuple('='.join(p) for p in part.get_params())
+        parms = tuple('='.join(p) for p in part.get_params(failobj=[]))
 
         # create and call external command
         cmd = mailcap.subst(entry['view'], ctype,

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -762,6 +762,16 @@ class TestExtractBodyPart(unittest.TestCase):
 
         self.assertEqual(actual, expected)
 
+    @mock.patch('alot.db.utils.settings.mailcap_find_match',
+                mock.Mock(return_value=(None, {'view': 'cat'})))
+    def test_plaintext_mailcap_wo_content_type(self):
+        with open('tests/static/mail/basic.eml') as fp:
+            mail = email.message_from_file(fp,
+                    _class=email.message.EmailMessage)
+        body_part = utils.get_body_part(mail)
+        actual = utils.extract_body_part(body_part)
+        expected = 'test body\n'
+        self.assertEqual(actual, expected)
 
 class TestRemoveCte(unittest.TestCase):
 

--- a/tests/static/mail/basic.eml
+++ b/tests/static/mail/basic.eml
@@ -1,0 +1,5 @@
+From: me@localhost
+To: you@localhost
+Subject: test subject
+
+test body


### PR DESCRIPTION
`get_params()` returns `None` when the header is missing. Use `failobj` argument to mitigate that.

Fixes #1512