### PR TITLE
nix: install support files

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,8 +34,15 @@
               urwid
               urwidtrees
             ];
+            postPatch = ''
+              substituteInPlace alot/settings/manager.py \
+                --replace /usr/share "$out/share"
+            '';
             postInstall = ''
               installShellCompletion --zsh --name _alot extra/completion/alot-completion.zsh
+              mkdir -p $out/share/{applications,alot}
+              cp -r extra/themes $out/share/alot
+              sed "s,/usr/bin,$out/bin,g" extra/alot.desktop > $out/share/applications/alot.desktop
             '';
             checkPhase = ''
               # In the nix sandbox stdin is not a terminal but /dev/null so we


### PR DESCRIPTION
This makes our  nix derivation usable not only as a development environment but also for installation in a nix based system and daily use. 

(I am installig the current master of alot on my home computer through this way and would like to have these goodies)