### PR TITLE
Support Python 3.13's removal of mailcap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "python-magic",
     "configobj>=4.7.0",
     "gpg>1.10.0",
+    "standard-mailcap; python_version>'3.12'"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Python 3.13 removed the dead battery mailcap and it is now offered on PyPi. This is temporarily workaround.

Related: #1632