### PR TITLE
alot/settings: Use notmuch config to read configuration

### DIFF
--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -72,7 +72,7 @@ class DBManager:
             raise DatabaseROError()
         if self.writequeue:
             # read notmuch's config regarding imap flag synchronization
-            sync = settings.get_notmuch_setting('maildir', 'synchronize_flags')
+            sync = settings.get_notmuch_setting('maildir', 'synchronize_flags') == 'true'
 
             # go through writequeue entries
             while self.writequeue:

--- a/alot/defaults/notmuch.rc
+++ b/alot/defaults/notmuch.rc
@@ -1,3 +1,0 @@
-[maildir]
-synchronize_flags = False
-

--- a/alot/defaults/notmuch.rc.spec
+++ b/alot/defaults/notmuch.rc.spec
@@ -1,3 +1,0 @@
-[maildir]
-synchronize_flags = boolean(default=False)
-

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -32,7 +32,6 @@ class SettingsManager:
     def __init__(self):
         self.hooks = None
         self._mailcaps = mailcap.getcaps()
-        self._notmuchconfig = None
         self._theme = None
         self._accounts = None
         self._accountmap = None

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -17,7 +17,7 @@ from ..helper import pretty_datetime, string_decode, get_xdg_env
 from ..utils import configobj as checks
 
 from .errors import ConfigError, NoMatchingAccount
-from .utils import read_config
+from .utils import read_config, read_notmuch_config
 from .utils import resolve_att
 from .theme import Theme
 
@@ -36,12 +36,13 @@ class SettingsManager:
         self._accounts = None
         self._accountmap = None
         self._notmuchconfig = None
+        self._notmuchconfig_path = None
         self._config = ConfigObj()
         self._bindings = None
 
     def reload(self):
         """Reload notmuch and alot config files"""
-        self.read_notmuch_config(self._notmuchconfig.filename)
+        self.read_notmuch_config(self._notmuchconfig_path)
         self.read_config(self._config.filename)
 
     def read_notmuch_config(self, path):
@@ -50,8 +51,8 @@ class SettingsManager:
         :param path: path to notmuch's config file
         :type path: str
         """
-        spec = os.path.join(DEFAULTSPATH, 'notmuch.rc.spec')
-        self._notmuchconfig = read_config(path, spec)
+        self._notmuchconfig = read_notmuch_config(path)
+        self._notmuchconfig_path = path  # Set the path *after* succesful read.
 
     def _update_bindings(self, newbindings):
         assert isinstance(newbindings, Section)
@@ -275,7 +276,8 @@ class SettingsManager:
         :type key: str
         :param fallback: fallback returned if key is not present
         :type fallback: str
-        :returns: config value with type as specified in the spec-file
+        :returns: the config value
+        :rtype: str
         """
         value = None
         if section in self._notmuchconfig:

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
     package_data={
         'alot': [
             'defaults/alot.rc.spec',
-            'defaults/notmuch.rc.spec',
             'defaults/abook_contacts.spec',
             'defaults/default.theme',
             'defaults/default.bindings',


### PR DESCRIPTION
The main benefit from this is that we get the defaults directly from
notmuch and do not risk using inconsistent configuration values.

A good example of this is getting the database path. Getting the path
directly from the notmuch config file is not enough, because the user
might be using the default location with no explicit entry in the file.
Since notmuch does is a bit of logic notmuch to get the database path
(see section "DATABASE LOCATION" in man page for notmuch-config(1)), it
is better to get it directly from "notmuch config".

Since get_notmuch_setting() now always returns a string, also refactor
the call to settings.get_notmuch_setting('maildir', 'synchronize_flags')
for this new reality.

