### PR TITLE
commands: thread: Reference existing message when forwarding

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -359,6 +359,10 @@ class ForwardCommand(Command):
                 subject = fsp + subject
         envelope.add('Subject', subject)
 
+        # Set forwarding reference headers
+        envelope.add('References', '<%s>' % self.message.get_message_id())
+        envelope.add('X-Forwarded-Message-Id', '<%s>' % self.message.get_message_id())
+
         # set From-header and sending account
         try:
             from_header, account = determine_sender(mail, 'reply')


### PR DESCRIPTION
When forwarding a mail, the outgoing mail, and any follow up
conversation becomes a disjointed thread.  This removes the original
context, and makes it harder to find and track while the conversation
splits in two directions.

Add appropriate reference headers to the envelope when constructing a
forwarded mail to ensure that the conversations continue to be related
and therefore presented in the same thread with notmuch and alot.

Signed-off-by: Kieran Bingham <kieran.bingham@ideasonboard.com>