### PR TITLE
feat: add a 'theme' command

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -35,6 +35,7 @@ from ..db.envelope import Envelope
 from ..settings.const import settings
 from ..settings.errors import ConfigError, NoMatchingAccount
 from ..utils import argparse as cargparse
+from ..settings.theme import Theme
 
 MODE = 'global'
 
@@ -1086,6 +1087,28 @@ class ReloadCommand(Command):
             settings.reload()
         except ConfigError as e:
             ui.notify('Error when reloading config files:\n {}'.format(e),
+                      priority='error')
+
+@registerCommand(MODE, 'theme',     arguments=[
+    (['theme_name'], {'help': 'Name of the theme'})], help='Select your own them')
+class ThemeCommand(Command):
+
+    """move in widget"""
+    def __init__(self, theme_name=None, **kwargs):
+        self.theme = theme_name
+        # if movement is None:
+        #     self.movement = ''
+        # else:
+        #     self.movement = ' '.join(movement)
+        Command.__init__(self, **kwargs)
+
+    """Reload configuration."""
+    def apply(self, ui):
+        # theme = matt
+        try:
+            settings._theme = Theme(self.theme)
+        except ConfigError as e:
+            ui.notify('Error when loading  theme:\n {}'.format(e),
                       priority='error')
 
 

--- a/alot/settings/utils.py
+++ b/alot/settings/utils.py
@@ -32,6 +32,7 @@ def read_config(configpath=None, specpath=None, checks=None,
 
     try:
         config = ConfigObj(infile=configpath, configspec=specpath,
+                raise_errors = True,
                            file_error=True, encoding='UTF8')
     except ConfigObjError as e:
         msg = 'Error when parsing `%s`:\n%s' % (configpath, e)


### PR DESCRIPTION
to be able to change the theme dynamically see https://github.com/pazz/alot/issues/1588

When running the command in development mode, I get:
`Could not read toto and/or /home/teto/alot/alot/settings/../defaults/theme.spec`

What is weird too is that starting alot in development mode takes 5 sec while the system one starts <1 sec . The system alot took longer the first time though so I wonder if alot generates some cache along the way ? Same happened with neomutt, took a long time starting the first time I ran it in a while then successive starts were much faster. I've got 136675 messages in DB and ran a notmuch compact.