### PR TITLE
Set the locale to the user’s default setting

### DIFF
--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -2,6 +2,7 @@
 # This file is released under the GNU GPL, version 3 or a later revision.
 # For further details see the COPYING file
 import argparse
+import locale
 import logging
 import os
 import sys
@@ -85,6 +86,9 @@ def main():
     """The main entry point to alot.  It parses the command line and prepares
     for the user interface main loop to run."""
     options, command = parser()
+
+    # locale
+    locale.setlocale(locale.LC_ALL, '')
 
     # logging
     root_logger = logging.getLogger()


### PR DESCRIPTION
According to POSIX, a program which has not called `setlocale(LC_ALL, '')` runs using the portable 'C' locale. Calling `setlocale(LC_ALL, '')` lets it use the default locale as defined by the LANG variable.

Source: https://docs.python.org/3/library/locale.html#locale.getdefaultlocale

Applications typically start with a call of

```python
import locale
locale.setlocale(locale.LC_ALL, '')
```

Source: https://docs.python.org/3/library/locale.html#locale.setlocale

Setting the locale fixes the detection of 24h format.

### Details

`pretty_datetime` function checks if `time.strftime("%p")` is empty for branching between 12h / 24h:

 https://github.com/pazz/alot/blob/3a3fc88deaaf134c3f2b583ca852f37afbf447e5/alot/helper.py#L216-L217
 
 According to the documentation above, the locale falls back to C and the format is always 12h. Here is the program to check the behavior:

#### Before

```python
import datetime
import locale

print(locale.getlocale(locale.LC_TIME))
print(datetime.datetime.now().strftime("%p"))
```
Output:
```console
$ LANG=cs_CZ.UTF-8 python ~/prg/python/time.py 
(None, None)
PM
```

#### After


```python
import datetime
import locale

locale.setlocale(locale.LC_ALL, '')    
print(locale.getlocale(locale.LC_TIME))
print(datetime.datetime.now().strftime("%p"))
```
Output:
```console
$ LANG=cs_CZ.UTF-8 python ~/prg/python/time.py 
('cs_CZ', 'UTF-8')

```
Note that the format is blank.
```
$ python --version
Python 3.11.8
```