### PR TITLE
commands: Do not try to escape quotes

### DIFF
--- a/alot/commands/__init__.py
+++ b/alot/commands/__init__.py
@@ -169,7 +169,6 @@ def commandfactory(cmdline, mode='global'):
     # allow to shellescape without a space after '!'
     if cmdline.startswith('!'):
         cmdline = 'shellescape \'%s\'' % cmdline[1:]
-    cmdline = re.sub(r'"(.*)"', r'"\\"\1\\""', cmdline)
     try:
         args = split_commandstring(cmdline)
     except ValueError as e:


### PR DESCRIPTION
Using `re.sub(r'"(.*)"', r'"\\"\1\\""', cmdline)` is wrong, as it would not work if we have multiple quoted fragments in the command line, for example: `search subject:"foo bar" and date:"this month"`.

Furthermore, there are other places using split_commandstring() - doing the escaping in just one place does not sound very consistent.

Just let shlex do its job. It is possible to use single quotes when needed. Using the example above, we can simply do `search subject:'"foo bar"' and date:'"this month"'`, which is what we would normally do when using notmuch from a shell.