### PR TITLE
Make 'bclose' key close help window

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -675,8 +675,12 @@ class HelpCommand(Command):
                     linewidgets.append(line)
 
             # global maps
+            close_key = 'esc'
             linewidgets.append(urwid.Text((section_att, '\nglobal maps')))
             for (k, v) in globalmaps.items():
+                if v == 'bclose':
+                    close_key = k
+
                 if k not in modemaps:
                     line = urwid.Columns(
                         [('fixed', keycolumnwidth, urwid.Text((text_att, k))),
@@ -684,7 +688,7 @@ class HelpCommand(Command):
                     linewidgets.append(line)
 
             body = urwid.ListBox(linewidgets)
-            titletext = 'Bindings Help (escape cancels)'
+            titletext = 'Bindings Help ("%s" cancels)' % close_key
 
             box = DialogBox(body, titletext,
                             bodyattr=text_att,
@@ -694,7 +698,7 @@ class HelpCommand(Command):
             overlay = urwid.Overlay(box, ui.root_widget, 'center',
                                     ('relative', 70), 'middle',
                                     ('relative', 70))
-            ui.show_as_root_until_keypress(overlay, 'esc')
+            ui.show_as_root_until_keypress(overlay, close_key)
         else:
             logging.debug('HELP %s', self.commandname)
             parser = commands.lookup_parser(self.commandname, ui.mode)


### PR DESCRIPTION
'bclose' key seems like the most logical key to close the help window. Falls back to 'escape' if 'bclose' key is not defined.