### PR TITLE
editnew: Use raw body text instead of rendered version

### DIFF
--- a/alot/commands/thread.py
+++ b/alot/commands/thread.py
@@ -466,7 +466,7 @@ class EditNewCommand(Command):
                                 'signed', 'encrypted', 'unread', 'attachment'})
         tags = list(tags)
         # set body text
-        mailcontent = self.message.get_body_text()
+        mailcontent = self.message.get_body_text(render=False)
         envelope = Envelope(bodytext=mailcontent, tags=tags)
 
         # copy selected headers

--- a/alot/db/message.py
+++ b/alot/db/message.py
@@ -282,9 +282,9 @@ class Message:
     def set_mime_part(self, mime_part):
         self._mime_part = mime_part
 
-    def get_body_text(self):
+    def get_body_text(self, render=True):
         """ returns bodystring extracted from this mail """
-        return extract_body_part(self.get_mime_part())
+        return extract_body_part(self.get_mime_part(), render=render)
 
     def matches(self, querystring):
         """tests if this messages is in the resultset for `querystring`"""

--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -491,13 +491,23 @@ def get_body_part(mail, mimetype=None):
     return body_part
 
 
-def extract_body_part(body_part):
-    """Returns a string view of a Message."""
+def extract_body_part(body_part, render=True):
+    """
+    Returns a string view of a Message.
+
+    :param render: If true (the default), try to render the content with
+                   `render_part`; otherwise skip rendering.
+    :type render: bool
+    """
     displaystring = ""
-    rendered_payload = render_part(
-        body_part,
-        **{'field_key': 'view'} if body_part.get_content_type() == 'text/plain'
-        else {})
+    if render:
+        rendered_payload = render_part(
+            body_part,
+            **{'field_key': 'view'} if body_part.get_content_type() == 'text/plain'
+            else {})
+    else:
+        rendered_payload = None
+
     if rendered_payload:  # handler had output
         displaystring = string_sanitize(rendered_payload)
     elif body_part.get_content_type() == 'text/plain':


### PR DESCRIPTION
Rendering mail content via mailcap makes sense when viewing email, but not when reusing the email for composing a new message, as it is desirable to rather edit the "original" content and, if mailcap rendering produces ANSI CSI escapes, the user would be left with a bunch of garbarge characters.

Make sure that the editnew command do not render the body when creating the envelope.