### PR TITLE
Fix external tmux command without display

### DIFF
--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -221,7 +221,7 @@ class ExternalCommand(Command):
             logging.debug('calling hook: touch_external_cmdlist')
             res = touchhook(cmd, shell=shell, spawn=spawn, thread=thread)
             logging.debug('got: %s', res)
-            cmd, shell, self.in_thread = res
+            cmd, shell, thread = res
         # otherwise if spawn requested and X11 is running
         elif spawn:
             if 'DISPLAY' in os.environ:

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -230,6 +230,7 @@ class ExternalCommand(Command):
                 termcmdlist = split_commandstring(term_cmd)
                 cmd = termcmdlist + cmd
             else:
+                logging.warning('unable to handle spawn outside of X11 without touch_external_cmdlist hook set')
                 thread = False
 
         self.cmdlist = cmd

--- a/extra/hooks/external_command_tmux_without_x11.py
+++ b/extra/hooks/external_command_tmux_without_x11.py
@@ -1,0 +1,12 @@
+import os
+
+
+def touch_external_cmdlist(cmd, shell=False, spawn=False, thread=False):
+    # Used to handle the case where tmux isn't running within X11
+    if spawn and 'TMUX' in os.environ:
+        termcmdlist = ['tmux-horizontal-split-blocking.sh']
+        cmd = termcmdlist + cmd
+        # Required to avoid tmux trying to nest itself.
+        shell = False
+
+    return cmd, shell, thread

--- a/extra/tmux-horizontal-split-blocking.sh
+++ b/extra/tmux-horizontal-split-blocking.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Uses unique tmux wait-for channel based on time with nanoseconds
+# Inspired by cjpbirkbeck's example @ https://github.com/pazz/alot/issues/1560#issuecomment-907222165
+
+IFS=' '
+
+# Ensure we're actually running inside tmux:
+if [ -n "$TMUX" ]; then
+    fin=$(date +%s%N)
+    # Use new-window to create a new window instead.
+    tmux split-window -h "${*}; tmux wait-for -S ${fin}"
+    tmux wait-for "${fin}"
+else
+    # You can replace xterm with your preferred terminal emulator.
+    xterm -e "${*}"
+fi
+


### PR DESCRIPTION
I spent entirely too long today fixing my own instance of #1560, because I'm not running alot in X11 and #460 and 2a7d1fd2dcc7354b06faa0da5574324b3578eba1 make alot simply fall back to non-spawning behaviour silently.

Initially I special-cased tmux outside of X11 in alot/commands/globals.py, but then I found out that I'm supposed to write a hook. So I did that, but I'd like to document it publicly.

There's also a bug where the `thread` result of that hook is not respected because `self.in_thread` gets set directly.

- Ensure the `thread` result of the `touch_external_command` hook is not overridden.
- Provide an example `touch_external_command` hook and corresponding shell script for tmux outside of X11. (Thanks to @cjpbirkbeck in https://github.com/pazz/alot/issues/1560#issuecomment-907222165)
- Log a warning if spawn is requested outside of X11 but no hook is set, rather than fall back silently to non-threaded mode.