### PR TITLE
Introduce a configurable thread search limit

### DIFF
--- a/alot/buffers/search.py
+++ b/alot/buffers/search.py
@@ -18,12 +18,14 @@ class SearchBuffer(Buffer):
     _REVERSE = {'oldest_first': 'newest_first',
                 'newest_first': 'oldest_first'}
 
-    def __init__(self, ui, initialquery='', sort_order=None):
+    def __init__(self, ui, initialquery='', sort_order=None, limit=None):
         self.dbman = ui.dbman
         self.ui = ui
         self.querystring = initialquery
         default_order = settings.get('search_threads_sort_order')
         self.sort_order = sort_order or default_order
+        default_limit = settings.get('search_threads_limit')
+        self.limit = limit if limit is not None else default_limit
         self.result_count = 0
         self.search_threads_rebuild_limit = \
             settings.get('search_threads_rebuild_limit')
@@ -60,8 +62,8 @@ class SearchBuffer(Buffer):
             selected_thread = self.get_selected_thread()
 
         try:
-            self.result_count = self.dbman.count_messages(self.querystring)
-            threads = self.dbman.get_threads(self.querystring, order)
+            threads, self.result_count = self.dbman.get_threads(
+                self.querystring, order, self.limit)
         except NotmuchError:
             self.ui.notify('malformed query string: %s' % self.querystring,
                            'error')

--- a/alot/commands/globals.py
+++ b/alot/commands/globals.py
@@ -91,6 +91,7 @@ class ExitCommand(Command):
 @registerCommand(MODE, 'search', usage='search query', arguments=[
     (['--sort'], {'help': 'sort order', 'choices': [
         'oldest_first', 'newest_first', 'message_id', 'unsorted']}),
+    (['--limit'], {'help': 'limit number of results', 'type': int}),
     (['query'], {'nargs': argparse.REMAINDER, 'help': 'search string'})])
 class SearchCommand(Command):
 
@@ -98,7 +99,7 @@ class SearchCommand(Command):
     :ref:`search.exclude_tags <search.exclude_tags>` setting."""
     repeatable = True
 
-    def __init__(self, query, sort=None, **kwargs):
+    def __init__(self, query, sort=None, limit=None, **kwargs):
         """
         :param query: notmuch querystring
         :type query: str
@@ -106,9 +107,12 @@ class SearchCommand(Command):
                      'oldest_first', 'newest_first', 'message_id' or
                      'unsorted'.
         :type sort: str
+        :param limit: limit the number of results
+        :type limit: int
         """
         self.query = ' '.join(query)
         self.order = sort
+        self.limit = limit
         Command.__init__(self, **kwargs)
 
     def apply(self, ui):
@@ -127,7 +131,8 @@ class SearchCommand(Command):
                     ui.update()
             else:
                 ui.buffer_open(buffers.SearchBuffer(ui, self.query,
-                                                    sort_order=self.order))
+                                                    sort_order=self.order,
+                                                    limit=self.limit))
         else:
             ui.notify('empty query string')
 

--- a/alot/commands/search.py
+++ b/alot/commands/search.py
@@ -64,6 +64,9 @@ class OpenThreadCommand(Command):
     (['sort'], {'help': 'sort order', 'choices': [
         'oldest_first', 'newest_first', 'message_id', 'unsorted']}),
 ])
+@registerCommand(MODE, 'limit', help='limit number of results', arguments=[
+    (['limit'], {'help': 'the thread count limit', 'type': int}),
+])
 class RefineCommand(Command):
 
     """refine the querystring of this buffer"""

--- a/alot/commands/search.py
+++ b/alot/commands/search.py
@@ -58,6 +58,7 @@ class OpenThreadCommand(Command):
 @registerCommand(MODE, 'refine', help='refine query', arguments=[
     (['--sort'], {'help': 'sort order', 'choices': [
         'oldest_first', 'newest_first', 'message_id', 'unsorted']}),
+    (['--limit'], {'help': 'limit number of results', 'type': int}),
     (['query'], {'nargs': argparse.REMAINDER, 'help': 'search string'})])
 @registerCommand(MODE, 'sort', help='set sort order', arguments=[
     (['sort'], {'help': 'sort order', 'choices': [
@@ -66,21 +67,28 @@ class OpenThreadCommand(Command):
 class RefineCommand(Command):
 
     """refine the querystring of this buffer"""
-    def __init__(self, query=None, sort=None, **kwargs):
+    def __init__(self, query=None, sort=None, limit=None, **kwargs):
         """
         :param query: new querystring given as list of strings as returned by
                       argparse
         :type query: list of str
+        :param sort: how to order results. Must be one of
+                     'oldest_first', 'newest_first', 'message_id' or
+                     'unsorted'.
+        :type sort: str
+        :param limit: limit the number of results
+        :type limit: int
         """
         if query is None:
             self.querystring = None
         else:
             self.querystring = ' '.join(query)
         self.sort_order = sort
+        self.limit = limit
         Command.__init__(self, **kwargs)
 
     def apply(self, ui):
-        if self.querystring or self.sort_order:
+        if self.querystring or self.sort_order or self.limit is not None:
             sbuffer = ui.current_buffer
             oldquery = sbuffer.querystring
             if self.querystring not in [None, oldquery]:
@@ -88,6 +96,9 @@ class RefineCommand(Command):
                 sbuffer = ui.current_buffer
             if self.sort_order:
                 sbuffer.sort_order = self.sort_order
+            if self.limit not in [None, sbuffer.limit]:
+                sbuffer.limit = self.limit
+                sbuffer = ui.current_buffer
             sbuffer.rebuild()
             ui.update()
         else:

--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -4,6 +4,7 @@
 # For further details see the COPYING file
 from collections import deque
 import contextlib
+import itertools
 import logging
 
 from notmuch2 import Database, NotmuchError, XapianError
@@ -255,8 +256,7 @@ class DBManager:
         """returns number of messages that match `querystring`"""
         db = Database(path=self.path, mode=Database.MODE.READ_ONLY,
                       config=self.config)
-        return db.count_messages(querystring,
-                                 exclude_tags=self.exclude_tags)
+        return db.count_messages(querystring, exclude_tags=self.exclude_tags)
 
     def collect_tags(self, querystring):
         """returns tags of messages that match `querystring`"""
@@ -327,7 +327,7 @@ class DBManager:
         return {k[6:]: db.config[k] for k in db.config if
                 k.startswith('query.')}
 
-    def get_threads(self, querystring, sort='newest_first'):
+    def get_threads(self, querystring, sort='newest_first', limit=None):
         """
         asynchronously look up thread ids matching `querystring`.
 
@@ -335,20 +335,24 @@ class DBManager:
         :type querystring: str.
         :param sort: Sort order. one of ['oldest_first', 'newest_first',
                      'message_id', 'unsorted']
-        :type query: str
-        :returns: a pipe together with the process that asynchronously
-                  writes to it.
-        :rtype: (:class:`multiprocessing.Pipe`,
-                :class:`multiprocessing.Process`)
+        :type sort: str
+        :param limit: Limit the number of threads returned.
+        :type limit: int
+        :returns: a thread ID iterator and the number of matched messages
+        :rtype: Tuple[Iterator[str], int]
         """
         assert sort in self._sort_orders
         db = Database(path=self.path, mode=Database.MODE.READ_ONLY,
                       config=self.config)
-        thread_ids = [t.threadid for t in db.threads(querystring,
-                            sort=self._sort_orders[sort],
-                            exclude_tags=self.exclude_tags)]
-        for t in thread_ids:
-            yield t
+        thread_iterator = db.threads(querystring,
+                                     sort=self._sort_orders[sort],
+                                     exclude_tags=self.exclude_tags)
+        threads = []
+        message_count = 0
+        for thread in itertools.islice(thread_iterator, limit or None):
+            threads.append(thread.threadid)
+            message_count += thread.matched
+        return iter(threads), message_count
 
     def add_message(self, path, tags=None, afterwards=None):
         """

--- a/alot/db/manager.py
+++ b/alot/db/manager.py
@@ -339,6 +339,8 @@ class DBManager:
         :param limit: Limit the number of threads returned.
         :type limit: int
         :returns: a thread ID iterator and the number of matched messages
+            (the iterator will have at most limit many items and the counted
+            messages are also influenced by this limit)
         :rtype: Tuple[Iterator[str], int]
         """
         assert sort in self._sort_orders

--- a/alot/defaults/alot.rc.spec
+++ b/alot/defaults/alot.rc.spec
@@ -189,6 +189,10 @@ initial_command = string(default='search tag:inbox AND NOT tag:killed')
 # default sort order of results in a search
 search_threads_sort_order = option('oldest_first', 'newest_first', 'message_id', 'unsorted', default='newest_first')
 
+# default maximum number of results in a search
+# when set to 0, no limit is set (can be very slow in searches that yield thousands of results)
+search_threads_limit = integer(default=0)
+
 # maximum amount of threads that will be consumed to try to restore the focus, upon triggering a search buffer rebuild
 # when set to 0, no limit is set (can be very slow in searches that yield thousands of results)
 search_threads_rebuild_limit = integer(default=0)

--- a/docs/source/configuration/alotrc_table
+++ b/docs/source/configuration/alotrc_table
@@ -588,6 +588,17 @@
     :default: [{buffer_no}: search] for "{querystring}", {input_queue} {result_count} of {total_messages} messages
 
 
+.. _search-threads-limit:
+
+.. describe:: search_threads_limit
+
+     default maximum number of results in a search
+     when set to 0, no limit is set (can be very slow in searches that yield thousands of results)
+
+    :type: integer
+    :default: 0
+
+
 .. _search-threads-move-last-limit:
 
 .. describe:: search_threads_move_last_limit

--- a/docs/source/usage/modes/global.rst
+++ b/docs/source/usage/modes/global.rst
@@ -205,6 +205,7 @@ The following commands are available globally:
 
     optional arguments
         :---sort: sort order; valid choices are: 'oldest_first','newest_first','message_id','unsorted'
+        :---limit: limit number of results
 
 .. _cmd.global.shellescape:
 

--- a/docs/source/usage/modes/search.rst
+++ b/docs/source/usage/modes/search.rst
@@ -5,6 +5,16 @@ Commands in 'search' mode
 -------------------------
 The following commands are available in search mode:
 
+.. _cmd.search.limit:
+
+.. describe:: limit
+
+    limit number of results
+
+    argument
+        the thread count limit
+
+
 .. _cmd.search.move:
 
 .. describe:: move

--- a/docs/source/usage/modes/search.rst
+++ b/docs/source/usage/modes/search.rst
@@ -26,6 +26,7 @@ The following commands are available in search mode:
 
     optional arguments
         :---sort: sort order; valid choices are: 'oldest_first','newest_first','message_id','unsorted'
+        :---limit: limit number of results
 
 .. _cmd.search.refineprompt:
 


### PR DESCRIPTION
The new search_threads_limit option can be used to configure a default maximum number of results for thread searches. The value can be overridden by using the --limit argument.

Addresses issue #1647.