### PR TITLE
Increase required version of notmuch2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
 ]
 dependencies = [
-    "notmuch2>=0.30",
+    "notmuch2>=0.34.2",
     "urwid>=1.3.0",
     "urwidtrees>=1.0.3",
     "twisted>=18.4.0",


### PR DESCRIPTION
Since aaa4a699c1a1a0d24463759530575eec1aa29d5b we are using a new parameter in the notmuch2.Database constructor which was only available since 0.34.2.

This fixes #1701.

@arjunkc you can also use this branch to test.