### PR TITLE
Set ui global body color on update.

### DIFF
--- a/alot/ui.py
+++ b/alot/ui.py
@@ -647,6 +647,9 @@ class UI:
         # get the main urwid.Frame widget
         mainframe = self.root_widget.original_widget
 
+        global_att = settings.get_theming_attribute('global', 'body')
+        self.root_widget.set_attr_map({None: global_att})
+
         # body
         if self.current_buffer:
             mainframe.set_body(self.current_buffer)


### PR DESCRIPTION
I ran into a bug with my recently merged PR #1711. When switching the theme using the `theme` command, the global body color is not updated.

I didn't notice this until I switched to a dark theme and also changed my terminal background color to match. The background color of alot remained what it was in the light theme.

The issue is that the global body attribute is only set in the `UI.__init__` constructor. I fixed it by setting the global body attribute again in the `UI.update` method.

Testing:\
I did basic manual testing that the `theme` command now changes the background color. Doesn't look like there are any unit tests for the `UI` class so I didn't attempt to add any.