### PR TITLE
sys.stderr replace mock with io.StringIO

### DIFF
--- a/tests/utils/test_argparse.py
+++ b/tests/utils/test_argparse.py
@@ -23,6 +23,7 @@ import shutil
 import tempfile
 import unittest
 from unittest import mock
+import io
 
 from alot.utils import argparse as cargparse
 
@@ -50,7 +51,7 @@ class TestValidatedStore(unittest.TestCase):
             'foo',
             action=cargparse.ValidatedStoreAction,
             validator=validator)
-        with mock.patch('sys.stderr', mock.Mock()):
+        with mock.patch('sys.stderr', io.StringIO()):
             return parser.parse_args(args)
 
     def test_validates(self):


### PR DESCRIPTION
Python 3.15 does some formatting on sys.stderr for argparse and this doesn't work with a Mock object (it tries call fileno and expects an integer).

Use io.StringIO instead, I think it's only used for supressing stderr.