### PR TITLE
Fix toggletags

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -1145,10 +1145,13 @@ class TagCommand(Command):
         tbuffer = ui.current_buffer
         if self.all:
             messagetrees = tbuffer.messagetrees()
+            testquery = "thread:%s" % \
+                        tbuffer.get_selected_thread().get_thread_id()
         else:
             messagetrees = [tbuffer.get_selected_messagetree()]
+            testquery = "mid:%s" % tbuffer.get_selected_mid()
 
-        def refresh_widgets():
+        def refresh():
             for mt in messagetrees:
                 mt.refresh()
 
@@ -1162,26 +1165,18 @@ class TagCommand(Command):
             tbuffer.refresh()
 
         tags = [t for t in self.tagsstring.split(',') if t]
+
         try:
-            for mt in messagetrees:
-                m = mt.get_message()
-                if self.action == 'add':
-                    m.add_tags(tags, afterwards=refresh_widgets)
-                if self.action == 'set':
-                    m.add_tags(tags, afterwards=refresh_widgets,
-                               remove_rest=True)
-                elif self.action == 'remove':
-                    m.remove_tags(tags, afterwards=refresh_widgets)
-                elif self.action == 'toggle':
-                    to_remove = []
-                    to_add = []
-                    for t in tags:
-                        if t in m.get_tags():
-                            to_remove.append(t)
-                        else:
-                            to_add.append(t)
-                    m.remove_tags(to_remove)
-                    m.add_tags(to_add, afterwards=refresh_widgets)
+            if self.action == 'add':
+                ui.dbman.tag(testquery, tags, remove_rest=False,
+                             afterwards=refresh)
+            if self.action == 'set':
+                ui.dbman.tag(testquery, tags, remove_rest=True,
+                             afterwards=refresh)
+            elif self.action == 'remove':
+                ui.dbman.untag(testquery, tags, afterwards=refresh)
+            elif self.action == 'toggle':
+                ui.dbman.toggle_tags(testquery, tags, afterwards=refresh)
 
         except DatabaseROError:
             ui.notify('index in read-only mode', priority='error')

--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -238,6 +238,16 @@ class DBManager:
         return db.count_messages(querystring,
                                  exclude_tags=settings.get('exclude_tags'))
 
+    def collect_tags(self, querystring):
+        """returns tags of messages that match `querystring`"""
+        db = Database(path=self.path, mode=Database.MODE.READ_ONLY)
+        tagset = notmuch2._tags.ImmutableTagSet(
+            db.messages(querystring,
+                        exclude_tags=settings.get('exclude_tags')),
+            '_iter_p',
+            notmuch2.capi.lib.notmuch_messages_collect_tags)
+        return [t for t in tagset]
+
     def count_threads(self, querystring):
         """returns number of threads that match `querystring`"""
         db = Database(path=self.path, mode=Database.MODE.READ_ONLY)

--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -111,16 +111,19 @@ class DBManager:
 
                         else:  # tag/set/untag
                             querystring, tags = current_item[2:]
+                            if cmd == 'toggle':
+                                presenttags = self.collect_tags(querystring)
+                                to_remove = []
+                                to_add = []
+                                for tag in tags:
+                                    if tag in presenttags:
+                                        to_remove.append(tag)
+                                    else:
+                                        to_add.append(tag)
+
                             for msg in db.messages(querystring):
                                 with msg.frozen():
                                     if cmd == 'toggle':
-                                        to_remove = []
-                                        to_add = []
-                                        for tag in tags:
-                                            if tag in msg.tags:
-                                                to_remove.append(tag)
-                                            else:
-                                                to_add.append(tag)
                                         for tag in to_remove:
                                             msg.tags.discard(tag)
                                         for tag in to_add:


### PR DESCRIPTION
There still seems to be quite a fall-out from the conversion of alot to nm2. This PR so far only solves one related to the toggletags command and the question whether toggle is per message or per thread (best described in the commit messages).

I have other weird effects, such as `notmuch search` giving a thread with 16 messages and `alot search` giving me only 1 message for that thread, and so does the thread buffer. I have not tracked this down yet.

This PR might serve to collect more fixes or be merged directly if deemed correct. Am I the only one experiencing these issues? I don't see any related bug reports.