### PR TITLE
Narrow down notmuch version in dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
             ['alot = alot.__main__:main'],
     },
     install_requires=[
-        'notmuch>=0.27',
+        'notmuch>=0.27,<0.30',
         'urwid>=1.3.0',
         'urwidtrees>=1.0.3',
         'twisted>=18.4.0',


### PR DESCRIPTION
This should be fixed by #1511. It might make issues like #1539 more clear, **I made this PR in the assumtion that we really require <0.30, that is what I gatherd from the comments there.**  If we do not really require <0.30 we should obviously ditch this PR.