### PR TITLE
Requery

### DIFF
--- a/alot/buffers/search.py
+++ b/alot/buffers/search.py
@@ -74,7 +74,8 @@ class SearchBuffer(Buffer):
 
         self.threadlist = IterableWalker(threads, ThreadlineWidget,
                                          dbman=self.dbman,
-                                         reverse=reverse)
+                                         reverse=reverse,
+                                         querystring=self.querystring)
 
         self.listbox = urwid.ListBox(self.threadlist)
         self.body = self.listbox

--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -245,18 +245,22 @@ class DBManager:
                                 exclude_tags=settings.get('exclude_tags'))
 
     @contextlib.contextmanager
-    def _with_notmuch_thread(self, tid):
+    def _with_notmuch_thread(self, tid, querystring=None):
         """returns :class:`notmuch2.Thread` with given id"""
+        if querystring:
+            query = 'thread:' + tid + ' AND (' + querystring + ')'
+        else:
+            query = 'thread:' + tid
         with Database(path=self.path, mode=Database.MODE.READ_ONLY) as db:
             try:
-                yield next(db.threads('thread:' + tid))
+                yield next(db.threads(query))
             except NotmuchError:
                 errmsg = 'no thread with id %s exists!' % tid
                 raise NonexistantObjectError(errmsg)
 
-    def get_thread(self, tid):
+    def get_thread(self, tid, querystring=None):
         """returns :class:`Thread` with given thread id (str)"""
-        with self._with_notmuch_thread(tid) as thread:
+        with self._with_notmuch_thread(tid, querystring) as thread:
             return Thread(self, thread)
 
     @contextlib.contextmanager

--- a/alot/db/thread.py
+++ b/alot/db/thread.py
@@ -42,6 +42,7 @@ class Thread:
     def _refresh(self, thread):
         self._total_messages = len(thread)
         self._notmuch_authors_string = thread.authors
+        self._matched_messages = thread.matched
 
         subject_type = settings.get('thread_subject')
         if subject_type == 'notmuch':
@@ -282,6 +283,10 @@ class Thread:
     def get_total_messages(self):
         """returns number of contained messages"""
         return self._total_messages
+
+    def get_matched_messages(self):
+        """returns number of contained messages"""
+        return self._matched_messages
 
     def matches(self, query):
         """

--- a/alot/db/thread.py
+++ b/alot/db/thread.py
@@ -15,7 +15,7 @@ class Thread:
     directly provide contained messages as :class:`~alot.db.message.Message`.
     """
 
-    def __init__(self, dbman, thread):
+    def __init__(self, dbman, thread, querystring=None):
         """
         :param dbman: db manager that is used for further lookups
         :type dbman: :class:`~alot.db.DBManager`
@@ -26,6 +26,7 @@ class Thread:
         self._authors = None
         self._id = thread.threadid
         self._messages = {}
+        self._querystring = querystring
         self._tags = set()
 
         self.refresh(thread)
@@ -33,7 +34,7 @@ class Thread:
     def refresh(self, thread=None):
         """refresh thread metadata from the index"""
         if not thread:
-            with self._dbman._with_notmuch_thread(self._id) as thread:
+            with self._dbman._with_notmuch_thread(self._id, self._querystring) as thread:
                 self._refresh(thread)
         else:
             self._refresh(thread)

--- a/alot/defaults/default.theme
+++ b/alot/defaults/default.theme
@@ -62,7 +62,7 @@
         [[[mailcount]]]
             normal = 'default','','light gray','default','g66','default'
             focus = 'standout','','yellow','light gray','yellow','g58'
-            width = 'fit', 5,5
+            width = 'fit', 9,9
         [[[tags]]]
             normal = 'bold','','dark cyan','','dark cyan',''
             focus = 'standout','','yellow','light gray','yellow','g58'

--- a/alot/widgets/search.py
+++ b/alot/widgets/search.py
@@ -172,7 +172,7 @@ def prepare_date_string(thread):
 
 
 def prepare_mailcount_string(thread):
-    return "(%d)" % thread.get_total_messages()
+    return "(%d/%d)" % (thread.get_matched_messages(), thread.get_total_messages())
 
 
 def prepare_authors_string(thread):

--- a/alot/widgets/search.py
+++ b/alot/widgets/search.py
@@ -17,19 +17,21 @@ class ThreadlineWidget(urwid.AttrMap):
     selectable line widget that represents a :class:`~alot.db.Thread`
     in the :class:`~alot.buffers.SearchBuffer`.
     """
-    def __init__(self, tid, dbman):
+
+    def __init__(self, tid, dbman, querystring=None):
         self.dbman = dbman
         self.tid = tid
         self.thread = None  # will be set by refresh()
         self.tag_widgets = []
         self.structure = None
+        self.querystring = querystring
         self.rebuild()
         normal = self.structure['normal']
         focussed = self.structure['focus']
         urwid.AttrMap.__init__(self, self.columns, normal, focussed)
 
     def rebuild(self):
-        self.thread = self.dbman.get_thread(self.tid)
+        self.thread = self.dbman.get_thread(self.tid, self.querystring)
         self.widgets = []
         self.structure = settings.get_threadline_theming(self.thread)
 


### PR DESCRIPTION
This mini-series addresses two issues related to the way threads are requeried: the initial query is by a search term, and further queries are by thread id.

The first patch addresses what I consider a bug: If, say, you respond to an e-mail then the search view for the inbox will show the date of your reply but sort the thread by the date of the latest message matching the inbox query. This can look strange.

The second patch uses the solution from the first patch (remembering the query) to achieve a look closer to notmuch's search result list: display numbers of matched messages within a thread in a search view.

The latter one may need some way to configure. [In fact I think I submitted or discusssed this before but couldn't find it, sorry.]