### PR TITLE
Add commands for managing queries in namedqueries mode

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -31,6 +31,7 @@ from ..completion.accounts import AccountCompleter
 from ..completion.tags import TagsCompleter
 from ..widgets.utils import DialogBox
 from ..db.errors import DatabaseLockedError
+from ..db.errors import DatabaseROError
 from ..db.envelope import Envelope
 from ..settings.const import settings
 from ..settings.errors import ConfigError, NoMatchingAccount

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -1154,7 +1154,7 @@ class RemoveQueryCommand(Command):
     """remove named query string for given alias"""
     repeatable = False
 
-    def __init__(self, alias, flush=True, **kwargs):
+    def __init__(self, alias, afterwards=None, flush=True, **kwargs):
         """
         :param alias: name to use for query string
         :type alias: str
@@ -1163,13 +1163,14 @@ class RemoveQueryCommand(Command):
         """
         self.alias = alias
         self.flush = flush
+        self.afterwards = afterwards
         Command.__init__(self, **kwargs)
 
     async def apply(self, ui):
         msg = 'removed alias "%s"' % (self.alias)
 
         try:
-            ui.dbman.remove_named_query(self.alias)
+            ui.dbman.remove_named_query(self.alias, afterwards=self.afterwards)
             logging.debug(msg)
             ui.notify(msg)
         except DatabaseROError:

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -1123,7 +1123,7 @@ class SaveQueryCommand(Command):
         self.flush = flush
         Command.__init__(self, **kwargs)
 
-    def apply(self, ui):
+    async def apply(self, ui):
         msg = 'saved alias "%s" for query string "%s"' % (self.alias,
                                                           self.query)
 
@@ -1137,7 +1137,7 @@ class SaveQueryCommand(Command):
 
         # flush index
         if self.flush:
-            ui.apply_command(commands.globals.FlushCommand())
+            return await ui.apply_command(commands.globals.FlushCommand())
 
 
 @registerCommand(
@@ -1165,7 +1165,7 @@ class RemoveQueryCommand(Command):
         self.flush = flush
         Command.__init__(self, **kwargs)
 
-    def apply(self, ui):
+    async def apply(self, ui):
         msg = 'removed alias "%s"' % (self.alias)
 
         try:
@@ -1178,7 +1178,7 @@ class RemoveQueryCommand(Command):
 
         # flush index
         if self.flush:
-            ui.apply_command(commands.globals.FlushCommand())
+            await ui.apply_command(commands.globals.FlushCommand())
 
 
 @registerCommand(

--- a/alot/commands/namedqueries.py
+++ b/alot/commands/namedqueries.py
@@ -4,7 +4,12 @@
 import argparse
 
 from . import Command, registerCommand
+from .globals import ConfirmCommand
+from .globals import FlushCommand
+from .globals import PromptCommand
+from .globals import RemoveQueryCommand
 from .globals import SearchCommand
+from ..db.errors import DatabaseROError
 
 MODE = 'namedqueries'
 
@@ -28,3 +33,89 @@ class NamedqueriesSelectCommand(Command):
 
         cmd = SearchCommand(query=query)
         await ui.apply_command(cmd)
+
+
+@registerCommand(MODE, 'query-rename', arguments=[
+    (['newalias'], {'help': 'new name for the query'}),
+])
+class NamedqueriesRenameCommand(Command):
+
+    """rename a query"""
+    def __init__(self, newalias, **kwargs):
+        self.newalias = newalias
+        self.complete_count = 0
+
+    def afterwards(self):
+        self.complete_count += 1
+        if self.complete_count == 2:
+            self.ui.current_buffer.rebuild()
+
+    async def apply(self, ui):
+        oldalias = ui.current_buffer.get_selected_query()
+        querydict = ui.dbman.get_named_queries()
+        query_string = querydict[oldalias]
+        self.ui = ui  # save for callback
+        try:
+            ui.dbman.save_named_query(self.newalias, query_string,
+                                      afterwards=self.afterwards)
+        except DatabaseROError:
+            ui.notify('index in read-only mode', priority='error')
+            return
+        ui.dbman.remove_named_query(oldalias, afterwards=self.afterwards)
+        return await ui.apply_command(FlushCommand())
+
+
+@registerCommand(MODE, 'query-duplicate', arguments=[
+    (['newalias'], {'help': 'name for duplicated query', 'nargs': '?'}),
+])
+class NamedqueriesDuplicateCommand(Command):
+
+    """create a copy of the query"""
+    def __init__(self, newalias, **kwargs):
+        self.newalias = newalias
+
+    def afterwards(self):
+        self.ui.current_buffer.rebuild()
+
+    async def apply(self, ui):
+        oldalias = ui.current_buffer.get_selected_query()
+        self.newalias = self.newalias or (oldalias + '_copy')
+        querydict = ui.dbman.get_named_queries()
+        query_string = querydict[oldalias]
+        self.ui = ui  # save for callback
+        try:
+            ui.dbman.save_named_query(self.newalias, query_string,
+                                      afterwards=self.afterwards)
+        except DatabaseROError:
+            ui.notify('index in read-only mode', priority='error')
+            return
+        return await ui.apply_command(FlushCommand())
+
+
+@registerCommand(MODE, 'query-refine')
+class NamedqueriesRefineCommand(Command):
+
+    """refine a query string"""
+    async def apply(self, ui):
+        alias = ui.current_buffer.get_selected_query()
+        query_string = ui.dbman.get_named_queries()[alias]
+        await ui.apply_command(PromptCommand('savequery {} {}'.format(
+            alias, query_string)))
+        ui.current_buffer.rebuild()
+
+
+@registerCommand(MODE, 'query-remove')
+class NamedqueriesRemoveCommand(Command):
+
+    def afterwards(self):
+        self.ui.current_buffer.rebuild()
+
+    """remove the selected namedquery"""
+    async def apply(self, ui):
+        self.ui = ui
+        alias = ui.current_buffer.get_selected_query()
+        await ui.apply_command(ConfirmCommand(
+            msg=['Remove named query {}'.format(alias)]))
+        # SequenceCanceled raised if not confirmed
+        await ui.apply_command(
+            RemoveQueryCommand(alias, afterwards=self.afterwards))


### PR DESCRIPTION
I wanted to use namedqueries as my main startup mode. I hadn't used namedqueries before and wanted some easy management tools for them. So this adds the following commands:

* `query-rename NEWNAME`
* `query-duplicate NEWNAME` (newname defaults to oldname_copy, so this can be bound to other commands)
* `query-remove` is a shortcut for `removequery` global command, which deletes the currently highlighted query (after a prompt)
* `query-refine` opens a prompt where you can edit the `savequery` command for the currently highlighted command. This is useful because it allows you to edit both the query name, and the query itself. This is effectively both an "edit" command, as well as a "edit and save as" command.

This branch is only preliminary - I wanted to check if there were any general objections to the approaches, naming, etc. If not, then I'd like to add documentation and tests.

By the way, great project! I'm enjoying using it and hope to be contributing more.