### PR TITLE
fix synchronisation of tags to Maildir flags

### DIFF
--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -97,6 +97,8 @@ class DBManager:
                                 logging.debug('freeze')
                                 for tag in tags:
                                     msg.tags.add(tag)
+                                if sync:
+                                    msg.tags.to_maildir_flags()
                                 logging.debug('added tags ')
                             logging.debug('thaw')
 
@@ -134,6 +136,8 @@ class DBManager:
                                                 msg.tags.add(tag)
                                             elif cmd == 'untag':
                                                 msg.tags.discard(tag)
+                                    if sync:
+                                        msg.tags.to_maildir_flags()
 
                         logging.debug('ended atomic')
 


### PR DESCRIPTION
Since the move to notmuch2, tag changes were no longer synchronised to Maildir flags.