### PR TITLE
Fix configobj to relay tuple type errors

### DIFF
--- a/alot/utils/configobj.py
+++ b/alot/utils/configobj.py
@@ -78,13 +78,15 @@ def width_tuple(value):
     elif value[0] not in ['fit', 'weight']:
         raise VdtTypeError(value)
     if value[0] == 'fit':
-        if not isinstance(value[1], int) or not isinstance(value[2], int):
-            VdtTypeError(value)
-        res = 'fit', int(value[1]), int(value[2])
+        try:
+            res = 'fit', int(value[1]), int(value[2])
+        except (IndexError, ValueError):
+            raise VdtTypeError(value)
     else:
-        if not isinstance(value[1], int):
-            VdtTypeError(value)
-        res = 'weight', int(value[1])
+        try:
+            res = 'weight', int(value[1])
+        except (IndexError, ValueError):
+            raise VdtTypeError(value)
     return res
 
 

--- a/alot/utils/configobj.py
+++ b/alot/utils/configobj.py
@@ -77,16 +77,15 @@ def width_tuple(value):
         raise VdtTypeError(value)
     elif value[0] not in ['fit', 'weight']:
         raise VdtTypeError(value)
-    if value[0] == 'fit':
-        try:
+    try:
+        if value[0] == 'fit':
             res = 'fit', int(value[1]), int(value[2])
-        except (IndexError, ValueError):
-            raise VdtTypeError(value)
-    else:
-        try:
+        else:
             res = 'weight', int(value[1])
-        except (IndexError, ValueError):
-            raise VdtTypeError(value)
+    except IndexError:
+        raise VdtTypeError(value)
+    except ValueError:
+        raise VdtValueError(value)
     return res
 
 

--- a/tests/utils/test_configobj.py
+++ b/tests/utils/test_configobj.py
@@ -19,22 +19,33 @@ class TestForceList(unittest.TestCase):
         forced = checks.force_list('')
         self.assertEqual(forced, [])
 
+
+class TestWidthTuple(unittest.TestCase):
+
     def test_validates_width_tuple(self):
         with self.assertRaises(VdtTypeError):
             checks.width_tuple('invalid-value')
 
-    def test_validates_width_tuple_for_fit(self):
+    def test_validates_width_tuple_for_fit_requires_two_args(self):
         with self.assertRaises(VdtTypeError):
             checks.width_tuple(['fit', 123])
+
+    def test_args_for_fit_must_be_numbers(self):
         with self.assertRaises(VdtValueError):
             checks.width_tuple(['fit', 123, 'not-a-number'])
+
+    def test_fit_with_two_numbers(self):
         fit_result = checks.width_tuple(['fit', 123, 456])
         self.assertEqual(('fit', 123, 456), fit_result)
 
-    def test_validates_width_tuple_for_weight(self):
+    def test_validates_width_tuple_for_weight_needs_an_argument(self):
         with self.assertRaises(VdtTypeError):
             checks.width_tuple(['weight'])
+
+    def test_arg_for_width_must_be_a_number(self):
         with self.assertRaises(VdtValueError):
             checks.width_tuple(['weight', 'not-a-number'])
+
+    def test_width_with_a_number(self):
         weight_result = checks.width_tuple(['weight', 123])
         self.assertEqual(('weight', 123), weight_result)

--- a/tests/utils/test_configobj.py
+++ b/tests/utils/test_configobj.py
@@ -19,10 +19,11 @@ class TestForceList(unittest.TestCase):
         forced = checks.force_list('')
         self.assertEqual(forced, [])
 
-    def test_validates_width_tuple_fit(self):
+    def test_validates_width_tuple(self):
         with self.assertRaises(VdtTypeError):
             checks.width_tuple('invalid-value')
 
+    def test_validates_width_tuple_for_fit(self):
         with self.assertRaises(VdtTypeError):
             checks.width_tuple(['fit', 123])
         with self.assertRaises(VdtValueError):
@@ -30,6 +31,7 @@ class TestForceList(unittest.TestCase):
         fit_result = checks.width_tuple(['fit', 123, 456])
         self.assertEqual(('fit', 123, 456), fit_result)
 
+    def test_validates_width_tuple_for_weight(self):
         with self.assertRaises(VdtTypeError):
             checks.width_tuple(['weight'])
         with self.assertRaises(VdtValueError):

--- a/tests/utils/test_configobj.py
+++ b/tests/utils/test_configobj.py
@@ -2,6 +2,7 @@
 import unittest
 
 from alot.utils import configobj as checks
+from validate import VdtTypeError, VdtValueError
 
 # Good descriptive test names often don't fit PEP8, which is meant to cover
 # functions meant to be called by humans.
@@ -17,3 +18,21 @@ class TestForceList(unittest.TestCase):
     def test_empty_strings_are_converted_to_empty_lists(self):
         forced = checks.force_list('')
         self.assertEqual(forced, [])
+
+    def test_validates_width_tuple_fit(self):
+        with self.assertRaises(VdtTypeError):
+            checks.width_tuple('invalid-value')
+
+        with self.assertRaises(VdtTypeError):
+            checks.width_tuple(['fit', 123])
+        with self.assertRaises(VdtValueError):
+            checks.width_tuple(['fit', 123, 'not-a-number'])
+        fit_result = checks.width_tuple(['fit', 123, 456])
+        self.assertEqual(('fit', 123, 456), fit_result)
+
+        with self.assertRaises(VdtTypeError):
+            checks.width_tuple(['weight'])
+        with self.assertRaises(VdtValueError):
+            checks.width_tuple(['weight', 'not-a-number'])
+        weight_result = checks.width_tuple(['weight', 123])
+        self.assertEqual(('weight', 123), weight_result)


### PR DESCRIPTION
Some current config tuple checking is of the form:

```python
if not isinstance(value[1], int) or not isinstance(value[2], int):
    VdtTypeError(value)
```

This has two problems. The first is that `isinstance('123', int)` is always `False`, which means the if's block always runs. A `VdtTypeError` would always be raised except that the `raise` keyword is missing.

This PR attempts to fix that issue.