### PR TITLE
fix move first and last

### DIFF
--- a/alot/buffers/search.py
+++ b/alot/buffers/search.py
@@ -115,6 +115,7 @@ class SearchBuffer(Buffer):
             self.body.set_focus(0)
         else:
             self.rebuild(reverse=False)
+            self.body.set_focus(0)
 
     def focus_last(self):
         if self.reversed:
@@ -125,6 +126,7 @@ class SearchBuffer(Buffer):
             self.body.set_focus(num_lines - 1)
         else:
             self.rebuild(reverse=True)
+            self.body.set_focus(0)
 
     def focus_thread(self, thread):
         tid = thread.get_thread_id()


### PR DESCRIPTION
After rebuilding the threadlist, we still need to actually update the focused thread. Currently, in a buffer with more than 200 results you need to run the command twice to actually change the selected thread.

Would you accept a PR to make this limit of 200 results configurable? I personally find it annoying that the ordering of the threads is incorrect because of this, at least according to the original order, as `oldest-first` is not the reverse of `newest-first`. I currently use `move last; refresh` as a best-effort workaround.