### PR TITLE
Fix utf8 encoding with a text/plain mailcap entry.

### DIFF
--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -429,11 +429,7 @@ def remove_cte(part, as_string=False):
     # decoding into a str is done at the end if requested
     elif '8bit' in cte:
         logging.debug('assuming Content-Transfer-Encoding: 8bit')
-        # Python's mail library may decode 8bit as raw-unicode-escape, so
-        # we need to encode that back to bytes so we can decode it using
-        # the correct encoding, or it might not, in which case assume that
-        # the str representation we got is correct.
-        bp = payload.encode('raw-unicode-escape')
+        bp = payload.encode('utf8')
 
     elif 'quoted-printable' in cte:
         logging.debug('assuming Content-Transfer-Encoding: quoted-printable')

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -748,6 +748,24 @@ class TestExtractBodyPart(unittest.TestCase):
 
         self.assertEqual(actual, expected)
 
+    @mock.patch('alot.db.utils.settings.mailcap_find_match',
+                mock.Mock(return_value=(
+                    None, {'view': 'sed "s/!/?/"'})))
+    def test_utf8_plaintext_mailcap(self):
+        """
+        Handle unicode correctly in the presence of a text/plain mailcap entry.
+
+        https://github.com/pazz/alot/issues/1522
+        """
+        mail = email.message_from_binary_file(
+                open('tests/static/mail/utf8.eml', 'rb'),
+                _class=email.message.EmailMessage)
+        body_part = utils.get_body_part(mail)
+        actual = utils.extract_body_part(body_part)
+        expected = "Liebe Grüße?\n"
+
+        self.assertEqual(actual, expected)
+
     @mock.patch('alot.db.utils.settings.get', mock.Mock(return_value=True))
     @mock.patch('alot.db.utils.settings.mailcap_find_match',
                 mock.Mock(return_value=(


### PR DESCRIPTION
This seems to essentially revert 777823f414aab5dfa130174dc7c80cda8036d13f,
the reasoning of which I don't yet follow.

This may resolve the issue in #1522.