### PR TITLE
Add `.git_archival.txt`

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst


### PR DESCRIPTION
The `sdist` source does not include all file relevant to Fedora packaging, particularly the `docs` folder that is used to generate the `man` pages. Therefore we need to use the git archive, but for this the `.git_archival.txt` file is missing: https://setuptools-scm.readthedocs.io/en/latest/usage/#git-archives