### PR TITLE
Fix spawn tests in different environments

### DIFF
--- a/.github/workflows/test.yml-broken
+++ b/.github/workflows/test.yml-broken
@@ -61,13 +61,5 @@ jobs:
       - name: Install dependencies
         run: pip install .
 
-      # These tests seem to fail on github's CI, we should fix these tests in
-      # some less hacky way
-      - name: disable some tests that don't work in CI
-        run: >
-          sed -Ei
-          -e 's/^(\s*)async def test_no_spawn_no_stdin_attached/\1@unittest.skip("broken in ci")\n&/'
-          tests/commands/test_global.py
-
       - name: Run tests
         run: python3 -m unittest --verbose

--- a/flake.nix
+++ b/flake.nix
@@ -36,10 +36,6 @@
 
             nativeCheckInputs = with pkgs; [ gnupg notmuch procps ];
             checkPhase = ''
-              # In the nix sandbox stdin is not a terminal but /dev/null so we
-              # change the shell command only in this specific test.
-              sed -i '/test_no_spawn_no_stdin_attached/,/^$/s/test -t 0/sh -c "[ $(wc -l) -eq 0 ]"/' tests/commands/test_global.py
-
               python3 -m unittest -v
             '';
           });

--- a/tests/commands/test_global.py
+++ b/tests/commands/test_global.py
@@ -124,19 +124,19 @@ class TestExternalCommand(unittest.TestCase):
     @utilities.async_test
     async def test_no_spawn_no_stdin_attached(self):
         ui = utilities.make_ui()
-        cmd = g_commands.ExternalCommand('test -t 0', refocus=False)
+        cmd = g_commands.ExternalCommand('test -p /dev/stdin', refocus=False)
         await cmd.apply(ui)
-        ui.notify.assert_not_called()
+        ui.notify.assert_called_once_with(
+                'editor has exited with error code 1 -- No stderr output',
+                priority='error')
 
     @utilities.async_test
     async def test_no_spawn_stdin_attached(self):
         ui = utilities.make_ui()
         cmd = g_commands.ExternalCommand(
-            "test -t 0", stdin='0', refocus=False)
+            "test -p /dev/stdin", stdin='0', refocus=False)
         await cmd.apply(ui)
-        ui.notify.assert_called_once_with(
-                'editor has exited with error code 1 -- No stderr output',
-                priority='error')
+        ui.notify.assert_not_called()
 
     @utilities.async_test
     async def test_no_spawn_failure(self):


### PR DESCRIPTION
We are running our tests in different environments, sometimes with a terminal as stdin and sometimes with /dev/null as stdin.  Both are seen as "not a pipe" by `test -p` so we use that to test if our python code redirects text into an external process.

This fixes #1580.

This pull request is based on my comment https://github.com/pazz/alot/issues/1580#issuecomment-2258138340
