### PR TITLE
Find notmuch config in new locations

### DIFF
--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -9,7 +9,7 @@ import sys
 import alot
 from alot.settings.const import settings
 from alot.settings.errors import ConfigError
-from alot.helper import get_xdg_env
+from alot.helper import get_xdg_env, get_notmuch_config_path
 from alot.db.manager import DBManager
 from alot.ui import UI
 from alot.commands import *
@@ -34,9 +34,7 @@ def parser():
                         validator=cargparse.require_file,
                         help='configuration file')
     parser.add_argument('-n', '--notmuch-config', metavar='FILENAME',
-                        default=os.environ.get(
-                            'NOTMUCH_CONFIG',
-                            os.path.expanduser('~/.notmuch-config')),
+                        default=get_notmuch_config_path(),
                         action=cargparse.ValidatedStoreAction,
                         validator=cargparse.require_file,
                         help='notmuch configuration file')

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -594,3 +594,25 @@ def get_xdg_env(env_name, fallback):
     """ Used for XDG_* env variables to return fallback if unset *or* empty """
     env = os.environ.get(env_name)
     return env if env else fallback
+
+
+def get_notmuch_config_path():
+    """ Find the notmuch config file via env vars and default locations """
+    # This code is modeled after the description in nomtuch-config(1)
+    # Case 1 is only applicable for the notmuch CLI
+    # Case 2: the NOTMUCH_CONFIG env variable
+    value = os.environ.get('NOTMUCH_CONFIG')
+    if value is not None:
+        return value
+    # Case 3: new location in XDG config directory
+    profile = os.environ.get('NOTMUCH_PROFILE', 'default')
+    value = os.path.join(get_xdg_env('XDG_CONFIG_HOME',
+                                     os.path.expanduser('~/.config')),
+                         'notmuch', profile, 'config')
+    if os.path.exists(value):
+        return value
+    # Case 4: traditional location in $HOME
+    profile = os.environ.get('NOTMUCH_PROFILE', '')
+    if profile:
+        profile = '.' + profile
+    return os.path.expanduser('~/.notmuch-config' + profile)

--- a/docs/source/api/settings.rst
+++ b/docs/source/api/settings.rst
@@ -17,9 +17,10 @@ There are four types of user settings:
 |                                    | or as given by the `hooksfile`   |                                             |
 |                                    | config value                     |                                             |
 +------------------------------------+----------------------------------+---------------------------------------------+
-| notmuch config                     | :file:`~/.notmuch-config` or     | :meth:`SettingsManager.get_notmuch_setting` |
-|                                    | given by `$NOTMUCH_CONFIG` or    |                                             |
+| notmuch config                     | notmuch config file as           | :meth:`SettingsManager.get_notmuch_setting` |
 |                                    | given by command option `-n`     |                                             |
+|                                    | or its default location          |                                             |
+|                                    | described in `notmuch-config(1)` |                                             |
 +------------------------------------+----------------------------------+---------------------------------------------+
 | mailcap -- defines shellcommands   | :file:`~/.mailcap`               | :meth:`SettingsManager.mailcap_find_match`  |
 | to handle mime types               | (:file:`/etc/mailcap`)           |                                             |

--- a/docs/source/usage/cli_options.rst
+++ b/docs/source/usage/cli_options.rst
@@ -2,8 +2,7 @@
 -c FILENAME, --config=FILENAME
                  configuration file (default: ~/.config/alot/config)
 -n FILENAME, --notmuch-config=FILENAME
-                 notmuch configuration file (default: $NOTMUCH_CONFIG
-                 or ~/.notmuch-config)
+                 notmuch configuration file (default: see notmuch-config(1))
 -C COLOURS, --colour-mode=COLOURS
                  number of colours to use on the terminal; must be 1, 16 or 256
                  (default: configuration option `colourmode` or 256)


### PR DESCRIPTION
Since a while ago notmuch allows to notmuch config file to be stored in some new locations (XDG directories).  This PR adds support for the new locations and env variables.  The official docs are in https://notmuchmail.org/manpages/notmuch-config-1/

I simplified the docs to refer to the notmuch man page because the new algorithm to find the file is unwieldy and I did not wat to copy it. I hope that is ok.