### PR TITLE
Make hooks optional

### DIFF
--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -112,7 +112,7 @@ edit_headers_blacklist = force_list(default=list(Content-Type,MIME-Version,Refer
 flush_retry_timeout = integer(default=5)
 
 # where to look up hooks
-hooksfile = string(default='$XDG_CONFIG_HOME/alot/hooks.py')
+hooksfile = string(default=None)
 
 # time in secs to display status messages
 notify_timeout = integer(default=2)

--- a/alot/settings/manager.py
+++ b/alot/settings/manager.py
@@ -77,13 +77,21 @@ class SettingsManager:
         self._config.merge(newconfig)
         self._config.walk(self._expand_config_values)
 
-        hooks_path = os.path.expanduser(self._config.get('hooksfile'))
-        try:
-            spec = importlib.util.spec_from_file_location('hooks', hooks_path)
-            self.hooks = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(self.hooks)
-        except:
-            logging.exception('unable to load hooks file:%s', hooks_path)
+        # set up hooks module if requested
+        hooks_path = self._config.get('hooksfile')
+        if hooks_path:
+            hooks_path = os.path.expanduser(hooks_path)
+            logging.debug('hooks: loading from: %s', hooks_path)
+            try:
+                spec = importlib.util.spec_from_file_location('hooks',
+                                                              hooks_path)
+                self.hooks = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(self.hooks)
+            except:
+                logging.exception('unable to load hooks file:%s', hooks_path)
+        else:
+            logging.debug('hooks: hooksfile config option is unset')
+
         if 'bindings' in newconfig:
             self._update_bindings(newconfig['bindings'])
 

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -385,7 +385,7 @@
      where to look up hooks
 
     :type: string
-    :default: "~/.config/alot/hooks.py"
+    :default: None
 
 
 .. _initial-command:

--- a/docs/source/configuration/hooks.rst
+++ b/docs/source/configuration/hooks.rst
@@ -3,7 +3,11 @@
 Hooks
 =====
 Hooks are python callables that live in a module specified by `hooksfile` in
-the config. Per default this points to :file:`~/.config/alot/hooks.py`.
+the config. 
+
+.. versionadded:: 0.11
+   in newer versions of alot, `hooksfile` does *not* default to :file:`~/.config/alot/hooks.py`
+   but instead needs to be explicitly set if you want to use hooks.
 
 Pre/Post Command Hooks
 ----------------------


### PR DESCRIPTION
This changes the default setting of the 'hooksfile' setting and associated behaviour so that, unless explicitly set, this config setting defaults to `None`, which then means loading the hooksfile is not even attempted.

Prior to this commit, the default value was
`$XDG_CONFIG_HOME/alot/hooks.py`
and no alot would try to read that file upon start (and report via logging.exception if it failed, which in the ui is uncritical).

This was problematic not only in that it hardcodes the unix separator '/' but also because it caused unecessary disk access / errors. More importantly, it caused several test cases to fail (see [here](https://bugs.gentoo.org/874372#c2).

The patch also includes updated docs.