### PR TITLE
Added an option to unfold only messages matching a query

### DIFF
--- a/alot/commands/search.py
+++ b/alot/commands/search.py
@@ -14,6 +14,7 @@ from .. import commands
 
 from .. import buffers
 from ..db.errors import DatabaseROError
+from ..settings.const import settings
 
 
 MODE = 'search'
@@ -35,7 +36,9 @@ class OpenThreadCommand(Command):
         if not self.thread:
             self.thread = ui.current_buffer.get_selected_thread()
         if self.thread:
-            query = ui.current_buffer.querystring
+            query = settings.get('thread_unfold_matching')
+            if not query:
+                query = ui.current_buffer.querystring
             logging.info('open thread view for %s', self.thread)
 
             tb = buffers.ThreadBuffer(ui, self.thread)

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -308,6 +308,9 @@ periodic_hook_frequency = integer(default=300)
 # for the whole message body.
 thread_focus_linewise = boolean(default=True)
 
+# Unfold messages matching the query. If not set, will unfold all messages matching search buffer query.
+thread_unfold_matching = string(default=None)
+
 
 # Key bindings
 [bindings]


### PR DESCRIPTION
When defined this option will make only matching messages unfold when opening a thread. Saves time rendering, avoids hacks like `select; fold *; ...` and improves ui/ux.

Sample use:
`thread_unfold_matching = "tag:unread"`