### PR TITLE
nix: fix build when overriding inputs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Install Nix
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v31
 
       - uses: actions/checkout@v4
 
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Install Nix
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v31
 
       - uses: actions/checkout@v4
 

--- a/extra/theme_test.py
+++ b/extra/theme_test.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Theme tester
 """

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
     eachSystem = nixpkgs.lib.genAttrs (import systems);
     # the package is called gpg on PyPI and gpgme in nixpkgs
     packageOverrides = final: prev: {gpg = final.gpgme;};
+    version = "0.dev+" + self.shortRev or self.dirtyShortRev or "override";
   in {
     packages = eachSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};
@@ -27,7 +28,7 @@
       };
       # overwrite these attributes in the buildPythonApplication call
       overrides = {
-        version = "0.dev+${self.shortRev or self.dirtyShortRev}";
+        inherit version;
         outputs = ["out" "doc" "man"];
         postPatch = ''
           substituteInPlace alot/settings/manager.py \

--- a/flake.nix
+++ b/flake.nix
@@ -47,12 +47,22 @@
         nativeBuildInputs = [python3.pkgs.sphinxHook pkgs.installShellFiles];
         sphinxBuilders = ["html" "man"];
       };
+      alot-pkg = python3.pkgs.buildPythonPackage (attrs // overrides);
+      alot-app = python3.pkgs.toPythonApplication alot-pkg;
     in {
-      alot = python3.pkgs.buildPythonApplication (attrs // overrides);
+      alot = alot-app;
       docs =
         pkgs.lib.trivial.warn "The docs attribute moved to alot.doc"
         self.packages.${system}.alot.doc;
-      default = self.packages.${system}.alot;
+      default = alot-app;
+      theme-test = pkgs.runCommand "theme-test.py" {
+        propagatedBuildInputs = [
+          (python3.withPackages (ps: [ alot-pkg ]))
+        ];
+      } ''
+        install -Dm755 ${./extra/theme_test.py} $out/bin/theme-test.py
+        patchShebangs $out/bin
+      '';
     });
     devShells = eachSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};


### PR DESCRIPTION
I had the case in #1715 that I wanted to build alot with an update version of nixpkgs. But our code to compute the version did not evaluate for that.  