### PR TITLE
Configurable help close/cancel key

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -684,7 +684,7 @@ class HelpCommand(Command):
                     linewidgets.append(line)
 
             body = urwid.ListBox(linewidgets)
-            titletext = 'Bindings Help (escape cancels)'
+            titletext = 'Bindings Help (%s cancels)' % settings.help_cancel_key
 
             box = DialogBox(body, titletext,
                             bodyattr=text_att,
@@ -694,7 +694,7 @@ class HelpCommand(Command):
             overlay = urwid.Overlay(box, ui.root_widget, 'center',
                                     ('relative', 70), 'middle',
                                     ('relative', 70))
-            ui.show_as_root_until_keypress(overlay, 'esc')
+            ui.show_as_root_until_keypress(overlay, settings.help_cancel_key)
         else:
             logging.debug('HELP %s', self.commandname)
             parser = commands.lookup_parser(self.commandname, ui.mode)

--- a/alot/defaults/default.bindings
+++ b/alot/defaults/default.bindings
@@ -91,3 +91,6 @@ q = exit
     'g h' = move parent
     'g l' = move first reply
     ' ' = move next
+
+[help]
+    esc = cancel

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -532,3 +532,15 @@ class SettingsManager:
             else:
                 rep = pretty_datetime(d)
         return rep
+
+    @property
+    def help_cancel_key(self):
+        """
+        Returns cancel key for help overlays
+        """
+        if not hasattr(self, '__help_cancel_key'):
+            _, helpmap = self.get_keybindings('help')
+            helpmap = {v: k for k, v in helpmap.items()}
+            self.__help_cancel_key = helpmap.get('cancel', 'esc')
+
+        return self.__help_cancel_key

--- a/alot/ui.py
+++ b/alot/ui.py
@@ -628,13 +628,14 @@ class UI:
 
         if block:
             # put "cancel to continue" widget as overlay on main widget
-            txt = build_line('(escape continues)', priority)
+            txt = build_line('(%s continues)' % settings.help_cancel_key,
+                             priority)
             overlay = urwid.Overlay(txt, self.root_widget,
                                     ('fixed left', 0),
                                     ('fixed right', 0),
                                     ('fixed bottom', 0),
                                     None)
-            self.show_as_root_until_keypress(overlay, 'esc',
+            self.show_as_root_until_keypress(overlay, settings.help_cancel_key,
                                              afterwards=clear)
         else:
             if timeout >= 0:


### PR DESCRIPTION
I didn't like (using) the hardcoded `escape` key to close help overlays, so i made the patch.