### PR TITLE
[WIP] Limit thread focus loop by time, not threads.

### DIFF
--- a/alot/buffers/search.py
+++ b/alot/buffers/search.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2011-2018  Patrick Totzke <patricktotzke@gmail.com>
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
+import time
+
 import urwid
 from notmuch import NotmuchError
 
@@ -102,13 +104,13 @@ class SearchBuffer(Buffer):
         while not self.threadlist.empty:
             self.threadlist._get_next_item()
 
-    def consume_pipe_until(self, predicate, limit=0):
-        n = limit
-        while not limit or n > 0:
+    def consume_pipe_until(self, predicate, timeout=1):
+        start = time.monotonic()
+        timeout_time = start + timeout
+        while time.monotonic() < timeout_time:
             if self.threadlist.empty \
                or predicate(self.threadlist._get_next_item()):
                 break
-            n -= 1
 
     def focus_first(self):
         if not self.reversed:
@@ -129,8 +131,7 @@ class SearchBuffer(Buffer):
     def focus_thread(self, thread):
         tid = thread.get_thread_id()
         self.consume_pipe_until(lambda w:
-                                w and w.get_thread().get_thread_id() == tid,
-                                self.search_threads_rebuild_limit)
+                                w and w.get_thread().get_thread_id() == tid)
 
         for pos, threadlinewidget in enumerate(self.threadlist.get_lines()):
             if threadlinewidget.get_thread().get_thread_id() == tid:


### PR DESCRIPTION
Resolve #1518. The problem that search_threads_rebuild_limit tries to
solve is UI responsiveness, so the relevant thing to limit is time, not
loops.

Next steps if this approach is accepted:
- Must: Deprecate search_threads_rebuild_limit -- Has a process been
developed for option deprecation/removal?
- Maybe: Add a configuration option for the timeout. Personally I don't
think this is necessary because unlike the previous approach this is not
relative to the user's processor and inbox size. It's always something
that can be added if a need arises.
- Maybe: Execute consume_pipe_until in a separate thread, sleep for the
timeout, and then kill the thread. This would eliminate the
wasteful clock checking every loop but I'm doubtful it's actually more
performant.