### PR TITLE
Run test on python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
As we have a temporary fix for #1632 now we should run our tests on python 3.13.

I am still working on packaging the standard-mailcap package on nixpkgs. If that is finished I would like to use python 3.13 for the nix code as well. This PR will be a draft until then.