### PR TITLE
Replace glob1 with glob

### DIFF
--- a/alot/account.py
+++ b/alot/account.py
@@ -299,10 +299,9 @@ class Account:
         if isinstance(mbx, mailbox.Maildir):
             # this is a dirty hack to get the path to the newly added file
             # I wish the mailbox module were more helpful...
-            plist = glob.glob1(os.path.join(mbx._path, 'new'),
-                               message_id + '*')
+            plist = glob.glob(os.path.join(mbx._path, 'new', message_id + '*'))
             if plist:
-                path = os.path.join(mbx._path, 'new', plist[0])
+                path = plist[0]
                 logging.debug('path of saved msg: %s', path)
         return path
 

--- a/alot/commands/__init__.py
+++ b/alot/commands/__init__.py
@@ -207,5 +207,5 @@ def commandfactory(cmdline, mode='global'):
     return cmd
 
 
-pyfiles = glob.glob1(os.path.dirname(__file__), '*.py')
-__all__ = list(filename[:-3] for filename in pyfiles)
+pyfiles = glob.glob(os.path.join(os.path.dirname(__file__), '*.py'))
+__all__ = list(os.path.basename(filename[:-3]) for filename in pyfiles)


### PR DESCRIPTION
Fixes #1712 

As glob.glob1 is undocumented and it's not so clear to me why it was used in the first place I'm not 100% sure if this fix is right.