### PR TITLE
Support env variables in mail_container path

### DIFF
--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -346,14 +346,16 @@ thread_focus_linewise = boolean(default=True)
         # sendmail command. This is the shell command used to send out mails via the sendmail protocol
         sendmail_command = string(default='sendmail -t')
 
-        # where to store outgoing mails, e.g. `maildir:///home/you/mail/Sent` or `maildir://~/mail/Sent`.
+        # where to store outgoing mails, e.g. `maildir:///home/you/mail/Sent`,
+        # `maildir://$MAILDIR/Sent` or `maildir://~/mail/Sent`.
         # You can use mbox, maildir, mh, babyl and mmdf in the protocol part of the URL.
         #
         # .. note:: If you want to add outgoing mails automatically to the notmuch index
         #           you must use maildir in a path within your notmuch database path.
         sent_box = mail_container(default=None)
 
-        # where to store draft mails, e.g. `maildir:///home/you/mail/Drafts` or `maildir://~/mail/Drafts`.
+        # where to store draft mails, e.g. `maildir:///home/you/mail/Drafts`,
+        # `maildir://$MAILDIR/Drafts` or `maildir://~/mail/Drafts`.
         # You can use mbox, maildir, mh, babyl and mmdf in the protocol part of the URL.
         #
         # .. note:: You will most likely want drafts indexed by notmuch to be able to

--- a/alot/utils/configobj.py
+++ b/alot/utils/configobj.py
@@ -106,7 +106,7 @@ def mail_container(value):
         }
     klass = uri_scheme_to_mbclass.get(mburl.scheme)
     if klass:
-        return klass(mburl.netloc + mburl.path)
+        return klass(os.path.expandvars(mburl.netloc + mburl.path))
     raise VdtTypeError(value)
 
 

--- a/docs/source/configuration/accounts.rst
+++ b/docs/source/configuration/accounts.rst
@@ -17,7 +17,7 @@ Here is an example configuration
             gpg_key = D7D6C5AA
             sendmail_command = msmtp --account=wayne -t
             sent_box = maildir:///home/bruce/mail/work/Sent
-            # ~ expansion also works
+            # ~, $VAR and ${VAR} expansion also work
             draft_box = maildir://~/mail/work/Drafts
 
         [[secret]]

--- a/docs/source/configuration/accounts_table
+++ b/docs/source/configuration/accounts_table
@@ -52,7 +52,8 @@
 
 .. describe:: draft_box
 
-     where to store draft mails, e.g. `maildir:///home/you/mail/Drafts` or `maildir://~/mail/Drafts`.
+     where to store draft mails, e.g. `maildir:///home/you/mail/Drafts`,
+     `maildir://$MAILDIR/Drafts` or `maildir://~/mail/Drafts`.
      You can use mbox, maildir, mh, babyl and mmdf in the protocol part of the URL.
 
      .. note:: You will most likely want drafts indexed by notmuch to be able to
@@ -177,7 +178,8 @@
 
 .. describe:: sent_box
 
-     where to store outgoing mails, e.g. `maildir:///home/you/mail/Sent` or `maildir://~/mail/Sent`.
+     where to store outgoing mails, e.g. `maildir:///home/you/mail/Sent`,
+     `maildir://$MAILDIR/Sent` or `maildir://~/mail/Sent`.
      You can use mbox, maildir, mh, babyl and mmdf in the protocol part of the URL.
 
      .. note:: If you want to add outgoing mails automatically to the notmuch index


### PR DESCRIPTION
Hey! 

I noticed that environment variable expansion did not work with `draft_box`. This patch will add that, and for `sent_box` too. (Implemented it in `mail_container`). The change itself is just 1 line, the rest is documentation.

I'd use this to have the same configuration on macOS and Linux, because my mail directory is in different places on these systems. 

Any feedback is of course welcome!