### PR TITLE
Properly sanitize control chars in subject/headers/body

### DIFF
--- a/alot/db/thread.py
+++ b/alot/db/thread.py
@@ -3,8 +3,10 @@
 # For further details see the COPYING file
 from datetime import datetime
 
+from ..helper import string_sanitize
 from .message import Message
 from ..settings.const import settings
+from .utils import decode_header
 
 
 class Thread:
@@ -44,11 +46,11 @@ class Thread:
 
         subject_type = settings.get('thread_subject')
         if subject_type == 'notmuch':
-            subject = thread.subject
+            subject = string_sanitize(thread.subject)
         elif subject_type == 'oldest':
             try:
                 first_msg = list(thread.toplevel())[0]
-                subject = first_msg.header('subject')
+                subject = decode_header(first_msg.header('subject'))
             except (IndexError, LookupError):
                 subject = ''
         self._subject = subject

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -12,6 +12,7 @@ import os
 import re
 import shlex
 import subprocess
+import unicodedata
 import email
 from email.mime.audio import MIMEAudio
 from email.mime.base import MIMEBase
@@ -41,6 +42,17 @@ def split_commandstring(cmdstring):
     return shlex.split(cmdstring)
 
 
+def unicode_printable(c):
+    """
+    Checks if the given character is a printable Unicode character, i.e., not a
+    private/unassigned character and not a control character other than tab or
+    newline.
+    """
+    if c in ('\n', '\t'):
+        return True
+    return unicodedata.category(c) not in ('Cc', 'Cn', 'Co')
+
+
 def string_sanitize(string, tab_width=8):
     r"""
     strips, and replaces non-printable characters
@@ -57,7 +69,7 @@ def string_sanitize(string, tab_width=8):
     'foo             bar'
     """
 
-    string = string.replace('\r', '')
+    string = ''.join([c for c in string if unicode_printable(c)])
 
     lines = list()
     for line in string.split('\n'):

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -167,6 +167,12 @@ class TestStringSanitize(unittest.TestCase):
         actual = helper.string_sanitize(base)
         self.assertEqual(actual, expected)
 
+    def test_control_characters(self):
+        base = 'foo\u009dbar\u0007\rtest'
+        expected = 'foobartest'
+        actual = helper.string_sanitize(base)
+        self.assertEqual(actual, expected)
+
 
 class TestStringDecode(unittest.TestCase):
 


### PR DESCRIPTION
I recently noticed that some messages (primarily spam) contain [control characters](https://www.compart.com/en/unicode/category/Cc) that result in garbled output in both the search widget and the thread view. This PR addresses this by

1. removing all unwanted control characters (and not just CR) from strings before outputting and
2. applying string_sanitize() to subjects in the search widget.