### PR TITLE
nix: parse dependencies from pyproject file

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,8 +8,12 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        # we want to extract some metadata and especially the dependencies
+        # from the pyproject file, like this we do not have to maintain the
+        # list a second time
         pyproject = pkgs.lib.trivial.importTOML ./pyproject.toml;
-        # get a list of python packages by name
+        # get a list of python packages by name, used to get the nix packages
+        # for the dependency names from the pyproject file
         getPkgs = names: builtins.attrValues (pkgs.lib.attrsets.getAttrs names pkgs.python3Packages);
         # extract the python dependencies from the pyprojec file, cut the version constraint
         dependencies' = pkgs.lib.lists.concatMap (builtins.match "([^>=<]*).*") pyproject.project.dependencies;


### PR DESCRIPTION
@pazz this is the result of my comment https://github.com/pazz/alot/issues/1666#issuecomment-2270396622 . This makes the nix code a little more complicated but removes the need to specify our dependencies twice.  As I know nix quite well I like it but I am unsure if it raises the bar for others to look at the nix code (do we care about that?). What do you think?