### PR TITLE
Fix default hooks config path to conform to XDG

### DIFF
--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -112,7 +112,7 @@ edit_headers_blacklist = force_list(default=list(Content-Type,MIME-Version,Refer
 flush_retry_timeout = integer(default=5)
 
 # where to look up hooks
-hooksfile = string(default='~/.config/alot/hooks.py')
+hooksfile = string(default='$XDG_CONFIG_HOME/alot/hooks.py')
 
 # time in secs to display status messages
 notify_timeout = integer(default=2)


### PR DESCRIPTION
Hey!

A very small patch that makes the default value for the hooks file use `$XDG_CONFIG_HOME` instead of `~/.config`. The previous behaviour was non-conforming.

I did not update the documentation because of two reasons:

* The documentation is currently inconsistent in calling out env variable support. so adding it should probably be in a different commit.
* the table in `docs/source/api/settings.rst` would get a bit wider and thus unreadable in my editor.