### PR TITLE
Another attempt at handling text/calendar sensibly

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -601,6 +601,11 @@ class ChangeDisplaymodeCommand(Command):
                     mimepart = get_body_part(message.get_email(), mimetype)
                 elif self.mimepart is True:
                     mimepart = ui.get_deep_focus().mimepart
+                if isinstance(mimepart, Attachment):
+                    # We're here because we're processing this attachment using a
+                    # mailcap view entry to actually display within alot.
+                    # Therefore, extract the mimepart from the Attachment here.
+                    mimepart = mimepart.part
                 mt.set_mimepart(mimepart)
                 ui.update()
             if self.mimetree == 'toggle':
@@ -919,7 +924,7 @@ class SaveAttachmentCommand(Command):
             focus = ui.get_deep_focus()
             if isinstance(focus, AttachmentWidget):
                 attachment = focus.get_attachment()
-                filename = attachment.get_filename()
+                filename = attachment.get_filename() or ''
                 if not self.path:
                     msg = 'save attachment (%s) to ' % filename
                     initialtext = os.path.join(savedir, filename)
@@ -958,7 +963,8 @@ class OpenAttachmentCommand(Command):
             afterwards = None  # callback, will rm tempfile if used
             handler_stdin = None
             tempfile_name = None
-            handler_raw_commandstring = entry['view']
+            handler_raw_commandstring = entry.get('x-alot-openattachment', '') or entry['view']
+            logging.info("Got {}".format(handler_raw_commandstring))
             # read parameter
             part = self.attachment.get_mime_representation()
             parms = tuple('='.join(p) for p in part.get_params())
@@ -1067,6 +1073,18 @@ class ThreadSelectCommand(Command):
             await ui.apply_command(OpenAttachmentCommand(focus.get_attachment()))
         elif getattr(focus, 'mimepart', False):
             if isinstance(focus.mimepart, Attachment):
+                # Check if both an attachment opener and view are defined
+                mimetype = focus.mimepart.get_content_type()
+                _, entry = settings.mailcap_find_match(mimetype)
+                if entry.get('x-alot-openattachment', ''):
+                    # Separate view and open actions defined, so attempt to view.
+                    # We do this before open, so that whatever it's viewed as is
+                    # visible in alot in case the open is some interactive external
+                    # thing
+                    await ui.apply_command(ChangeDisplaymodeCommand(
+                        mimepart=True, mimetree='toggle'))
+                # Always attempt to open the attachment
+                # alternatively: gate behind else?
                 await ui.apply_command(OpenAttachmentCommand(focus.mimepart))
             else:
                 await ui.apply_command(ChangeDisplaymodeCommand(

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -251,8 +251,18 @@ class Message:
                             'application/pgp-encrypted'):
                         self._attachments.pop()
 
+                # handle calendar invites from outlook by adding a
+                # content-disposition header if not present
+                if ct.lower() == 'text/calendar':
+                    cd = part.get('Content-Disposition', '')
+                    if not cd:
+                        part.add_header('Content-Disposition', 'inline',
+                                        filename='inline-{}.ics'.format(
+                                            len(self._attachments)))
+
                 if self._is_attachment(part, ct):
                     self._attachments.append(Attachment(part))
+
         return self._attachments
 
     @staticmethod


### PR DESCRIPTION
This is an attempt at fixing the following combination of long-standing issues:

1. Outlook sends calendar invites as `text/calendar` without a content disposition, so it doesn't show up as an attachment.

2. alot doesn't handle `text/calendar` as a mimepart without explicitly navigating to it via the mimetree.

3. *If* a user sets their mailcap to `text/calendar; cat '%s'; copiousoutput`, the calendar contents get displayed as expected, and may be processed using a pipeto command.

The combination of 1 and 2 make it so that `text/calendar` invites from outlook are effectively hidden by default in alot.

The existence of 3 makes it so that we can't simply turn `text/calendar` into attachments.

An early attempt at fixing this by allowing `text/calendar` to be a preferred mimetype was made in <https://github.com/pazz/alot/pull/640> but that seems to have been lost. However, we have to assume that the demonstrated workflow based on decoding with mailcap and using `pipeto` is in use.

<https://github.com/pazz/alot/pull/752> handles this situation by having multiple mailcap lines with different flags. This was merged but then removed in 7a883108b1bc6d8b59ac5a14ebf6265312135be2

Another idea, handling all unrendered parts as attachments, was proposed in <https://github.com/pazz/alot/issues/777>. Since we now have a mimetree, this is not *strictly* necessary, but it *would* be nice to be able to save the inline text/calendar as a .ics-file.

Combining these ideas, this proposal does three things:

1. Introduce an alot-specific x-alot-openattachment field for mailcap, that alot prefers when *opening* an attachment. If it is not present, alot will fall back to the standard ('view') field for opening the attachment.

2. Every `text/calendar` part without a content-disposition gets one forced on it, effectively turning it into an attachment. The resulting attachment is visible in the attachments list and can be handled as any other attachment: saved, and handled by mailcap. However, *opening* such an attachment via the attachment widget *will not display it* in the current proposal. Since these weren't attachments before, there's no need to handle them backwards-compatible with issue 3 above.

3. When a part gets selected via the mimetree, alot checks whether there is a separate `x-alot-openattachment` field defined in the mailcap. If there is, alot will first attempt to display the attachment as mimepart, and then open the attachment as per 2. I expect this to be the most controversial change.

Example mailcap entry:
```text/calendar; cat '%s'; x-alot-openattachment=tmux-horizontal-split-blocking.sh khal import '%s'; copiousoutput```