### PR TITLE
fix default-theme to correctly highlight focused attachments

### DIFF
--- a/alot/defaults/default.theme
+++ b/alot/defaults/default.theme
@@ -32,7 +32,7 @@
     arrow_heads = '','','dark red','','#a00',''
     arrow_bars = '','','dark red','','#800',''
     attachment = 'default','','light gray','dark gray','light gray','dark gray'
-    attachment_focus = 'underline','','light gray','light green','light gray','light green'
+    attachment_focus = 'underline','','dark gray','light green','dark gray','light green'
     body = 'default','','default','default','default','default'
     body_focus = 'default','','default,standout','default','default,standout','default'
     header = 'default','','white','dark gray','white','dark gray'

--- a/alot/defaults/default.theme
+++ b/alot/defaults/default.theme
@@ -32,7 +32,7 @@
     arrow_heads = '','','dark red','','#a00',''
     arrow_bars = '','','dark red','','#800',''
     attachment = 'default','','light gray','dark gray','light gray','dark gray'
-    attachment_focus = 'underline','','light gray','light green','light gray','dark gray'
+    attachment_focus = 'underline','','light gray','light green','light gray','light green'
     body = 'default','','default','default','default','default'
     body_focus = 'default','','default,standout','default','default,standout','default'
     header = 'default','','white','dark gray','white','dark gray'


### PR DESCRIPTION
e90da9b3da225683c0ab6e8890ebda916d3c4d97 broke the highlighting of focused_attachments.

This PR resets the faulty value in question to its prior color.