### PR TITLE
Update ci badge in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status][travis-img]][travis]
+[![Build Status]][ghactions]
 [![Code Climate][codeclimate-img]][codeclimate]
 [![Codacy Grade][codacy-grade-img]][codacy-grade]
 [![Codacy Coverage][codacy-coverage-img]][codacy-coverage]
@@ -59,8 +59,8 @@ See the [manual][docs] for more usage info.
 [FAQ]: http://alot.readthedocs.io/en/latest/faq.html
 [features]: https://github.com/pazz/alot/issues?labels=feature
 
-[travis]: https://travis-ci.com/pazz/alot
-[travis-img]: https://travis-ci.com/pazz/alot.svg?branch=master
+[Build Status]: https://github.com/pazz/alot/actions/workflows/check.yml/badge.svg
+[ghactions]: https://github.com/pazz/alot/actions
 [codacy-coverage]: https://www.codacy.com/app/patricktotzke/alot?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=pazz/alot&amp;utm_campaign=Badge_Coverage
 [codacy-coverage-img]: https://api.codacy.com/project/badge/Coverage/fa7c4a567cd546568a12e88c57f9dbd6
 [codacy-grade]: https://www.codacy.com/app/patricktotzke/alot?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=pazz/alot&amp;utm_campaign=Badge_Grade


### PR DESCRIPTION
The badge did still point to travis which is not used any longer.  The new batch points to our github actions and shows the status of the action in the check.yml file.

It looks like this: https://github.com/pazz/alot/tree/readme-badge?tab=readme-ov-file
Sadly the text can not be controlled on the badge but is copied from the workflow file's `name` field.