### PR TITLE
Message summary subjects

### DIFF
--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -26,7 +26,7 @@ class Message:
     It it uses a :class:`~alot.db.DBManager` for cached manipulation
     and lazy lookups.
     """
-    def __init__(self, dbman, msg, thread=None):
+    def __init__(self, dbman, msg, thread=None, parent=None):
         """
         :param dbman: db manager that is used for further lookups
         :type dbman: alot.db.DBManager
@@ -34,11 +34,15 @@ class Message:
         :type msg: notmuch2.Message
         :param thread: this messages thread (will be looked up later if `None`)
         :type thread: :class:`~alot.db.Thread` or `None`
+        :param parent: this message's parent (if it was a reply, and we have the
+                                              message it was a reply to)
+        :type parent: :class:`~alot.db.Message` or `None`
         """
         self._dbman = dbman
         self._id = msg.messageid
         self._thread_id = msg.threadid
         self._thread = thread
+        self._parent = parent
         try:
             self._datetime = datetime.fromtimestamp(msg.date)
         except ValueError:
@@ -114,6 +118,10 @@ class Message:
                 self._email = email.message_from_string(
                     warning, policy=email.policy.SMTP)
         return self._email
+
+    def get_parent(self):
+        """returns parent Message if this is a reply or None otherwise"""
+        return self._parent
 
     def get_date(self):
         """returns Date header value as :class:`~datetime.datetime`"""

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -50,6 +50,11 @@ class Message:
         self._mime_tree = None  # will be read upon first use
         self._tags = msg.tags
 
+        try:
+            self._subject = decode_header(msg.header('subject'))
+        except LookupError:  # No Subject on Email
+            self._subject = ''
+
         self._session_keys = [
             value for _, value in msg.properties.getall(prefix="session-key",
                                                         exact=True)
@@ -117,6 +122,10 @@ class Message:
     def get_filename(self):
         """returns absolute path of message files location"""
         return self._filename
+
+    def get_subject(self):
+        """returns Subject header (str)"""
+        return self._subject
 
     def get_message_id(self):
         """returns messages id (str)"""

--- a/alot/db/thread.py
+++ b/alot/db/thread.py
@@ -238,11 +238,11 @@ class Thread:
         if not self._messages:  # if not already cached
             with self._dbman._with_notmuch_thread(self._id) as thread:
 
-                def accumulate(acc, msg):
-                    M = Message(self._dbman, msg, thread=self)
+                def accumulate(acc, msg, parent=None):
+                    M = Message(self._dbman, msg, thread=self, parent=parent)
                     acc[M] = []
                     for m in msg.replies():
-                        acc[M].append(accumulate(acc, m))
+                        acc[M].append(accumulate(acc, m, M))
                     return M
 
                 self._messages = {}

--- a/alot/widgets/thread.py
+++ b/alot/widgets/thread.py
@@ -78,9 +78,22 @@ class MessageSummaryWidget(urwid.WidgetWrap):
     def __str__(self):
         author, address = self.message.get_author()
         date = self.message.get_datestring()
+        subject = self.message.get_subject()
         rep = author if author != '' else address
         if date is not None:
             rep += " (%s)" % date
+
+        # Hide Subjects which are replies to the parent message.
+        # This allows threads containing multiple messages with distinct
+        # subjects to be displayed without adding noise to the replies.
+        parent = self.message.get_parent()
+        if parent:
+            psubject = parent.get_subject()
+            if psubject:
+                subject = subject.replace(psubject, "...")
+
+        rep += ": " + subject
+
         return rep
 
     def selectable(self):


### PR DESCRIPTION
This series tackles presenting threads where a multi-patch series is sent with a cover letter, for instance when sent with git-send-mail.

The default presentation in the thread view hides the details required to identify the patch titles:
![alot-without-message-summaries](https://user-images.githubusercontent.com/38009/138094004-7176217a-f296-4e80-a669-9d238790e64f.png)

With this development the individual patches can be seen to show their titles on the summary.

![alot-with-message-summaries](https://user-images.githubusercontent.com/38009/138094008-2948ae81-9edb-47bd-90ce-9a4c13d4aa11.png)

To prevent adding a lot of noise, replies do not further repeat the message title. The implemenation here so far is just to check if 'subject.startswith(('Re:')) and ignore those ones which does not seem fool-proof (and may be entirely locale dependant based upon the senders) so I'm looking for advice on a better way to implement that.

I had wondered if comparing the Subject against a parent subject, and only printing if they differ would be better, but the prefixes that get added  by replies would still affect that too.