### PR TITLE
Add github action to check the nix build

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: Run code checks
+name: Run code checks with different build tools
 
 on:
   - push
@@ -6,7 +6,7 @@ on:
 
 jobs:
 
-  check:
+  poetry:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -28,3 +28,15 @@ jobs:
 
       - name: Run check "${{ matrix.check }}"
         run: "${{ matrix.check }}"
+
+  nix-flake:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install Nix
+      uses: cachix/install-nix-action@v22
+
+    - uses: actions/checkout@v4
+
+    - name: Build the nix derivation (also runs the tests)
+      run: nix build --print-build-logs

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,6 +7,11 @@ on:
 jobs:
 
   poetry:
+
+    # TODO remove this line after the gpg dependency problem from #1630 and
+    # c1137ea9 is fixed. Until then these checks are deactivated.
+    if: false
+
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,6 +31,12 @@ jobs:
 
   nix-flake:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        derivation:
+          - default
+          - docs
 
     steps:
     - name: Install Nix
@@ -38,5 +44,5 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Build the nix derivation (also runs the tests)
-      run: nix build --print-build-logs
+    - name: Build the ${{ matrix.derivation }} derivation
+      run: 'nix build --print-build-logs .\#${{ matrix.derivation }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,10 +60,9 @@ jobs:
         run: >
           sed -Ei
           -e '1iimport unittest'
-          -e 's/^(\s*)(async )?def test_(no_spawn_no_stdin_attached|save_named_query|parsing_notmuch_config_with_non_bool_synchronize_flag_fails)/\1@unittest.skip("broken in ci")\n&/'
+          -e 's/^(\s*)(async )?def test_(no_spawn_no_stdin_attached|save_named_query)/\1@unittest.skip("broken in ci")\n&/'
           tests/commands/test_global.py
           tests/db/test_manager.py
-          tests/settings/test_manager.py
 
       - name: Run tests
         run: python3 -m unittest --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,10 +59,8 @@ jobs:
       - name: disable some tests that don't work in CI
         run: >
           sed -Ei
-          -e '1iimport unittest'
-          -e 's/^(\s*)(async )?def test_(no_spawn_no_stdin_attached|save_named_query)/\1@unittest.skip("broken in ci")\n&/'
+          -e 's/^(\s*)async def test_no_spawn_no_stdin_attached/\1@unittest.skip("broken in ci")\n&/'
           tests/commands/test_global.py
-          tests/db/test_manager.py
 
       - name: Run tests
         run: python3 -m unittest --verbose

--- a/.github/workflows/test.yml-broken
+++ b/.github/workflows/test.yml-broken
@@ -1,3 +1,10 @@
+# WARNING: This workflow is deactivated until the gpg dependency problem from
+# issue 1630 (see
+# https://github.com/pazz/alot/issues/1630#issuecomment-1938174029 and
+# onwards) is fixed.  The problem was introduced in c1137ea9: the gpg
+# dependency is required with version > 1.10.0 and such a version is not
+# currently available on PyPI but must be build from hand.
+
 name: Run tests
 
 on:

--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -51,9 +51,7 @@ class DBManager:
         if exclude_tags is not None:
             return exclude_tags
 
-        exclude_tags = settings.get_notmuch_setting('search', 'exclude_tags')
-        if exclude_tags:
-            return [t for t in exclude_tags.split(';') if t]
+        return settings.get_notmuch_setting('search', 'exclude_tags')
 
     def flush(self):
         """
@@ -72,7 +70,7 @@ class DBManager:
             raise DatabaseROError()
         if self.writequeue:
             # read notmuch's config regarding imap flag synchronization
-            sync = settings.get_notmuch_setting('maildir', 'synchronize_flags') == 'true'
+            sync = settings.get_notmuch_setting('maildir', 'synchronize_flags')
 
             # go through writequeue entries
             while self.writequeue:

--- a/alot/helper.py
+++ b/alot/helper.py
@@ -285,7 +285,7 @@ def call_cmd(cmdlist, stdin=None):
     return out, err, ret
 
 
-async def call_cmd_async(cmdlist, stdin=None, env=None):
+async def call_cmd_async(cmdlist, stdin=None):
     """Given a command, call that command asynchronously and return the output.
 
     This function only handles `OSError` when creating the subprocess, any
@@ -305,15 +305,10 @@ async def call_cmd_async(cmdlist, stdin=None, env=None):
     termenc = urwid.util.detected_encoding
     cmdlist = [s.encode(termenc) for s in cmdlist]
 
-    environment = os.environ.copy()
-    if env is not None:
-        environment.update(env)
-    logging.debug('ENV = %s', environment)
     logging.debug('CMD = %s', cmdlist)
     try:
         proc = await asyncio.create_subprocess_exec(
             *cmdlist,
-            env=environment,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             stdin=asyncio.subprocess.PIPE if stdin else None)

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,8 @@
               notmuch2 = pkgs.python3.pkgs.notmuch2;
             });
 
+            nativeCheckInputs = with pkgs; [ gnupg notmuch procps ];
+            checkPhase = "python3 -m unittest -v";
           };
           default = self.packages.${system}.alot;
         };

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,13 @@
             });
 
             nativeCheckInputs = with pkgs; [ gnupg notmuch procps ];
-            checkPhase = "python3 -m unittest -v";
+            checkPhase = ''
+              # In the nix sandbox stdin is not a terminal but /dev/null so we
+              # change the shell command only in this specific test.
+              sed -i '/test_no_spawn_no_stdin_attached/,/^$/s/test -t 0/sh -c "[ $(wc -l) -eq 0 ]"/' tests/commands/test_global.py
+
+              python3 -m unittest -v
+            '';
           };
           default = self.packages.${system}.alot;
         };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,12 @@ pycodestyle = "*"
 pytest = "*"
 sphinx = "*"
 
+[tool.poetry.group.doc]
+optional = true
+
+[tool.poetry.group.doc.dependencies]
+sphinx = "*"
+
 [tool.poetry.scripts]
 alot = "alot.__main__:main"
 

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -739,9 +739,9 @@ class TestExtractBodyPart(unittest.TestCase):
     @mock.patch('alot.db.utils.settings.mailcap_find_match',
                 mock.Mock(return_value=(None, None)))
     def test_simple_utf8_file(self):
-        mail = email.message_from_binary_file(
-                open('tests/static/mail/utf8.eml', 'rb'),
-                _class=email.message.EmailMessage)
+        with open('tests/static/mail/utf8.eml', 'rb') as f:
+            mail = email.message_from_binary_file(
+                f, _class=email.message.EmailMessage)
         body_part = utils.get_body_part(mail)
         actual = utils.extract_body_part(body_part)
         expected = "Liebe Grüße!\n"
@@ -757,9 +757,9 @@ class TestExtractBodyPart(unittest.TestCase):
 
         https://github.com/pazz/alot/issues/1522
         """
-        mail = email.message_from_binary_file(
-                open('tests/static/mail/utf8.eml', 'rb'),
-                _class=email.message.EmailMessage)
+        with open('tests/static/mail/utf8.eml', 'rb') as f:
+            mail = email.message_from_binary_file(
+                f, _class=email.message.EmailMessage)
         body_part = utils.get_body_part(mail)
         actual = utils.extract_body_part(body_part)
         expected = "Liebe Grüße?\n"

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -423,23 +423,6 @@ class TestCallCmdAsync(unittest.TestCase):
         self.assertEqual(ret[0], 'foo')
 
     @utilities.async_test
-    async def test_env_set(self):
-        with mock.patch.dict(os.environ, {}, clear=True):
-            ret = await helper.call_cmd_async(
-                ['python3', '-c', 'import os; '
-                                  'print(os.environ.get("foo", "fail"), end="")'
-                ],
-                env={'foo': 'bar'})
-        self.assertEqual(ret[0], 'bar')
-
-    @utilities.async_test
-    async def test_env_doesnt_pollute(self):
-        with mock.patch.dict(os.environ, {}, clear=True):
-            await helper.call_cmd_async(['echo', '-n', 'foo'],
-                                        env={'foo': 'bar'})
-            self.assertEqual(os.environ, {})
-
-    @utilities.async_test
     async def test_command_fails(self):
         _, err, ret = await helper.call_cmd_async(['_____better_not_exist'])
         self.assertEqual(ret, 1)


### PR DESCRIPTION
This adds CI jobs to run the nix build of alot and also a second nix target with a ci job to build the sphinx docs.

Some test are fixed or removed, see commit messages.  The last question about the fixed test is https://github.com/pazz/alot/pull/1653#issuecomment-2094563736

The plan behind this is that we have *some* CI that is green until the pip/poetry installation of alot is fixed again and our other CI jobs can be trusted.  And also to check that the nix code works correctly because I personally rely on it.

