### PR TITLE
Remove erroneous extra argument

### DIFF
--- a/alot/buffers/thread.py
+++ b/alot/buffers/thread.py
@@ -180,7 +180,7 @@ class ThreadBuffer(Buffer):
     def set_focus(self, pos):
         "Set the focus in the underlying body widget."
         logging.debug('setting focus to %s ', pos)
-        self.body.set_focus(pos, valign='top')
+        self.body.set_focus(pos)
 
     def focus_first(self):
         """set focus to first message of thread"""


### PR DESCRIPTION
Introduced in 05ab65cdcb0107d7cd541e59b3937aefdd0d8cda (part of #1528) but as far as I can see the definition of that function does not accept the extra keyword argument.

I also get this message in the logs
```
ERROR:ui:Traceback (most recent call last):
  File "/home/luc/src/alot/alot/ui.py", line 723, in apply_command
    cmd.apply(self)
  File "/home/luc/src/alot/alot/commands/thread.py", line 614, in apply
    tbuffer.focus_selected_message()
  File "/home/luc/src/alot/alot/buffers/thread.py", line 199, in focus_selected_message
    self.set_focus(self.get_selected_message_position())
  File "/home/luc/src/alot/alot/buffers/thread.py", line 183, in set_focus
    self.body.set_focus(pos, valign='top')
TypeError: set_focus() got an unexpected keyword argument 'valign'
```
with the corresponding error message in the interface.