### PR TITLE
db/utils: encode 8bit emails as utf-8

### DIFF
--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -429,11 +429,7 @@ def remove_cte(part, as_string=False):
     # decoding into a str is done at the end if requested
     elif '8bit' in cte:
         logging.debug('assuming Content-Transfer-Encoding: 8bit')
-        # Python's mail library may decode 8bit as raw-unicode-escape, so
-        # we need to encode that back to bytes so we can decode it using
-        # the correct encoding, or it might not, in which case assume that
-        # the str representation we got is correct.
-        bp = payload.encode('raw-unicode-escape')
+        bp = payload.encode('utf-8')
 
     elif 'quoted-printable' in cte:
         logging.debug('assuming Content-Transfer-Encoding: quoted-printable')

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -737,11 +737,11 @@ class TestExtractBodyPart(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     @mock.patch('alot.db.utils.settings.mailcap_find_match',
-                mock.Mock(return_value=(None, None)))
+                mock.Mock(return_value=(None, {'view': 'cat %s'})))
     def test_simple_utf8_file(self):
-        mail = email.message_from_binary_file(
-                open('tests/static/mail/utf8.eml', 'rb'),
-                _class=email.message.EmailMessage)
+        with open('tests/static/mail/utf8.eml', 'rb') as fp:
+            mail = email.message_from_binary_file(
+                fp, _class=email.message.EmailMessage)
         body_part = utils.get_body_part(mail)
         actual = utils.extract_body_part(body_part)
         expected = "Liebe Grüße!\n"


### PR DESCRIPTION
The encoding as 'raw-unicode-escape' was producing unreadable characters
for non-ascii letters.

Closes #1314