### PR TITLE
Clarify exclude tags

### DIFF
--- a/alot/buffers/search.py
+++ b/alot/buffers/search.py
@@ -57,14 +57,10 @@ class SearchBuffer(Buffer):
         if self.threadlist:
             selected_thread = self.get_selected_thread()
 
-        exclude_tags = settings.get_notmuch_setting('search', 'exclude_tags')
-        if exclude_tags:
-            exclude_tags = [t for t in exclude_tags.split(';') if t]
-
         try:
             self.result_count = self.dbman.count_messages(self.querystring)
             threads = self.dbman.get_threads(
-                self.querystring, order, exclude_tags)
+                self.querystring, order)
         except NotmuchError:
             self.ui.notify('malformed query string: %s' % self.querystring,
                            'error')

--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -292,7 +292,7 @@ class DBManager:
         return {k[6:]: db.config[k] for k in db.config if
                 k.startswith('query.')}
 
-    def get_threads(self, querystring, sort='newest_first', exclude_tags=None):
+    def get_threads(self, querystring, sort='newest_first'):
         """
         asynchronously look up thread ids matching `querystring`.
 
@@ -301,9 +301,6 @@ class DBManager:
         :param sort: Sort order. one of ['oldest_first', 'newest_first',
                      'message_id', 'unsorted']
         :type query: str
-        :param exclude_tags: Tags to exclude by default unless included in the
-                             search
-        :type exclude_tags: list of str
         :returns: a pipe together with the process that asynchronously
                   writes to it.
         :rtype: (:class:`multiprocessing.Pipe`,

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -14,7 +14,7 @@ attachment_prefix = string(default='~')
 input_timeout = float(default=1.0)
 
 # A list of tags that will be excluded from search results by default. Using an excluded tag in a query will override that exclusion.
-# .. note:: this config setting is equivalent to, but independent of, the 'search.exclude_tags' in the notmuch config.
+# .. note:: this config setting is the alot equivalent to the 'search.exclude_tags' setting in the notmuch config.
 exclude_tags = force_list(default=list())
 
 # display background colors set by ANSI character escapes

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -277,7 +277,7 @@
 .. describe:: exclude_tags
 
      A list of tags that will be excluded from search results by default. Using an excluded tag in a query will override that exclusion.
-     .. note:: this config setting is equivalent to, but independent of, the 'search.exclude_tags' in the notmuch config.
+     .. note:: this config setting is the alot equivalent to the 'search.exclude_tags' setting in the notmuch config.
 
     :type: string list
     :default: ,


### PR DESCRIPTION
Clarify documentation on `exclude_tags` to make it more clear the notmuch `exclude_tags` setting is not used in notmuch. And cleanup of some old unused code loading the notmuch setting.