### PR TITLE
Include package defaults pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,9 @@ Issues = "https://github.com/pazz/alot/issues"
 
 [tool.setuptools.packages.find]
 include = ["alot*"]
-include-package-data = true
 
-[tool.setuptools_scm]
+[setuptools.package-data]
+alot = ["defaults/*"]
 
 [tool.mypy]
 python_version = "3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ Issues = "https://github.com/pazz/alot/issues"
 
 [tool.setuptools.packages.find]
 include = ["alot*"]
+include-package-data = true
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
Include `alot/defaults/` directory containing no `*.py` files ignored by setuptools.

Reported in https://codeberg.org/guix/guix/issues/5797