### PR TITLE
notmuch2 copatibility

### DIFF
--- a/alot/__main__.py
+++ b/alot/__main__.py
@@ -124,7 +124,8 @@ def main():
     # get ourselves a database manager
     indexpath = settings.get_notmuch_setting('database', 'path')
     indexpath = options.mailindex_path or indexpath
-    dbman = DBManager(path=indexpath, ro=options.read_only)
+    dbman = DBManager(path=indexpath, ro=options.read_only,
+                      config=options.notmuch_config)
 
     # determine what to do
     if command is None:

--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -39,7 +39,7 @@ class DBManager:
         :type path: str
         :param ro: open the index in read-only mode
         :type ro: bool
-        :param path: absolute path to the notmuch config file
+        :param config: absolute path to the notmuch config file
         :type path: str
         """
         self.ro = ro
@@ -83,7 +83,7 @@ class DBManager:
                 # watch out for notmuch errors to re-insert current_item
                 # to the queue on errors
                 try:
-                    # the first two coordinants are cnmdname and post-callback
+                    # the first two coordinates are cnmdname and post-callback
                     cmd, afterwards = current_item[:2]
                     logging.debug('cmd created')
 


### PR DESCRIPTION
This change causes alot to pass on the "notmuch-config" option (path to notmuch's configuration file) to any call to `Database(..)` in the underlying database.

#1597