### PR TITLE
Immediately remove unread tag from one-message threads

### DIFF
--- a/alot/buffers/thread.py
+++ b/alot/buffers/thread.py
@@ -107,11 +107,18 @@ class ThreadBuffer(Buffer):
 
         if settings.get('auto_remove_unread'):
             logging.debug('Tbuffer: auto remove unread tag from msg?')
+
             msg = self.get_selected_message()
             mid = msg.get_message_id()
-            focus_pos = self.body.get_focus()[1]
-            summary_pos = (self.body.get_focus()[1][0], (0,))
-            cursor_on_non_summary = (focus_pos != summary_pos)
+
+            if self.message_count > 1:
+                focus_pos = self.body.get_focus()[1]
+                summary_pos = (self.body.get_focus()[1][0], (0,))
+                cursor_on_non_summary = (focus_pos != summary_pos)
+            else:
+                # immediately remove unread tag from one-message threads
+                cursor_on_non_summary = True
+
             if cursor_on_non_summary:
                 if mid not in self._auto_unread_dont_touch_mids:
                     if 'unread' in msg.get_tags():

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -675,12 +675,8 @@ class HelpCommand(Command):
                     linewidgets.append(line)
 
             # global maps
-            close_key = 'esc'
             linewidgets.append(urwid.Text((section_att, '\nglobal maps')))
             for (k, v) in globalmaps.items():
-                if v == 'bclose':
-                    close_key = k
-
                 if k not in modemaps:
                     line = urwid.Columns(
                         [('fixed', keycolumnwidth, urwid.Text((text_att, k))),
@@ -688,7 +684,7 @@ class HelpCommand(Command):
                     linewidgets.append(line)
 
             body = urwid.ListBox(linewidgets)
-            titletext = 'Bindings Help ("%s" cancels)' % close_key
+            titletext = 'Bindings Help (escape cancels)'
 
             box = DialogBox(body, titletext,
                             bodyattr=text_att,
@@ -698,7 +694,7 @@ class HelpCommand(Command):
             overlay = urwid.Overlay(box, ui.root_widget, 'center',
                                     ('relative', 70), 'middle',
                                     ('relative', 70))
-            ui.show_as_root_until_keypress(overlay, close_key)
+            ui.show_as_root_until_keypress(overlay, 'esc')
         else:
             logging.debug('HELP %s', self.commandname)
             parser = commands.lookup_parser(self.commandname, ui.mode)

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -675,8 +675,12 @@ class HelpCommand(Command):
                     linewidgets.append(line)
 
             # global maps
+            close_key = 'esc'
             linewidgets.append(urwid.Text((section_att, '\nglobal maps')))
             for (k, v) in globalmaps.items():
+                if v == 'bclose':
+                    close_key = k
+
                 if k not in modemaps:
                     line = urwid.Columns(
                         [('fixed', keycolumnwidth, urwid.Text((text_att, k))),
@@ -684,7 +688,7 @@ class HelpCommand(Command):
                     linewidgets.append(line)
 
             body = urwid.ListBox(linewidgets)
-            titletext = 'Bindings Help (escape cancels)'
+            titletext = 'Bindings Help ("%s" cancels)' % close_key
 
             box = DialogBox(body, titletext,
                             bodyattr=text_att,
@@ -694,7 +698,7 @@ class HelpCommand(Command):
             overlay = urwid.Overlay(box, ui.root_widget, 'center',
                                     ('relative', 70), 'middle',
                                     ('relative', 70))
-            ui.show_as_root_until_keypress(overlay, 'esc')
+            ui.show_as_root_until_keypress(overlay, close_key)
         else:
             logging.debug('HELP %s', self.commandname)
             parser = commands.lookup_parser(self.commandname, ui.mode)


### PR DESCRIPTION
If 'auto_remove_unread' is enabled, immediately remove unread tag from one-message threads.