### PR TITLE
Fix build on RTD with dynamic version

### DIFF
--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -7,6 +7,17 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
+  apt_packages:
+    - libmagic # for python-magic
+  jobs:
+    # remove and mock problematic dependencies
+    pre_install:
+      - sed -i '/gpg/d;/notmuch2/d' pyproject.toml
+      - touch gpg.py
+      - echo NullPointerError = NotmuchError = None > notmuch2.py
+    # make the git state clean again for setuptools_scm
+    post_install:
+      - git checkout pyproject.toml
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:


### PR DESCRIPTION
I think this should do it.

@pazz  I took the liberty to also push this branch to the "rtd" branch as that still looks activated on RTD. So I hope to get a build of this branch on RTD (maybe you can check and if neccesary activate the dversion or dversion2 branch on RTD).