### PR TITLE
configurable limit on move last

### DIFF
--- a/alot/buffers/search.py
+++ b/alot/buffers/search.py
@@ -46,7 +46,7 @@ class SearchBuffer(Buffer):
         info['result_count_positive'] = 's' if self.result_count > 1 else ''
         return info
 
-    def rebuild(self, reverse=False):
+    def rebuild(self, reverse=False, restore_focus=True):
         self.isinitialized = True
         self.reversed = reverse
         selected_thread = None
@@ -56,7 +56,7 @@ class SearchBuffer(Buffer):
         else:
             order = self.sort_order
 
-        if self.threadlist:
+        if restore_focus and self.threadlist:
             selected_thread = self.get_selected_thread()
 
         exclude_tags = settings.get_notmuch_setting('search', 'exclude_tags')
@@ -116,7 +116,7 @@ class SearchBuffer(Buffer):
         if not self.reversed:
             self.body.set_focus(0)
         else:
-            self.rebuild(reverse=False)
+            self.rebuild(reverse=False, restore_focus=False)
             self.body.set_focus(0)
 
     def focus_last(self):
@@ -129,7 +129,7 @@ class SearchBuffer(Buffer):
             num_lines = len(self.threadlist.get_lines())
             self.body.set_focus(num_lines - 1)
         else:
-            self.rebuild(reverse=True)
+            self.rebuild(reverse=True, restore_focus=False)
             self.body.set_focus(0)
 
     def focus_thread(self, thread):

--- a/alot/buffers/search.py
+++ b/alot/buffers/search.py
@@ -27,6 +27,8 @@ class SearchBuffer(Buffer):
         self.result_count = 0
         self.search_threads_rebuild_limit = \
             settings.get('search_threads_rebuild_limit')
+        self.search_threads_move_last_limit = \
+            settings.get('search_threads_move_last_limit')
         self.isinitialized = False
         self.threadlist = None
         self.rebuild()
@@ -120,7 +122,9 @@ class SearchBuffer(Buffer):
     def focus_last(self):
         if self.reversed:
             self.body.set_focus(0)
-        elif self.result_count < 200 or self.sort_order not in self._REVERSE:
+        elif self.search_threads_move_last_limit == 0 \
+                or self.result_count < self.search_threads_move_last_limit \
+                or self.sort_order not in self._REVERSE:
             self.consume_pipe()
             num_lines = len(self.threadlist.get_lines())
             self.body.set_focus(num_lines - 1)

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -193,6 +193,12 @@ search_threads_sort_order = option('oldest_first', 'newest_first', 'message_id',
 # when set to 0, no limit is set (can be very slow in searches that yield thousands of results)
 search_threads_rebuild_limit = integer(default=0)
 
+# Maximum number of results in a search buffer before 'move last' builds the
+# thread list in reversed order as a heuristic. The resulting order will be
+# different for threads with multiple matching messages.
+# When set to 0, no limit is set (can be very slow in searches that yield thousands of results)
+search_threads_move_last_limit = integer(default=200)
+
 # in case more than one account has an address book:
 # Set this to True to make tab completion for recipients during compose only
 # look in the abook of the account matching the sender address

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -588,6 +588,19 @@
     :default: [{buffer_no}: search] for "{querystring}", {input_queue} {result_count} of {total_messages} messages
 
 
+.. _search-threads-move-last-limit:
+
+.. describe:: search_threads_move_last_limit
+
+     Maximum number of results in a search buffer before 'move last' builds the
+     thread list in reversed order as a heuristic. The resulting order will be
+     different for threads with multiple matching messages.
+     When set to 0, no limit is set (can be very slow in searches that yield thousands of results)
+
+    :type: integer
+    :default: 200
+
+
 .. _search-threads-rebuild-limit:
 
 .. describe:: search_threads_rebuild_limit


### PR DESCRIPTION
As discussed in #1561, I added an option to configure the maximum number of results before using the reverse order heuristic for `move last`. I kept the default at `200`, although `search_threads_rebuild_limit` is unlimited by default, as we do have the heuristic approach as a fallback.

I also disabled restoring focus after the building the reversed threadlist, as that is limited by `search_threads_rebuild_limit`, making this heuristic pointless by default, as you still load the whole threadbuffer, while getting an inexact order. And even when `search_threads_rebuild_limit` is set to a different value, it would still be unnecessarily slow.