### PR TITLE
buffers: thread: Fix Urwid set_focus align

### DIFF
--- a/alot/buffers/thread.py
+++ b/alot/buffers/thread.py
@@ -180,7 +180,7 @@ class ThreadBuffer(Buffer):
     def set_focus(self, pos):
         "Set the focus in the underlying body widget."
         logging.debug('setting focus to %s ', pos)
-        self.body.set_focus(pos, valign='top')
+        self.body.set_focus(pos)
 
     def focus_first(self):
         """set focus to first message of thread"""


### PR DESCRIPTION
An update to urwid results in the valign parameter no longer being recognised or supported. Drop it.