### PR TITLE
use notmuch exclude_tags as fallback

### DIFF
--- a/alot/buffers/search.py
+++ b/alot/buffers/search.py
@@ -59,14 +59,9 @@ class SearchBuffer(Buffer):
         if restore_focus and self.threadlist:
             selected_thread = self.get_selected_thread()
 
-        exclude_tags = settings.get_notmuch_setting('search', 'exclude_tags')
-        if exclude_tags:
-            exclude_tags = [t for t in exclude_tags.split(';') if t]
-
         try:
             self.result_count = self.dbman.count_messages(self.querystring)
-            threads = self.dbman.get_threads(
-                self.querystring, order, exclude_tags)
+            threads = self.dbman.get_threads(self.querystring, order)
         except NotmuchError:
             self.ui.notify('malformed query string: %s' % self.querystring,
                            'error')

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -14,8 +14,8 @@ attachment_prefix = string(default='~')
 input_timeout = float(default=1.0)
 
 # A list of tags that will be excluded from search results by default. Using an excluded tag in a query will override that exclusion.
-# .. note:: this config setting is equivalent to, but independent of, the 'search.exclude_tags' in the notmuch config.
-exclude_tags = force_list(default=list())
+# .. note:: when set, this config setting will overrule the 'search.exclude_tags' in the notmuch config.
+exclude_tags = force_list(default=None)
 
 # display background colors set by ANSI character escapes
 interpret_ansi_background = boolean(default=True)

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -277,10 +277,10 @@
 .. describe:: exclude_tags
 
      A list of tags that will be excluded from search results by default. Using an excluded tag in a query will override that exclusion.
-     .. note:: this config setting is equivalent to, but independent of, the 'search.exclude_tags' in the notmuch config.
+     .. note:: when set, this config setting will overrule the 'search.exclude_tags' in the notmuch config.
 
     :type: string list
-    :default: ,
+    :default: None
 
 
 .. _flush-retry-timeout:


### PR DESCRIPTION
This changes alot's exclude tag setting to use the notmuch exclude_tags setting as a fallback when the alot setting isn't set, as discussed in #1566.