### PR TITLE
nix: use pyproject-nix to parse the pyproject.toml file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1749143949,
@@ -34,10 +16,31 @@
         "type": "github"
       }
     },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1746540146,
+        "narHash": "sha256-QxdHGNpbicIrw5t6U3x+ZxeY/7IEJ6lYbvsjXmcxFIM=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "e09c10c24ebb955125fda449939bfba664c467fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "pyproject-nix": "pyproject-nix",
+        "systems": "systems"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,69 +1,57 @@
 {
   description = "alot: Terminal-based Mail User Agent";
 
-  inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.pyproject-nix.url = "github:pyproject-nix/pyproject.nix";
+  inputs.pyproject-nix.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.systems.url = "github:nix-systems/default";
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-        # reuse this python version throughout the nix code, for easier
-        # switching (thus we just pick python3 by default)
-        python = pkgs.python3;
-        # we want to extract some metadata and especially the dependencies
-        # from the pyproject file, like this we do not have to maintain the
-        # list a second time
-        pyproject = pkgs.lib.trivial.importTOML ./pyproject.toml;
-        # get a list of python packages by name, used to get the nix packages
-        # for the dependency names from the pyproject file
-        getPkgs = names: builtins.attrValues (pkgs.lib.attrsets.getAttrs names python.pkgs);
-        # extract the python dependencies from the pyprojec file, cut the version constraints
-        dependencies' = pkgs.lib.lists.concatMap (builtins.match "([^>=<;]*).*") pyproject.project.dependencies;
-        # the package is called gpg on PyPI but gpgme in nixpkgs
-        renameGPG = x: if x == "gpg" then "gpgme" else x;
-        # mailcap has been removed from the stdlib in py3.13 and needs to be
-        # fetched from pypi
-        withMailcap = x: (pkgs.lib.strings.versionOlder "3.12" python.version) || (x != "standard-mailcap");
-        dependencies = map renameGPG (builtins.filter withMailcap dependencies');
-      in
-      {
-        packages = {
-          alot = python.pkgs.buildPythonApplication {
-            name = "alot";
-            version = "0.dev+${if self ? shortRev then self.shortRev else "dirty"}";
-            src = self;
-            pyproject = true;
-            outputs = [
-              "out"
-              "doc"
-              "man"
-            ];
-            build-system = getPkgs pyproject."build-system".requires;
-            dependencies = getPkgs dependencies;
-            postPatch = ''
-              substituteInPlace alot/settings/manager.py \
-                --replace /usr/share "$out/share"
-            '';
-            postInstall = ''
-              installShellCompletion --zsh --name _alot extra/completion/alot-completion.zsh
-              mkdir -p $out/share/{applications,alot}
-              cp -r extra/themes $out/share/alot
-              sed "s,/usr/bin,$out/bin,g" extra/alot.desktop > $out/share/applications/alot.desktop
-            '';
-            checkPhase = ''
-              python3 -m unittest -v
-            '';
-            nativeCheckInputs = with pkgs; [ gnupg notmuch procps ];
-            nativeBuildInputs = with pkgs; [
-              python.pkgs.sphinxHook
-              installShellFiles
-            ];
-            sphinxBuilders = [ "html" "man" ];
-          };
-          docs = pkgs.lib.trivial.warn "The docs attribute moved to alot.doc"
-            self.packages.${system}.alot.doc;
-          default = self.packages.${system}.alot;
-        };
-      });
+  outputs = {
+    self,
+    nixpkgs,
+    pyproject-nix,
+    systems,
+  }: let
+    project = pyproject-nix.lib.project.loadPyproject {projectRoot = ./.;};
+    eachSystem = nixpkgs.lib.genAttrs (import systems);
+    # the package is called gpg on PyPI and gpgme in nixpkgs
+    packageOverrides = final: prev: {gpg = final.gpgme;};
+  in {
+    packages = eachSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      python3 = pkgs.python3;
+      # let pyproject-nix generate the argument for buildPythonApplication
+      # from our pyproject.toml file
+      attrs = project.renderers.buildPythonPackage {
+        python = python3.override {inherit packageOverrides;};
+      };
+      # overwrite these attributes in the buildPythonApplication call
+      overrides = {
+        version = "0.dev+${self.shortRev or self.dirtyShortRev}";
+        outputs = ["out" "doc" "man"];
+        postPatch = ''
+          substituteInPlace alot/settings/manager.py \
+            --replace /usr/share "$out/share"
+        '';
+        postInstall = ''
+          installShellCompletion --zsh --name _alot extra/completion/alot-completion.zsh
+          mkdir -p $out/share/{applications,alot}
+          cp -r extra/themes $out/share/alot
+          sed "s,/usr/bin,$out/bin,g" extra/alot.desktop > $out/share/applications/alot.desktop
+        '';
+        checkPhase = ''
+          python3 -m unittest -v
+        '';
+        nativeCheckInputs = with pkgs; [gnupg notmuch procps];
+        nativeBuildInputs = [python3.pkgs.sphinxHook pkgs.installShellFiles];
+        sphinxBuilders = ["html" "man"];
+      };
+    in {
+      alot = python3.pkgs.buildPythonApplication (attrs // overrides);
+      docs =
+        pkgs.lib.trivial.warn "The docs attribute moved to alot.doc"
+        self.packages.${system}.alot.doc;
+      default = self.packages.${system}.alot;
+    });
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -53,5 +53,15 @@
         self.packages.${system}.alot.doc;
       default = self.packages.${system}.alot;
     });
+    devShells = eachSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      arg = project.renderers.withPackages {
+        python = pkgs.python3.override {inherit packageOverrides;};
+        extras = builtins.attrNames project.dependencies.extras;
+      };
+      pythonEnv = pkgs.python3.withPackages arg;
+    in {
+      default = pkgs.mkShell {packages = [pythonEnv];};
+    });
   };
 }


### PR DESCRIPTION
This frees us from some hand written setup code.