### PR TITLE
Fix return type of message without a preferred body

### DIFF
--- a/alot/db/utils.py
+++ b/alot/db/utils.py
@@ -476,7 +476,7 @@ def get_body_part(mail, mimetype=None):
     :param mail: the mail to use
     :type mail: :class:`email.message.EmailMessage`
     :returns: The combined text of any parts to be used
-    :rtype: str
+    :rtype: :class:`email.message.EmailMessage`
     """
 
     if not mimetype:
@@ -486,7 +486,9 @@ def get_body_part(mail, mimetype=None):
 
     body_part = mail.get_body(preferencelist)
     if body_part is None:  # if no part matching preferredlist was found
-        return ""
+        empty = email.message.EmailMessage()
+        empty.set_payload("")
+        return empty
 
     return body_part
 


### PR DESCRIPTION
The `get_body(...)` call (and hence the nominal return of the `get_body_part(...)` method) returns a email.message.EmailMessage. So if there is no body return an empty such class instead of a string, because the callers expects that it behaves like a message. E.g.:

      File "alot/db/utils.py", line 499, in extract_body_part
        **{'field_key': 'view'} if body_part.get_content_type() == 'text/plain'
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
    AttributeError: 'str' object has no attribute 'get_content_type'


Someone sent me a message where the body was some encapsulated message. I still have not gotten it rendered properly, but showing up as an empty message is at least better than crashing alot